### PR TITLE
Fixed bug where refreshing on /profile directs to /calendar

### DIFF
--- a/my-app/src/App.tsx
+++ b/my-app/src/App.tsx
@@ -17,15 +17,22 @@ import BasePage from './pages/Base/Base';
 import CreateUsers from './pages/CreateUsers/CreateUsers';
 import DeliverySpreadsheet from "./pages/Delivery/DeliverySpreadsheet";
 
+import { useAuth } from './auth/AuthProvider';
 
 function App() {
+  const { loading } = useAuth();
+
+  if (loading) {
+    return <div>Loading...</div>; // Or a spinner
+  }
+
   return (
     <Router>
       <Routes>
         {/* Public routes */}
         <Route path="/" element={<Login />} />
         <Route path="/forgot-password" element={<ForgotPasswordPage />} />
-        
+
         {/* Protected or main routes wrapped with BasePage */}
         <Route
           path="/calendar"
@@ -37,14 +44,14 @@ function App() {
         />
         <Route path="/profile/:id" element={
           <BasePage>
-          <Profile />
-        </BasePage>
+            <Profile />
+          </BasePage>
         } />
         <Route
           path="/profile"
           element={
             <BasePage>
-              <Profile  />
+              <Profile />
             </BasePage>
           }
         />


### PR DESCRIPTION
Bug was occurring because when the app first mounts, the state of the user is null and the state of the page loading is true. Therefore, if any component redirect based on the state of the user being null before the page stop loading, it would prematurely redirect. This was the case for `Profile.tsx`, where the page would redirect to `/` when the user was null. Once the auth state changed resolved and the user was obtained, the page would then redirect to `/calendar`.

I was able to fix this by returning a loading page when the page was still loading in `App.tsx`. This ensured that no routes render until Firebase's authStateChanged had resolved.