### PR TITLE
added storage for custom spreadsheet

### DIFF
--- a/my-app/src/hooks/useCustomColumns.ts
+++ b/my-app/src/hooks/useCustomColumns.ts
@@ -1,7 +1,11 @@
 // useCustomColumns.ts
 import { SelectChangeEvent } from "@mui/material";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { DeliveryDetails, DietaryRestrictions } from '../types';
+
+interface useCustomColumnsProps {
+  page: string
+}
 
 // Define the CustomColumn interface to ensure type-safety
 export interface CustomColumn {
@@ -23,9 +27,17 @@ export interface CustomRowData {
   ethnicity: string;
 }
 
-export const useCustomColumns = () => {
-  // Manage the custom columns state
-  const [customColumns, setCustomColumns] = useState<CustomColumn[]>([]);
+export const useCustomColumns = ({page}: useCustomColumnsProps) => {
+  // Manage the custom columns state. Default to [] if not found in local storage
+  const [customColumns, setCustomColumns] = useState<CustomColumn[]>(() => {
+    const saved = localStorage.getItem(`ffaCustomColumns${page}`);
+    return saved ? JSON.parse(saved) : [];
+  });
+
+  //detect custom column change and update local store
+  useEffect(()=>{
+    localStorage.setItem(`ffaCustomColumns${page}`, JSON.stringify(customColumns))
+  },[customColumns])
 
   // Function to add a new custom column
   const handleAddCustomColumn = () => {

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -286,7 +286,7 @@ const DeliverySpreadsheet: React.FC = () => {
     handleCustomHeaderChange,
     handleRemoveCustomColumn,
     handleCustomColumnChange,
-  } = useCustomColumns();
+  } = useCustomColumns({page: 'DeliverySpreadsheet'});
   const [customRows, setCustomRows] = useState<CustomRowData[]>([])
 
 


### PR DESCRIPTION
Used localStorage to store the state of custom tables for both the delivery page and the clients page. Also modified the useCustomColumns hook so that the states of both tables could be independent (allows for different customizations for each page). Storage key naming convention is "ffa<feature><page>" 