### PR TITLE
Fixed bugs when canceling profile edits and saving when not all required fields were filled.

### DIFF
--- a/my-app/package-lock.json
+++ b/my-app/package-lock.json
@@ -17532,8 +17532,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",

--- a/my-app/src/pages/Profile/Profile.tsx
+++ b/my-app/src/pages/Profile/Profile.tsx
@@ -25,21 +25,20 @@ import {
   doc,
   getDoc,
   getDocs,
+  limit,
+  orderBy,
   query,
   setDoc,
-  orderBy,
   updateDoc,
   where,
-  limit,
 } from "firebase/firestore";
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { db, auth } from "../../auth/firebaseConfig";
+import { auth, db } from "../../auth/firebaseConfig";
 import "./Profile.css";
 
 import { Timestamp } from "firebase/firestore";
 import TagPopup from "./Tags/TagPopup";
-import { StringLiteral } from "typescript";
 
 declare global {
   interface Window {
@@ -82,9 +81,13 @@ const CustomSelect = styled(Select)({
 const Profile = () => {
   // #### STATE ####
   const [dropdownOpen, setDropdownOpen] = useState(false);
-  const [tags, setTags] = useState<string[]>([])
+  const [tags, setTags] = useState<string[]>([]);
   const [allTags, setAllTags] = useState<string[]>([]);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [prevTags, setPrevTags] = useState<string[] | null>(null);
+  const [prevClientProfile, setPrevClientProfile] = useState<ClientProfile | null>(
+    null
+  );
   const [clientProfile, setClientProfile] = useState<ClientProfile>({
     uid: "",
     firstName: "",
@@ -133,7 +136,7 @@ const Profile = () => {
     endDate: "",
     recurrence: "None",
     tags: [],
-    ward: ""
+    ward: "",
   });
   const [isNewProfile, setIsNewProfile] = useState(true);
   const [editMode, setEditMode] = useState(true);
@@ -171,9 +174,7 @@ const Profile = () => {
     if (auth.currentUser === null) {
       navigate("/");
     }
-  }, [])
-
-
+  }, [navigate]);
 
   //get list of all tags
   useEffect(() => {
@@ -205,7 +206,7 @@ const Profile = () => {
         if (profileData) {
           setTags(profileData.tags.filter((tag) => allTags.includes(tag)) || []);
           setClientProfile(profileData);
-  
+
           // Set prevNotes only when the profile is loaded from Firebase
           if (!profileLoaded) {
             setPrevNotes(profileData.notes || ""); // Set the original notes
@@ -262,7 +263,7 @@ const Profile = () => {
         await getWard(clientProfile.address);
       }
     };
-  
+
     fetchWard();
   }, [clientProfile.address]); // Runs whenever the address field changes
 
@@ -309,8 +310,8 @@ const Profile = () => {
     lifeChallenges: string;
     notes: string;
     notesTimestamp?: {
-      notes: string,
-      timestamp: Date
+      notes: string;
+      timestamp: Date;
     } | null;
     lifestyleGoals: string;
     language: string;
@@ -368,7 +369,7 @@ const Profile = () => {
   };
 
   const getWard = async (searchAddress: string) => {
-    console.log("getting ward")
+    console.log("getting ward");
     const baseurl = "https://datagate.dc.gov/mar/open/api/v2.2";
     const apikey = process.env.REACT_APP_DC_WARD_API_KEY;
     const marURL = baseurl + "/locations/";
@@ -397,22 +398,26 @@ const Profile = () => {
       const data = await response.json();
 
       // Check if the response is successful and contains the expected data
-      if (data.Success === true && data.Result.addresses && data.Result.addresses.length > 0) {
+      if (
+        data.Success === true &&
+        data.Result.addresses &&
+        data.Result.addresses.length > 0
+      ) {
         const result = data.Result.addresses[0];
 
         if (result.zones && result.zones.ward[0]) {
           wardName = result.zones.ward[0].properties.NAME;
         } else {
           console.log("No ward information found in the response.");
-          wardName = "No ward information"
+          wardName = "No ward information";
         }
       } else {
         console.log("No address found or invalid response.");
-        wardName = "No address found"
+        wardName = "No address found";
       }
     } catch (error) {
       console.error("Error fetching ward information:", error);
-      wardName = "Error getting ward"
+      wardName = "Error getting ward";
     }
     clientProfile.ward = wardName;
     setWard(wardName);
@@ -431,6 +436,38 @@ const Profile = () => {
     setEditMode((prev) => !prev);
   };
 
+  function deepCopy<T>(obj: T): T {
+    // If obj is null or not an object, return it (base case)
+    if (obj === null || typeof obj !== "object") {
+      return obj;
+    }
+
+    // Handle Date objects
+    if (obj instanceof Date) {
+      return new Date(obj.getTime()) as T;
+    }
+
+    // Handle arrays by recursively copying each element
+    if (Array.isArray(obj)) {
+      return obj.map((item) => deepCopy(item)) as unknown as T;
+    }
+
+    // Handle plain objects by recursively copying each property
+    const copy = {} as { [key: string]: any };
+    for (const key in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        copy[key] = deepCopy((obj as any)[key]);
+      }
+    }
+    return copy as T;
+  }
+
+  const handlePrevClientCopying = () => {
+    if (!prevClientProfile) {
+      setPrevClientProfile(deepCopy(clientProfile));
+    }
+  };
+
   const handleChange = (
     e:
       | React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
@@ -440,6 +477,7 @@ const Profile = () => {
 
     // Always mark as unsaved when a change occurs
     setIsSaved(false);
+    handlePrevClientCopying();
 
     if (name === "dob") {
       const newDob = e.target.value; // this will be in the format YYYY-MM-DD
@@ -463,7 +501,7 @@ const Profile = () => {
         ...prevState,
         [name]: value,
       }));
-      
+
       // Special handling for notes field
       if (name === "notes") {
         console.log("Notes changed to:", value);
@@ -474,54 +512,96 @@ const Profile = () => {
   const validateProfile = () => {
     const newErrors: { [key: string]: string } = {};
 
-    if (!clientProfile.firstName?.trim())
+    if (!clientProfile.firstName?.trim()) {
       newErrors.firstName = "First Name is required";
-    if (!clientProfile.lastName?.trim())
+      console.log("Debug: firstName invalid:", clientProfile.firstName);
+    }
+    if (!clientProfile.lastName?.trim()) {
       newErrors.lastName = "Last Name is required";
-    if (!clientProfile.address?.trim())
+      console.log("Debug: lastName invalid:", clientProfile.lastName);
+    }
+    if (!clientProfile.address?.trim()) {
       newErrors.address = "Address 1 is required";
-    if (!clientProfile.zipCode)
+      console.log("Debug: address invalid:", clientProfile.address);
+    }
+    if (!clientProfile.zipCode) {
       newErrors.zipCode = "Zip code is required";
-    if (!clientProfile.city)
+      console.log("Debug: zipCode invalid:", clientProfile.zipCode);
+    }
+    if (!clientProfile.city) {
       newErrors.city = "City is required";
-    if (!clientProfile.state)
+      console.log("Debug: city invalid:", clientProfile.city);
+    }
+    if (!clientProfile.state) {
       newErrors.state = "State is required";
-    if (!clientProfile.dob)
+      console.log("Debug: state invalid:", clientProfile.state);
+    }
+    if (!clientProfile.dob) {
       newErrors.dob = "Date of Birth is required";
-    if (!clientProfile.recurrence.trim())
-      newErrors.recccurence = "Reccurence is required";
-    if (!clientProfile.startDate.trim())
+      console.log("Debug: dob invalid:", clientProfile.dob);
+    }
+    // Adding optional chaining here to prevent errors if undefined
+    if (!clientProfile.recurrence?.trim()) {
+      newErrors.recccurence = "Recurrence is required";
+      console.log("Debug: recurrence invalid:", clientProfile.recurrence);
+    }
+    if (!clientProfile.startDate?.trim()) {
       newErrors.startDate = "Start Date is required";
-    if (!clientProfile.endDate.trim())
+      console.log("Debug: startDate invalid:", clientProfile.startDate);
+    }
+    if (!clientProfile.endDate?.trim()) {
       newErrors.endDate = "End Date is required";
-    if (!clientProfile.phone?.trim())
+      console.log("Debug: endDate invalid:", clientProfile.endDate);
+    }
+    if (!clientProfile.phone?.trim()) {
       newErrors.phone = "Phone is required";
-    if (!clientProfile.gender?.trim())
+      console.log("Debug: phone invalid:", clientProfile.phone);
+    }
+    if (!clientProfile.gender?.trim()) {
       newErrors.gender = "Gender is required";
-    if (!clientProfile.ethnicity?.trim())
+      console.log("Debug: gender invalid:", clientProfile.gender);
+    }
+    if (!clientProfile.ethnicity?.trim()) {
       newErrors.ethnicity = "Ethnicity is required";
-    if (!clientProfile.language.trim()) newErrors.language = "Language is required";
+      console.log("Debug: ethnicity invalid:", clientProfile.ethnicity);
+    }
+    if (!clientProfile.language?.trim()) {
+      newErrors.language = "Language is required";
+      console.log("Debug: language invalid:", clientProfile.language);
+    }
     if (clientProfile.adults === 0 && clientProfile.seniors === 0) {
       newErrors.total = "At least one adult or senior is required";
+      console.log(
+        "Debug: adults and seniors are both zero:",
+        clientProfile.adults,
+        clientProfile.seniors
+      );
     }
     if (!/^\d{10}$/.test(clientProfile.phone || "")) {
       newErrors.phone = "Phone number must be exactly 10 digits";
+      console.log("Debug: phone format invalid:", clientProfile.phone);
     }
-
     if (
       clientProfile.alternativePhone &&
       !/^\d{10}$/.test(clientProfile.alternativePhone)
     ) {
       newErrors.alternativePhone =
         "Alternative Phone number must be exactly 10 digits";
+      console.log(
+        "Debug: alternativePhone format invalid:",
+        clientProfile.alternativePhone
+      );
     }
 
     setErrors(newErrors);
-    console.log(newErrors);
+    console.log("Final errors:", newErrors);
     return Object.keys(newErrors).length === 0;
   };
 
-  const checkIfNotesExists = (notes: string, prevNotesTimestamp: { notes: string; timestamp: Date } | null) => {
+  const checkIfNotesExists = (
+    notes: string,
+    prevNotesTimestamp: { notes: string; timestamp: Date } | null
+  ) => {
     if (!prevNotesTimestamp && notes.trim() !== "") {
       return { notes, timestamp: new Date() };
     }
@@ -547,17 +627,27 @@ const Profile = () => {
       console.log("Invalid Profile");
       return;
     }
-  
+
     try {
       const currNotes = clientProfile.notes;
-  
-      let updatedNotesTimestamp = checkIfNotesExists(currNotes, clientProfile.notesTimestamp ?? null);
-      updatedNotesTimestamp = checkIfNotesChanged(prevNotes, currNotes, updatedNotesTimestamp);
-  
+
+      let updatedNotesTimestamp = checkIfNotesExists(
+        currNotes,
+        clientProfile.notesTimestamp ?? null
+      );
+      updatedNotesTimestamp = checkIfNotesChanged(
+        prevNotes,
+        currNotes,
+        updatedNotesTimestamp
+      );
+
       console.log("Previous notes:", prevNotes);
       console.log("Current notes:", currNotes);
-      console.log("Timestamp updated:", updatedNotesTimestamp !== clientProfile.notesTimestamp);
-      
+      console.log(
+        "Timestamp updated:",
+        updatedNotesTimestamp !== clientProfile.notesTimestamp
+      );
+
       // Update the clientProfile object with the latest tags state
       const updatedProfile = {
         ...clientProfile,
@@ -565,11 +655,11 @@ const Profile = () => {
         notesTimestamp: updatedNotesTimestamp, // Update the notesTimestamp
         updatedAt: new Date(),
         total: clientProfile.adults + clientProfile.children + clientProfile.seniors,
-        ward: await getWard(clientProfile.address)
+        ward: await getWard(clientProfile.address),
       };
-  
+
       const sortedAllTags = [...allTags].sort((a, b) => a.localeCompare(b));
-  
+
       if (isNewProfile) {
         // Generate new UID for new profile
         const newUid = await generateUID();
@@ -578,11 +668,14 @@ const Profile = () => {
           uid: newUid,
           createdAt: new Date(),
         };
-  
+
         // Save to Firestore for new profile
         await setDoc(doc(db, "clients", newUid), newProfile);
-        await setDoc(doc(db, "tags", "oGuiR2dQQeOBXHCkhDeX"), { tags: sortedAllTags });
+        await setDoc(doc(db, "tags", "oGuiR2dQQeOBXHCkhDeX"), {
+          tags: sortedAllTags,
+        });
         setClientProfile(newProfile);
+        setPrevClientProfile(null);
         setIsNewProfile(false);
         console.log("New profile created with ID: ", newUid);
         navigate(`/profile/${newUid}`);
@@ -591,26 +684,30 @@ const Profile = () => {
         await setDoc(doc(db, "clients", clientProfile.uid), updatedProfile, {
           merge: true,
         });
-        await setDoc(doc(db, "tags", "oGuiR2dQQeOBXHCkhDeX"), { tags: sortedAllTags }, {
-          merge: true,
-        });
+        await setDoc(
+          doc(db, "tags", "oGuiR2dQQeOBXHCkhDeX"),
+          { tags: sortedAllTags },
+          {
+            merge: true,
+          }
+        );
+        setPrevClientProfile(null);
         setClientProfile(updatedProfile);
       }
-  
+
       // Make sure we update prevNotes with the current notes value to track changes properly
-      setPrevNotes(currNotes); 
+      setPrevNotes(currNotes);
       console.log("Updated prevNotes to:", currNotes);
-      
+
       // Update UI state
       setIsSaved(true);
       setEditMode(false);
       setIsEditing(false);
-      
+
       // Show save popup
       setShowSavePopup(true);
       // Hide popup after 2 seconds
       setTimeout(() => setShowSavePopup(false), 2000);
-      
     } catch (e) {
       console.error("Error saving document: ", e);
     }
@@ -626,18 +723,21 @@ const Profile = () => {
       ? getNestedValue(clientProfile, fieldPath)
       : clientProfile[fieldPath as keyof ClientProfile];
 
-        const handleTag = (text: any) => {
-        if (tags.includes(text)) {
-          const updatedTags = tags.filter((t) => t !== text);
-          setTags(updatedTags); 
-        } 
-        else if(text.trim() != ""){
-          const updatedTags = [...tags, text.trim()]; 
-          setTags(updatedTags); 
-        }
-      };
+    const handleTag = (text: any) => {
+      if (!prevTags) {
+        setPrevTags(deepCopy(tags));
+      }
 
-  if (fieldPath === "deliveryDetails.dietaryRestrictions") {
+      if (tags.includes(text)) {
+        const updatedTags = tags.filter((t) => t !== text);
+        setTags(updatedTags);
+      } else if (text.trim() !== "") {
+        const updatedTags = [...tags, text.trim()];
+        setTags(updatedTags);
+      }
+    };
+
+    if (fieldPath === "deliveryDetails.dietaryRestrictions") {
       return renderDietaryRestrictions();
     }
 
@@ -690,7 +790,7 @@ const Profile = () => {
           );
 
         case "textarea":
-          if (fieldPath == "ward") {
+          if (fieldPath === "ward") {
             return (
               <CustomTextField
                 name={fieldPath}
@@ -699,8 +799,7 @@ const Profile = () => {
                 fullWidth
               />
             );
-          }
-          else {
+          } else {
             return (
               <CustomTextField
                 name={fieldPath}
@@ -715,15 +814,19 @@ const Profile = () => {
         case "tags":
           return (
             <>
-              <Box sx={{ textAlign: 'left' }}>
-                {
-                  tags.length > 0 ? (<p>{tags.join(", ")}</p>) : <p>No tags selected</p>
-                }
+              <Box sx={{ textAlign: "left" }}>
+                {tags.length > 0 ? (
+                  <p>{tags.join(", ")}</p>
+                ) : (
+                  <p>No tags selected</p>
+                )}
               </Box>
               <Button
                 variant="contained"
                 // startIcon={<Add />}
-                onClick={() => { setIsModalOpen(true); }}
+                onClick={() => {
+                  setIsModalOpen(true);
+                }}
                 sx={{
                   marginRight: 4,
                   width: 166,
@@ -738,8 +841,8 @@ const Profile = () => {
                 tags={tags}
                 handleTag={handleTag}
                 isModalOpen={isModalOpen}
-                setIsModalOpen={setIsModalOpen}>
-              </TagPopup>
+                setIsModalOpen={setIsModalOpen}
+              ></TagPopup>
             </>
           );
         default:
@@ -747,29 +850,29 @@ const Profile = () => {
             <>
               {/* <TextFieldInput descriptor={fieldPath} handleChange={handleChange} /> */}
               <CustomTextField
-        type="text"
-        name={fieldPath}
-        value={fieldPath === "ward" ? ward : String(value || "")}
-        onChange={handleChange}
-        onBlur={async () => {
-          if (fieldPath === "address") {
-            // Call getWard with the updated address1 value
-            await getWard(clientProfile.address);
-          }
-        }}
-        fullWidth
-        inputRef={fieldPath === "address" ? addressInputRef : null}
-      />
+                type="text"
+                name={fieldPath}
+                value={fieldPath === "ward" ? ward : String(value || "")}
+                onChange={handleChange}
+                onBlur={async () => {
+                  if (fieldPath === "address") {
+                    // Call getWard with the updated address1 value
+                    await getWard(clientProfile.address);
+                  }
+                }}
+                fullWidth
+                inputRef={fieldPath === "address" ? addressInputRef : null}
+              />
             </>
           );
-        }
       }
-    
-      return (
-        <Typography variant="body1" sx={{ fontWeight: 600 }}>
-          {renderFieldValue(fieldPath, value)}
-        </Typography>
-      );
+    }
+
+    return (
+      <Typography variant="body1" sx={{ fontWeight: 600 }}>
+        {renderFieldValue(fieldPath, value)}
+      </Typography>
+    );
   };
 
   // Helper function to render field values properly
@@ -807,7 +910,7 @@ const Profile = () => {
       return value as string;
     }
     if (fieldPath === "tags") {
-      value = (tags.length > 0 ? tags : "None");
+      value = tags.length > 0 ? tags : "None"; // Tags depend on this
     }
     if (fieldPath === "deliveryDetails.dietaryRestrictions") {
       return (
@@ -853,10 +956,11 @@ const Profile = () => {
       );
     }
 
-    const selectedRestrictions = Object.entries(restrictions)
-      .filter(([key, value]) => value === true && typeof value === "boolean")
-      .map(([key]) => key.replace(/([A-Z])/g, " $1").trim())
-      .join(", ") || "None";
+    const selectedRestrictions =
+      Object.entries(restrictions)
+        .filter(([key, value]) => value === true && typeof value === "boolean")
+        .map(([key]) => key.replace(/([A-Z])/g, " $1").trim())
+        .join(", ") || "None";
 
     return (
       <CustomTextField
@@ -873,6 +977,7 @@ const Profile = () => {
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
     const { name, checked } = e.target;
+    handlePrevClientCopying();
     setClientProfile((prevState) => ({
       ...prevState,
       deliveryDetails: {
@@ -901,27 +1006,26 @@ const Profile = () => {
   const addressInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if(isEditing) {
+    if (isEditing) {
       // check if the Google Maps API script is already loaded
-      const script = document.createElement('script');
+      const script = document.createElement("script");
       if (!window.google) {
-        
         script.src = `https://maps.googleapis.com/maps/api/js?key=${process.env.REACT_APP_GOOGLE_MAPS_API_KEY || ""}&libraries=places`;
         script.async = true;
         script.defer = true;
-        
+
         // initialize autocomplete when script loading finishes
         script.onload = () => {
           if (addressInputRef.current) {
             const autocomplete = new window.google.maps.places.Autocomplete(
               addressInputRef.current,
-              { 
-                types: ['address'],
-                componentRestrictions: { country: 'us' } 
+              {
+                types: ["address"],
+                componentRestrictions: { country: "us" },
               }
             );
-            
-            autocomplete.addListener('place_changed', () => {
+
+            autocomplete.addListener("place_changed", () => {
               const place = autocomplete.getPlace();
               if (place.formatted_address) {
                 console.log(place);
@@ -929,40 +1033,43 @@ const Profile = () => {
                 // address components in json format
                 const addressComponents = place.address_components;
                 console.log(address);
-                
-                let streetNumber = '';
-                let streetName = '';
-                let city = '';
-                let state = '';
-                let zipCode = '';
-                let quadrant = ''; 
-                
+
+                let streetNumber = "";
+                let streetName = "";
+                let city = "";
+                let state = "";
+                let zipCode = "";
+                let quadrant = "";
+
                 // getting relevant components
                 if (addressComponents) {
                   for (const component of addressComponents) {
                     const types = component.types;
-                    
-                    if (types.includes('street_number')) {
+
+                    if (types.includes("street_number")) {
                       streetNumber = component.long_name;
                     }
-                    
-                    if (types.includes('route')) {
+
+                    if (types.includes("route")) {
                       streetName = component.long_name;
                     }
-                    
-                    if (types.includes('locality') || types.includes('sublocality')) {
+
+                    if (
+                      types.includes("locality") ||
+                      types.includes("sublocality")
+                    ) {
                       city = component.long_name;
                     }
-                    
-                    if (types.includes('administrative_area_level_1')) {
+
+                    if (types.includes("administrative_area_level_1")) {
                       state = component.short_name; // Use short_name for state code (e.g., "DC" instead of "District of Columbia")
                     }
-                    
-                    if (types.includes('postal_code')) {
+
+                    if (types.includes("postal_code")) {
                       zipCode = component.long_name;
                     }
                   }
-                  
+
                   // using regex to look for quadrant
                   const quadrantMatch = address.match(/(NW|NE|SW|SE)(\s|,|$)/);
                   if (state === "DC" && quadrantMatch) {
@@ -970,52 +1077,62 @@ const Profile = () => {
                   }
 
                   //TODO: DELETE
-                  console.log('Street Number:', streetNumber);
-                  console.log('Street Name:', streetName);
-                  console.log('City:', city);
-                  console.log('State:', state);
-                  console.log('Zip Code:', zipCode);
-                  console.log('Quadrant:', quadrant);
+                  console.log("Street Number:", streetNumber);
+                  console.log("Street Name:", streetName);
+                  console.log("City:", city);
+                  console.log("State:", state);
+                  console.log("Zip Code:", zipCode);
+                  console.log("Quadrant:", quadrant);
                 }
-                
+
                 // Update the client profile with all the parsed components
-                setClientProfile(prev => ({
+                setClientProfile((prev) => ({
                   ...prev,
                   address: `${streetNumber} ${streetName}`.trim(),
                   city: city,
                   state: state,
                   zipCode: zipCode,
-                  quadrant: quadrant
+                  quadrant: quadrant,
                 }));
               }
             });
           }
         };
-        
-        document.head.appendChild(script);
-      } 
-    }
-    return () => {
 
+        document.head.appendChild(script);
+      }
     }
-  }, [isEditing])
-  
-  
+    return () => {};
+  }, [isEditing]);
+
+  const handleCancel = () => {
+    // May not need to deep copy here.
+    if (prevClientProfile) {
+      setClientProfile(deepCopy(prevClientProfile));
+      setPrevClientProfile(null);
+    }
+
+    if (prevTags) {
+      setTags(deepCopy(prevTags));
+      setPrevTags(null);
+    }
+  };
+
   return (
     <Box className="profile-container">
       {showSavePopup && (
         <Box
           sx={{
-            position: 'fixed',
-            bottom: '20px',
-            right: '20px',
-            backgroundColor: '#257e68',
-            color: 'white',
-            padding: '16px',
-            borderRadius: '4px',
-            boxShadow: '0 2px 5px rgba(0,0,0,0.2)',
+            position: "fixed",
+            bottom: "20px",
+            right: "20px",
+            backgroundColor: "#257e68",
+            color: "white",
+            padding: "16px",
+            borderRadius: "4px",
+            boxShadow: "0 2px 5px rgba(0,0,0,0.2)",
             zIndex: 1000,
-            animation: 'slideIn 0.3s ease-out',
+            animation: "slideIn 0.3s ease-out",
           }}
         >
           Profile saved successfully!
@@ -1072,7 +1189,13 @@ const Profile = () => {
                 color={isEditing ? "secondary" : "primary"}
               >
                 <Tooltip title={isEditing ? "Cancel Editing" : "Edit All"}>
-                  {isEditing ? <CloseIcon /> : <EditIcon />}
+                  {isEditing ? (
+                    <span onClick={handleCancel}>
+                      <CloseIcon />
+                    </span>
+                  ) : (
+                    <EditIcon />
+                  )}
                 </Tooltip>
               </IconButton>
               {isEditing && (
@@ -1141,135 +1264,136 @@ const Profile = () => {
             </Box>
 
             {/* Address 1 */}
-<Box>
-  <Typography
-    className="field-descriptor"
-    sx={{
-      ...fieldLabelStyles,
-      position: "relative",
-      top: isEditing ? "-19px" : "0",
-    }}
-  >
-    ADDRESS<span className="required-asterisk">*</span>
-  </Typography>
-  {renderField("address", "text")}
-  {errors.address && (
-    <Typography color="error" variant="body2">
-      {errors.address}
-    </Typography>
-  )}
-</Box>
+            <Box>
+              <Typography
+                className="field-descriptor"
+                sx={{
+                  ...fieldLabelStyles,
+                  position: "relative",
+                  top: isEditing ? "-19px" : "0",
+                }}
+              >
+                ADDRESS<span className="required-asterisk">*</span>
+              </Typography>
+              {renderField("address", "text")}
+              {errors.address && (
+                <Typography color="error" variant="body2">
+                  {errors.address}
+                </Typography>
+              )}
+            </Box>
 
-{/* Address 2 */}
-<Box>
-  <Typography
-    className="field-descriptor"
-    sx={{
-      ...fieldLabelStyles,
-      position: "relative",
-      top: isEditing ? "-19px" : "0",
-    }}
-  >
-    ADDRESS 2
-  </Typography>
-  <CustomTextField
-    type="text"
-    name="address2"
-    value={clientProfile.address2 || ""}
-    onChange={(e) => {
-      const { value } = e.target;
-      setClientProfile((prevState) => ({
-        ...prevState,
-        address2: value, // Update address2 without triggering getWard
-      }));
-    }}
-    fullWidth
-  />
-</Box>
+            {/* Address 2 */}
+            <Box>
+              <Typography
+                className="field-descriptor"
+                sx={{
+                  ...fieldLabelStyles,
+                  position: "relative",
+                  top: isEditing ? "-19px" : "0",
+                }}
+              >
+                ADDRESS 2
+              </Typography>
+              <CustomTextField
+                type="text"
+                name="address2"
+                value={clientProfile.address2 || ""}
+                onChange={(e) => {
+                  const { value } = e.target;
+                  handlePrevClientCopying();
+                  setClientProfile((prevState) => ({
+                    ...prevState,
+                    address2: value, // Update address2 without triggering getWard
+                  }));
+                }}
+                fullWidth
+              />
+            </Box>
 
-           {/* City */}
-<Box>
-  <Typography
-    className="field-descriptor"
-    sx={{
-      ...fieldLabelStyles,
-      position: "relative",
-      top: isEditing ? "-19px" : "0",
-    }}
-  >
-    CITY <span className="required-asterisk">*</span>
-  </Typography>
-  <CustomTextField
-    type="text"
-    name="city"
-    value={clientProfile.city || ""}
-    disabled
-    fullWidth
-  />
-</Box>
+            {/* City */}
+            <Box>
+              <Typography
+                className="field-descriptor"
+                sx={{
+                  ...fieldLabelStyles,
+                  position: "relative",
+                  top: isEditing ? "-19px" : "0",
+                }}
+              >
+                CITY <span className="required-asterisk">*</span>
+              </Typography>
+              <CustomTextField
+                type="text"
+                name="city"
+                value={clientProfile.city || ""}
+                disabled
+                fullWidth
+              />
+            </Box>
 
-{/* State */}
-<Box>
-  <Typography
-    className="field-descriptor"
-    sx={{
-      ...fieldLabelStyles,
-      position: "relative",
-      top: isEditing ? "-19px" : "0",
-    }}
-  >
-    STATE <span className="required-asterisk">*</span>
-  </Typography>
-  <CustomTextField
-    type="text"
-    name="state"
-    value={clientProfile.state || ""}
-    disabled
-    fullWidth
-  />
-</Box>
+            {/* State */}
+            <Box>
+              <Typography
+                className="field-descriptor"
+                sx={{
+                  ...fieldLabelStyles,
+                  position: "relative",
+                  top: isEditing ? "-19px" : "0",
+                }}
+              >
+                STATE <span className="required-asterisk">*</span>
+              </Typography>
+              <CustomTextField
+                type="text"
+                name="state"
+                value={clientProfile.state || ""}
+                disabled
+                fullWidth
+              />
+            </Box>
 
-{/* ZIP CODE */}
-<Box>
-  <Typography
-    className="field-descriptor"
-    sx={{
-      ...fieldLabelStyles,
-      position: "relative",
-      top: isEditing ? "-19px" : "0",
-    }}
-  >
-    ZIP CODE <span className="required-asterisk">*</span>
-  </Typography>
-  <CustomTextField
-    type="text"
-    name="zipCode"
-    value={clientProfile.zipCode || ""}
-    disabled
-    fullWidth
-  />
-</Box>
+            {/* ZIP CODE */}
+            <Box>
+              <Typography
+                className="field-descriptor"
+                sx={{
+                  ...fieldLabelStyles,
+                  position: "relative",
+                  top: isEditing ? "-19px" : "0",
+                }}
+              >
+                ZIP CODE <span className="required-asterisk">*</span>
+              </Typography>
+              <CustomTextField
+                type="text"
+                name="zipCode"
+                value={clientProfile.zipCode || ""}
+                disabled
+                fullWidth
+              />
+            </Box>
 
-{/* Quadrant */}
-<Box>
-  <Typography
-    className="field-descriptor"
-    sx={{
-      ...fieldLabelStyles,
-      position: "relative",
-      top: isEditing ? "-19px" : "0",
-    }}
-  >
-    QUADRANT
-  </Typography>
-  <CustomTextField
-    type="text"
-    name="quadrant"
-    value={clientProfile.quadrant || ""}
-    disabled
-    fullWidth
-  />
-</Box>
+            {/* Quadrant */}
+            <Box>
+              <Typography
+                className="field-descriptor"
+                sx={{
+                  ...fieldLabelStyles,
+                  position: "relative",
+                  top: isEditing ? "-19px" : "0",
+                }}
+              >
+                QUADRANT
+              </Typography>
+              <CustomTextField
+                type="text"
+                name="quadrant"
+                value={clientProfile.quadrant || ""}
+                disabled
+                fullWidth
+              />
+            </Box>
             {/* Gender */}
             <Box>
               <Typography
@@ -1387,7 +1511,11 @@ const Profile = () => {
               <CustomTextField
                 type="text"
                 name="total"
-                value={Number(clientProfile.seniors) + Number(clientProfile.adults) + Number(clientProfile.children)}
+                value={
+                  Number(clientProfile.seniors) +
+                  Number(clientProfile.adults) +
+                  Number(clientProfile.children)
+                }
                 disabled
                 fullWidth
               />
@@ -1404,6 +1532,7 @@ const Profile = () => {
                   value={clientProfile.headOfHousehold || ""}
                   onChange={(e) => {
                     const { value } = e.target;
+                    handlePrevClientCopying();
                     setClientProfile((prevState) => ({
                       ...prevState,
                       headOfHousehold: value as "Adult" | "Senior",
@@ -1434,7 +1563,7 @@ const Profile = () => {
               )}
             </Box>
 
-              {/* Start Date */}
+            {/* Start Date */}
             <Box>
               <Typography className="field-descriptor" sx={fieldLabelStyles}>
                 START DATE <span className="required-asterisk">*</span>
@@ -1461,6 +1590,7 @@ const Profile = () => {
                   value={clientProfile.recurrence || ""}
                   onChange={(e) => {
                     const { value } = e.target;
+                    handlePrevClientCopying();
                     setClientProfile((prevState) => ({
                       ...prevState,
                       recurrence: value as "Weekly" | "2x-Monthly" | "Monthly",
@@ -1504,13 +1634,15 @@ const Profile = () => {
               </Typography>
               {renderField("notes", "textarea")}
               {isSaved && clientProfile.notes.trim() !== "" && (
-  <p id="timestamp">
-    Last edited: {(clientProfile.notesTimestamp?.timestamp instanceof Timestamp
-      ? clientProfile.notesTimestamp.timestamp.toDate()
-      : clientProfile.notesTimestamp?.timestamp || clientProfile.createdAt
-    ).toLocaleString()}
-  </p>
-)}
+                <p id="timestamp">
+                  Last edited:{" "}
+                  {(clientProfile.notesTimestamp?.timestamp instanceof Timestamp
+                    ? clientProfile.notesTimestamp.timestamp.toDate()
+                    : clientProfile.notesTimestamp?.timestamp ||
+                      clientProfile.createdAt
+                  ).toLocaleString()}
+                </p>
+              )}
             </Box>
 
             {/* Life Challenges */}
@@ -1543,18 +1675,26 @@ const Profile = () => {
                 DIETARY RESTRICTIONS
               </Typography>
               {isEditing ? (
-                renderField("deliveryDetails.dietaryRestrictions", "dietaryRestrictions")
+                renderField(
+                  "deliveryDetails.dietaryRestrictions",
+                  "dietaryRestrictions"
+                )
               ) : (
                 <Typography variant="body1" sx={{ fontWeight: 600 }}>
                   {Object.entries(clientProfile.deliveryDetails.dietaryRestrictions)
-                    .filter(([key, value]) => value === true && typeof value === "boolean")
-                    .map(([key]) =>
-                      key
-                        .replace(/([A-Z])/g, " $1") // Add space before capital letters
-                        .trim()
-                        .split(" ") // Split into words
-                        .map((word) => word.charAt(0).toUpperCase() + word.slice(1)) // Capitalize each word
-                        .join(" ") // Join back into a single string
+                    .filter(
+                      ([key, value]) => value === true && typeof value === "boolean"
+                    )
+                    .map(
+                      ([key]) =>
+                        key
+                          .replace(/([A-Z])/g, " $1") // Add space before capital letters
+                          .trim()
+                          .split(" ") // Split into words
+                          .map(
+                            (word) => word.charAt(0).toUpperCase() + word.slice(1)
+                          ) // Capitalize each word
+                          .join(" ") // Join back into a single string
                     )
                     .join(", ") || "None"}
                 </Typography>

--- a/my-app/src/pages/Profile/Tags/Tag.tsx
+++ b/my-app/src/pages/Profile/Tags/Tag.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react';
-import { Box, Tooltip, Typography } from '@mui/material';
-import CloseIcon from '@mui/icons-material/Close';
-import { styled } from '@mui/system';
-import AddIcon from '@mui/icons-material/Add';
+import AddIcon from "@mui/icons-material/Add";
+import CloseIcon from "@mui/icons-material/Close";
+import { Box, Tooltip, Typography } from "@mui/material";
+import { styled } from "@mui/system";
+import React, { useState } from "react";
 
 interface TagProps {
   text: string;
@@ -16,107 +16,111 @@ interface TagProps {
 
 // Styled component for the tag container with a transition effect
 const TagContainer = styled(Box)(({ theme }) => ({
-  backgroundColor: '#e0e0e0', 
-  textAlign: 'center',
-  borderRadius: '5px',
-  padding: '6px 12px', 
-  minWidth: '60px', 
-  minHeight: '30px', 
-  cursor: 'pointer',
-  transition: 'background-color 0.3s ease', 
-  '&:hover': {
-    backgroundColor: '#bdbdbd', 
+  backgroundColor: "#e0e0e0",
+  textAlign: "center",
+  borderRadius: "5px",
+  padding: "6px 12px",
+  minWidth: "60px",
+  minHeight: "30px",
+  cursor: "pointer",
+  transition: "background-color 0.3s ease",
+  "&:hover": {
+    backgroundColor: "#bdbdbd",
   },
-  '&.active': {
-    backgroundColor: '#257E68', 
-    color: '#fff', 
+  "&.active": {
+    backgroundColor: "#257E68",
+    color: "#fff",
   },
 }));
 
 const CreateTagContainer = styled(Box)(({ theme }) => ({
-    backgroundColor: 'white', 
-    borderRadius: '5px',
-    padding: '6px 12px',
-    cursor: 'pointer',
-    border: '1px dashed lightgray', 
-    transition: 'background-color 0.3s ease', 
-    display: 'flex', 
-    alignItems: 'center', 
-    justifyContent: 'center', 
-    minWidth: '60px', 
-    minHeight: '30px', 
-    position: 'relative',
-    '&:hover': {
-      backgroundColor: '#f3f3f3',
-    },
-  }));
+  backgroundColor: "white",
+  borderRadius: "5px",
+  padding: "6px 12px",
+  cursor: "pointer",
+  border: "1px dashed lightgray",
+  transition: "background-color 0.3s ease",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  minWidth: "60px",
+  minHeight: "30px",
+  position: "relative",
+  "&:hover": {
+    backgroundColor: "#f3f3f3",
+  },
+}));
 
-const Tag: React.FC<TagProps> = ({ text, handleTag, values, createTag, setInnerPopup, deleteMode, setTagToDelete}) => {
-    const handleClick = () => {
-        handleTag(text);
-    };
+const Tag: React.FC<TagProps> = ({
+  text,
+  handleTag,
+  values,
+  createTag,
+  setInnerPopup,
+  deleteMode,
+  setTagToDelete,
+}) => {
+  const handleClick = () => {
+    handleTag(text);
+  };
 
-    if(!deleteMode){
-        return !createTag? (
-            <TagContainer
-            className={values.includes(text) ? 'active' : ''}
-            onClick={handleClick}
-            >
-                <Typography variant="body1">{text}</Typography>
-            </TagContainer>
-        ):
-        (
-            <Tooltip title={"Create a new tag"} placement="top">
-                <CreateTagContainer
-                className={values.includes(text) ? 'active' : ''}
-                onClick={() => {setInnerPopup(true)}}
-                >
-                <AddIcon
-                    sx={{
-                    fontSize: '20px',
-                    color: '#257E68',
-                    padding: 0, 
-                    margin: 0, 
-                    }}
-                />
-                </CreateTagContainer>
-            </Tooltip>
-        )
-    }
-    else{
-        return !createTag? (
-            <CreateTagContainer
-                className={values.includes(text) ? 'active' : ''}
-            >
-                <Typography variant="body1">{text}</Typography>
-                <CloseIcon
-                    sx={{
-                        position: 'absolute',
-                        top: -7, 
-                        right: -8, 
-                        backgroundColor: 'white', 
-                        color: 'red',
-                        boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.2)',
-                        borderRadius: '50%',
-                        width: '20px', 
-                        height: '20px', 
-                        '&:hover': {
-                        backgroundColor: 'lightgray', 
-                        },
-                    }}
-                    onClick={(e) => {
-                        e.stopPropagation(); 
-                        setInnerPopup(true);
-                        setTagToDelete(text);
-                    }}
-                />
-            </CreateTagContainer>
-        ):
-        (
-            <>
-            </>
-        )
-    }
+  if (!deleteMode) {
+    return !createTag ? (
+      <TagContainer
+        className={values.includes(text) ? "active" : ""}
+        onClick={handleClick}
+      >
+        <Typography variant="body1">{text}</Typography>
+      </TagContainer>
+    ) : (
+      <Tooltip title={"Create a new tag"} placement="top">
+        <CreateTagContainer
+          className={values.includes(text) ? "active" : ""}
+          onClick={() => {
+            setInnerPopup(true);
+          }}
+        >
+          <AddIcon
+            sx={{
+              fontSize: "20px",
+              color: "#257E68",
+              padding: 0,
+              margin: 0,
+            }}
+          />
+        </CreateTagContainer>
+      </Tooltip>
+    );
+  } else {
+    return !createTag ? (
+      <CreateTagContainer className={values.includes(text) ? "active" : ""}>
+        <Typography variant="body1">{text}</Typography>
+        <CloseIcon
+          sx={{
+            position: "absolute",
+            top: -7,
+            right: -8,
+            backgroundColor: "white",
+            color: "red",
+            boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.2)",
+            borderRadius: "50%",
+            width: "20px",
+            height: "20px",
+            "&:hover": {
+              backgroundColor: "lightgray",
+            },
+          }}
+          onClick={(e) => {
+            e.stopPropagation();
+            setInnerPopup(true);
+            setTagToDelete(text);
+          }}
+        />
+      </CreateTagContainer>
+    ) : (
+      <></>
+    );
+  }
 };
 
 export default Tag;

--- a/my-app/src/pages/Profile/Tags/TagPopup.tsx
+++ b/my-app/src/pages/Profile/Tags/TagPopup.tsx
@@ -1,108 +1,191 @@
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Input, Typography } from "@mui/material"
-import Tags from "./Tags"
-import { useState } from "react"
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Input,
+  Typography,
+} from "@mui/material";
+import { useState } from "react";
+import Tags from "./Tags";
 
-export default function TagPopup({allTags, tags, handleTag, isModalOpen, setIsModalOpen}: any){
-    const [innerPopup, setInnerPopup] = useState(false)
-    const [newTag, setNewTag] = useState("")
-    const [deleteMode, setDeleteMode] = useState(false)
-    const [tagToDelete, setTagToDelete] = useState("")
+export default function TagPopup({
+  allTags,
+  tags,
+  handleTag,
+  isModalOpen,
+  setIsModalOpen,
+}: any) {
+  const [innerPopup, setInnerPopup] = useState(false);
+  const [newTag, setNewTag] = useState("");
+  const [deleteMode, setDeleteMode] = useState(false);
+  const [tagToDelete, setTagToDelete] = useState("");
 
-    const addNewTag = (text: string) => {
-        text = text.trim();
-        if(text != "" && !allTags.includes(text)){
-            allTags.push(text);
-        }
+  const addNewTag = (text: string) => {
+    text = text.trim();
+    if (text !== "" && !allTags.includes(text)) {
+      allTags.push(text);
     }
+  };
 
-    const deleteTag = async (text: string) => {
-        text = text.trim();
-        if(text != ""){
-            const index = allTags.indexOf(text);
-            allTags.splice(index, 1);
-            if(tags.includes(text)){
-                const index = tags.indexOf(text);
-                tags.splice(index, 1);
-            }
-        }
+  const deleteTag = async (text: string) => {
+    text = text.trim();
+    if (text !== "") {
+      const index = allTags.indexOf(text);
+      allTags.splice(index, 1);
+      if (tags.includes(text)) {
+        const index = tags.indexOf(text);
+        tags.splice(index, 1);
+      }
     }
-    return(
-        <Dialog open={isModalOpen} onClose={() => setIsModalOpen(false)}>
-            {/* All tags display*/}
-            <DialogTitle>Edit Tags</DialogTitle>
-            <DialogContent>
-            <Tags allTags = {allTags} values = {tags} handleTag = {handleTag} setInnerPopup = {setInnerPopup} deleteMode = {deleteMode} setTagToDelete={setTagToDelete}></Tags>
-            </DialogContent>
+  };
+  return (
+    <Dialog open={isModalOpen} onClose={() => setIsModalOpen(false)}>
+      {/* All tags display*/}
+      <DialogTitle>Edit Tags</DialogTitle>
+      <DialogContent>
+        <Tags
+          allTags={allTags}
+          values={tags}
+          handleTag={handleTag}
+          setInnerPopup={setInnerPopup}
+          deleteMode={deleteMode}
+          setTagToDelete={setTagToDelete}
+        ></Tags>
+      </DialogContent>
 
-            <DialogContent sx={{display:'flex', gap: '10px', maxWidth: '100%', flexWrap:'wrap'}}> 
-                <p>Selected Tags: </p>
-                {tags.length > 0 ? (
-                    tags.map((tag: any, index: number) => (
-                    <p key={tag}>
-                        {tag}
-                        {index !== tags.length - 1 && ", "} 
-                    </p>
-                    ))
-                ) : (
-                    <p>No tags selected.</p> 
-                )}
-            </DialogContent>
+      <DialogContent
+        sx={{ display: "flex", gap: "10px", maxWidth: "100%", flexWrap: "wrap" }}
+      >
+        <p>Selected Tags: </p>
+        {tags.length > 0 ? (
+          tags.map((tag: any, index: number) => (
+            <p key={tag}>
+              {tag}
+              {index !== tags.length - 1 && ", "}
+            </p>
+          ))
+        ) : (
+          <p>No tags selected.</p>
+        )}
+      </DialogContent>
 
-            {/* Create or delete tag from db*/}
-            <DialogContent sx={{display:'flex', justifyContent:'center', gap: '10px', padding: '10px'}}>
-                <Button
-                    variant="contained"
-                    // startIcon={<Add />}
-                    onClick={() => {setDeleteMode(!deleteMode)}}
-                    sx={{
-                        flex: 1,
-                        color: "#fff",
-                        backgroundColor: "#257E68",
-                    }}
-                >
-                    {deleteMode ? "Cancel": "Delete tag"}
-                </Button>
-                <Button
-                    variant="contained"
-                    onClick={() => setIsModalOpen(false)}
-                    sx={{
-                        flex: 1,
-                        color: "#fff",
-                        backgroundColor: "#257E68",
-                    }}
-                >
-                    DONE
-                </Button>
-            </DialogContent>
+      {/* Create or delete tag from db*/}
+      <DialogContent
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          gap: "10px",
+          padding: "10px",
+        }}
+      >
+        <Button
+          variant="contained"
+          // startIcon={<Add />}
+          onClick={() => {
+            setDeleteMode(!deleteMode);
+          }}
+          sx={{
+            flex: 1,
+            color: "#fff",
+            backgroundColor: "#257E68",
+          }}
+        >
+          {deleteMode ? "Cancel" : "Delete tag"}
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => setIsModalOpen(false)}
+          sx={{
+            flex: 1,
+            color: "#fff",
+            backgroundColor: "#257E68",
+          }}
+        >
+          DONE
+        </Button>
+      </DialogContent>
 
-            {/* Create new tag */}
-            <Dialog open={innerPopup && !deleteMode} onClose={() => {setInnerPopup(false); setNewTag("")}}>
-                <DialogTitle>Create New Tag</DialogTitle>
-                <DialogContent sx={{display:'flex', gap: '10px', maxWidth: '100%', flexWrap:'wrap'}}>
-                <Input
-                    value={newTag}
-                    onChange={(e) => setNewTag(e.target.value)}
-                    sx={{width:'300px'}}
-                    className="login-input-field"
-                    placeholder="New Tag"
-                />
-                </DialogContent>
-                <DialogActions>
-                    <Button onClick={() => {setInnerPopup(false); addNewTag(newTag); setNewTag("")}}>DONE</Button>
-                </DialogActions>
-            </Dialog>
+      {/* Create new tag */}
+      <Dialog
+        open={innerPopup && !deleteMode}
+        onClose={() => {
+          setInnerPopup(false);
+          setNewTag("");
+        }}
+      >
+        <DialogTitle>Create New Tag</DialogTitle>
+        <DialogContent
+          sx={{ display: "flex", gap: "10px", maxWidth: "100%", flexWrap: "wrap" }}
+        >
+          <Input
+            value={newTag}
+            onChange={(e) => setNewTag(e.target.value)}
+            sx={{ width: "300px" }}
+            className="login-input-field"
+            placeholder="New Tag"
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => {
+              setInnerPopup(false);
+              addNewTag(newTag);
+              setNewTag("");
+            }}
+          >
+            DONE
+          </Button>
+        </DialogActions>
+      </Dialog>
 
-            {/* Delete Confirmation */}
-            <Dialog open={innerPopup && deleteMode} onClose={() => {setInnerPopup(false); setNewTag("")}}>
-                <DialogTitle sx={{textAlign:'center'}}>WARNING</DialogTitle>
-                <DialogContent sx={{display:'flex', gap: '10px', maxWidth: '100%', flexWrap:'wrap', textAlign:'center'}}>
-                <Typography>Deleting this tag will erase if from ALL PROFILES. If you want to deselect it just for this profile, click "CANCEL" and just click the tag. <br></br> <br></br> Are you sure you want to proceed?</Typography>
-                </DialogContent>
-                <DialogActions>
-                <Button sx = {{backgroundColor:'red !important'}} onClick={() => {setInnerPopup(false); deleteTag(tagToDelete); setTagToDelete(""); setDeleteMode(false)}}>DELETE TAG</Button>
-                    <Button onClick={() => {setInnerPopup(false); setDeleteMode(false)}}>CANCEL</Button>
-                </DialogActions>
-            </Dialog>
-        </Dialog>
-    )
+      {/* Delete Confirmation */}
+      <Dialog
+        open={innerPopup && deleteMode}
+        onClose={() => {
+          setInnerPopup(false);
+          setNewTag("");
+        }}
+      >
+        <DialogTitle sx={{ textAlign: "center" }}>WARNING</DialogTitle>
+        <DialogContent
+          sx={{
+            display: "flex",
+            gap: "10px",
+            maxWidth: "100%",
+            flexWrap: "wrap",
+            textAlign: "center",
+          }}
+        >
+          <Typography>
+            Deleting this tag will erase if from ALL PROFILES. If you want to
+            deselect it just for this profile, click "CANCEL" and just click the tag.{" "}
+            <br></br> <br></br> Are you sure you want to proceed?
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            sx={{ backgroundColor: "red !important" }}
+            onClick={() => {
+              setInnerPopup(false);
+              deleteTag(tagToDelete);
+              setTagToDelete("");
+              setDeleteMode(false);
+            }}
+          >
+            DELETE TAG
+          </Button>
+          <Button
+            onClick={() => {
+              setInnerPopup(false);
+              setDeleteMode(false);
+            }}
+          >
+            CANCEL
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Dialog>
+  );
 }


### PR DESCRIPTION
To fix the canceling profile edits bug, I create 2 new variables to store the profile/tag state before any edits are made. Before any state of those two variables are made, I make copies of them to remember their unedited state. They are in the variables `prevClientProfile` and `prevTags` respectively. I made a function `handleCancel` that checks to see that if an edit was made but the user wants to cancel, restore the `clientProfile` and `tags` variables to their previous state, and clear `prevClientProfile` and `prevTags`. There was also another issue where `valiadateProfile` would crash if certain fields were not filled out, so I fixed that by adding chaining to those variables.