### PR TITLE
Add ability to delete upcoming deliveries from profile page

### DIFF
--- a/my-app/package-lock.json
+++ b/my-app/package-lock.json
@@ -47,7 +47,6 @@
         "react-icons": "^5.5.0",
         "react-router-dom": "^6.26.2",
         "react-scripts": "5.0.1",
-        "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -68,6 +67,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "prettier": "^3.3.3",
         "stream-browserify": "^3.0.0",
+        "typescript": "^4.9.5",
         "util": "^0.12.5"
       }
     },

--- a/my-app/package.json
+++ b/my-app/package.json
@@ -42,7 +42,6 @@
     "react-icons": "^5.5.0",
     "react-router-dom": "^6.26.2",
     "react-scripts": "5.0.1",
-    "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },
   "scripts": {
@@ -90,6 +89,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "prettier": "^3.3.3",
     "stream-browserify": "^3.0.0",
+    "typescript": "^4.9.5",
     "util": "^0.12.5"
   }
 }

--- a/my-app/src/pages/Calendar/components/CalendarMultiSelect.tsx
+++ b/my-app/src/pages/Calendar/components/CalendarMultiSelect.tsx
@@ -21,6 +21,10 @@ const CalendarMultiSelect: React.FC<CalendarMultiSelectProps> = ({ selectedDates
   };
 
   const handleDeleteDate = (dateToDelete: Date) => {
+    if (dateToDelete < new Date()) {
+      console.warn("Cannot delete chips for past dates.");
+      return;
+    }
     setSelectedDates(selectedDates.filter(d => d.toDateString() !== dateToDelete.toDateString()));
   };
 
@@ -66,4 +70,4 @@ const CalendarMultiSelect: React.FC<CalendarMultiSelectProps> = ({ selectedDates
   );
 };
 
-export default CalendarMultiSelect; 
+export default CalendarMultiSelect;

--- a/my-app/src/pages/Calendar/components/EventMenu.tsx
+++ b/my-app/src/pages/Calendar/components/EventMenu.tsx
@@ -60,11 +60,19 @@ const EventMenu: React.FC<EventMenuProps> = ({ event, onEventModified }) => {
   };
 
   const handleDeleteClick = () => {
+    if (new Date(event.deliveryDate) < new Date()) {
+      console.warn("Cannot delete past events.");
+      return;
+    }
     setIsDeleteDialogOpen(true);
     handleMenuClose();
   };
 
   const handleEditClick = () => {
+    if (new Date(event.deliveryDate) < new Date()) {
+      console.warn("Cannot edit past events.");
+      return;
+    }
     setIsEditDialogOpen(true);
     handleMenuClose();
   };
@@ -186,10 +194,13 @@ const EventMenu: React.FC<EventMenuProps> = ({ event, onEventModified }) => {
     setIsEditDialogOpen(false);
   };
 
+  const isPastEvent = new Date(event.deliveryDate) < new Date();
+
   return (
     <>
       <IconButton
         onClick={handleMenuOpen}
+        disabled={isPastEvent}
         sx={{
           backgroundColor: 'var(--color-background-light)',
           borderRadius: '50%',
@@ -197,14 +208,13 @@ const EventMenu: React.FC<EventMenuProps> = ({ event, onEventModified }) => {
           color: 'var(--color-primary)',
           transition: 'background 0.2s, color 0.2s',
           '&:hover': {
-            backgroundColor: 'rgba(37, 126, 104, 0.12)', // var(--color-primary) with opacity
+            backgroundColor: 'rgba(37, 126, 104, 0.12)',
             color: 'var(--color-primary-dark)',
           },
           width: 40,
           height: 40,
           display: 'flex',
           alignItems: 'center',
-          justifyContent: 'center',
         }}
         aria-label="Open event menu"
       >
@@ -212,8 +222,8 @@ const EventMenu: React.FC<EventMenuProps> = ({ event, onEventModified }) => {
       </IconButton>
 
       <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleMenuClose}>
-        <MenuItem disabled = {userRole === UserType.ClientIntake} onClick={handleEditClick}>Edit</MenuItem>
-        <MenuItem disabled = {userRole === UserType.ClientIntake} onClick={handleDeleteClick}>Delete</MenuItem>
+        <MenuItem disabled={isPastEvent || userRole === UserType.ClientIntake} onClick={handleEditClick}>Edit</MenuItem>
+        <MenuItem disabled={isPastEvent || userRole === UserType.ClientIntake} onClick={handleDeleteClick}>Delete</MenuItem>
       </Menu>
 
       {/* Edit Dialog */}
@@ -268,25 +278,23 @@ const EventMenu: React.FC<EventMenuProps> = ({ event, onEventModified }) => {
                 </Select>
               </FormControl>
 
-              {editRecurrence.recurrence !== "None" && (
-                <Box>
-                  <Typography variant="subtitle1">End Date</Typography>
-                  <TextField
-                    label="End Date"
-                    type="date"
-                    value={editRecurrence.repeatsEndDate}
-                    onChange={(e) =>
-                      setEditRecurrence({
-                        ...editRecurrence,
-                        repeatsEndDate: e.target.value,
-                      })
-                    }
-                    fullWidth
-                    margin="normal"
-                    InputLabelProps={{ shrink: true }}
-                  />
-                </Box>
-              )}
+              <Box>
+                <Typography variant="subtitle1">End Date</Typography>
+                <TextField
+                  label="End Date"
+                  type="date"
+                  value={editRecurrence.repeatsEndDate}
+                  onChange={(e) =>
+                    setEditRecurrence({
+                      ...editRecurrence,
+                      repeatsEndDate: e.target.value,
+                    })
+                  }
+                  fullWidth
+                  margin="normal"
+                  InputLabelProps={{ shrink: true }}
+                />
+              </Box>
             </>
           )}
         </DialogContent>

--- a/my-app/src/pages/Calendar/components/EventMenu.tsx
+++ b/my-app/src/pages/Calendar/components/EventMenu.tsx
@@ -278,23 +278,25 @@ const EventMenu: React.FC<EventMenuProps> = ({ event, onEventModified }) => {
                 </Select>
               </FormControl>
 
-              <Box>
-                <Typography variant="subtitle1">End Date</Typography>
-                <TextField
-                  label="End Date"
-                  type="date"
-                  value={editRecurrence.repeatsEndDate}
-                  onChange={(e) =>
-                    setEditRecurrence({
-                      ...editRecurrence,
-                      repeatsEndDate: e.target.value,
-                    })
-                  }
-                  fullWidth
-                  margin="normal"
-                  InputLabelProps={{ shrink: true }}
-                />
-              </Box>
+              {editRecurrence.recurrence !== "None" && (
+                <Box>
+                  <Typography variant="subtitle1">End Date</Typography>
+                  <TextField
+                    label="End Date"
+                    type="date"
+                    value={editRecurrence.repeatsEndDate}
+                    onChange={(e) =>
+                      setEditRecurrence({
+                        ...editRecurrence,
+                        repeatsEndDate: e.target.value,
+                      })
+                    }
+                    fullWidth
+                    margin="normal"
+                    InputLabelProps={{ shrink: true }}
+                  />
+                </Box>
+              )}
             </>
           )}
         </DialogContent>

--- a/my-app/src/pages/Profile/Profile.tsx
+++ b/my-app/src/pages/Profile/Profile.tsx
@@ -29,6 +29,7 @@ import {
   updateDoc,
   where,
   Timestamp,
+  deleteDoc,
 } from "firebase/firestore";
 import React, { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
@@ -52,7 +53,8 @@ import TagManager from "./Tags/TagManager";
 // Import types
 import { CaseWorker, ClientProfile } from "../../types";
 import { ClientProfileKey, InputType } from "./types";
-import { DeliveryEvent } from "../../types";
+import { DeliveryEvent } from "../../types/calendar-types";
+import { Delivery } from '../../types/delivery-types';
 
 // Styling
 const fieldStyles = {
@@ -742,7 +744,6 @@ const Profile = () => {
 
       // Also force geocode if coordinates are missing or invalid
       if (!addressChanged && (!clientProfile.coordinates || clientProfile.coordinates.length === 0 || (clientProfile.coordinates[0].lat === 0 && clientProfile.coordinates[0].lng === 0))) {
-          console.log("Forcing geocode due to missing/invalid coordinates.");
           addressChanged = true;
       }
 
@@ -750,11 +751,8 @@ const Profile = () => {
       let coordinatesToSave = clientProfile.coordinates; // Default to existing coordinates
 
       if (addressChanged) {
-        console.log("Address changed, fetching new Ward and Coordinates...");
         fetchedWard = await getWard(clientProfile.address); // Fetch ward only if address changed
         coordinatesToSave = await getCoordinates(clientProfile.address); // Fetch coordinates only if address changed
-      } else {
-        console.log("Address unchanged, using existing Ward and Coordinates.");
       }
       // --- Geocoding Optimization End ---
 
@@ -1762,6 +1760,15 @@ const Profile = () => {
               pastDeliveries={pastDeliveries}
               futureDeliveries={futureDeliveries}
               fieldLabelStyles={fieldLabelStyles}
+              onDeleteDelivery={async (delivery: DeliveryEvent) => {
+                try {
+                  const updatedFutureDeliveries = futureDeliveries.filter(d => d.id !== delivery.id);
+                  setFutureDeliveries(updatedFutureDeliveries);
+                  // Optionally, add Firestore deletion logic here
+                } catch (error) {
+                  console.error('Error deleting delivery:', error);
+                }
+              }}
             />
           </SectionBox>
 

--- a/my-app/src/pages/Profile/Profile.tsx
+++ b/my-app/src/pages/Profile/Profile.tsx
@@ -1812,11 +1812,19 @@ const Profile = () => {
               fieldLabelStyles={fieldLabelStyles}
               onDeleteDelivery={async (delivery: DeliveryEvent) => {
                 try {
+                  // Update the parent component's state to reflect the deletion
+                  // Note: Firestore deletion is already handled by DeliveryLogForm
                   const updatedFutureDeliveries = futureDeliveries.filter(d => d.id !== delivery.id);
                   setFutureDeliveries(updatedFutureDeliveries);
-                  // Optionally, add Firestore deletion logic here
+                  
+                  // Also refresh the delivery history to ensure consistency
+                  if (clientId) {
+                    const deliveryService = DeliveryService.getInstance();
+                    const { futureDeliveries: refreshedFutureDeliveries } = await deliveryService.getClientDeliveryHistory(clientId);
+                    setFutureDeliveries(refreshedFutureDeliveries);
+                  }
                 } catch (error) {
-                  console.error('Error deleting delivery:', error);
+                  console.error('Error updating delivery state after deletion:', error);
                 }
               }}
             />

--- a/my-app/src/pages/Profile/components/DeliveryLogForm.tsx
+++ b/my-app/src/pages/Profile/components/DeliveryLogForm.tsx
@@ -1,28 +1,212 @@
-import React from "react";
-import { Box, Typography, Chip, Stack } from "@mui/material";
+import React, { useState, useEffect } from "react";
+import { Box, Typography, Chip, Stack, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Button } from "@mui/material";
 import { DeliveryEvent } from "../../../types";
+import DeliveryService from "../../../services/delivery-service";
 
-interface DeliveryLogProps {
-    pastDeliveries: DeliveryEvent[],
-    futureDeliveries: DeliveryEvent[],
+// Ensure DeliveryLogProps is properly defined
+interface DeliveryEventWithHidden extends DeliveryEvent {
+    hidden?: boolean;
+}
+
+export interface DeliveryLogProps {
+    pastDeliveries: DeliveryEvent[];
+    futureDeliveries: DeliveryEventWithHidden[]; // Update type to include hidden property
     fieldLabelStyles: any;
+    onDeleteDelivery: (delivery: DeliveryEvent) => Promise<void>;
 }
 
 const DeliveryLogForm: React.FC<DeliveryLogProps> = ({
     pastDeliveries,
     futureDeliveries,
     fieldLabelStyles,
+    onDeleteDelivery, // Destructure the restored property
 }) => {
+    const [confirmDelete, setConfirmDelete] = useState(false);
+    const [selectedDelivery, setSelectedDelivery] = useState<DeliveryEvent | null>(null);
+    const [deletingChipId, setDeletingChipId] = useState<string | null>(null);
+    const [futureDeliveriesState, setFutureDeliveries] = useState<DeliveryEventWithHidden[]>(futureDeliveries); // Local state for future deliveries
+    const [zoomingInChipId, setZoomingInChipId] = useState<string | null>(null); // New state for zoom-in transition
 
-    const formatDate = (date: Date): string => {
-        const month = String(date.getMonth() + 1).padStart(2, '0');
-        const day = String(date.getDate()).padStart(2, '0');
-        const year = date.getFullYear();
+    const deliveryService = DeliveryService.getInstance();
+
+    const formatDate = (date: Date | string): string => {
+        const dateObj = typeof date === 'string' ? new Date(date) : date;
+        if (!(dateObj instanceof Date) || isNaN(dateObj.getTime())) {
+            return 'Invalid date';
+        }
+        const month = String(dateObj.getMonth() + 1).padStart(2, '0');
+        const day = String(dateObj.getDate()).padStart(2, '0');
+        const year = dateObj.getFullYear();
         return `${month}/${day}/${year}`;
     };
 
+    // Sort the delivery dates before rendering the Chips
+    const sortedFutureDeliveries = [...futureDeliveriesState].sort((a, b) => new Date(a.deliveryDate).getTime() - new Date(b.deliveryDate).getTime());
+    const sortedPastDeliveries = [...pastDeliveries].sort((a, b) => new Date(a.deliveryDate).getTime() - new Date(b.deliveryDate).getTime());
+
+    const handleDeleteClick = (delivery: DeliveryEvent) => {
+        setSelectedDelivery(delivery);
+        setConfirmDelete(true);
+    };
+
+    const fetchFutureDeliveries = async () => {
+        try {
+            if (!selectedDelivery?.clientId) {
+                return;
+            }
+
+            const allEvents = await deliveryService.getEventsByClientId(selectedDelivery.clientId);
+            const now = new Date();
+            const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+            const futureDeliveries = allEvents.filter((event) => event.deliveryDate >= today)
+                .sort((a, b) => new Date(a.deliveryDate).getTime() - new Date(b.deliveryDate).getTime())
+                .slice(0, 5); // Ensure only the next 5 future deliveries are included
+
+            const currentIds = futureDeliveriesState.map((delivery) => delivery.id);
+            const newDeliveries = futureDeliveries.filter((delivery) => !currentIds.includes(delivery.id));
+
+            setFutureDeliveries(futureDeliveries.map((delivery) => ({ ...delivery, hidden: true }))); // Add hidden property to all deliveries
+
+            // Wait for the chips to load on the DOM and animate only the new chip
+            setTimeout(() => {
+                newDeliveries.forEach((delivery) => {
+                    setZoomingInChipId(delivery.id);
+                    setFutureDeliveries((prev) => prev.map((d) =>
+                        d.id === delivery.id ? { ...d, hidden: false } : d
+                    ));
+
+                    setTimeout(() => {
+                        setZoomingInChipId(null);
+                    }, 1200); // Match zoom-in transition duration
+                });
+            }, 100); // Initial delay to ensure DOM readiness
+        } catch (error) {
+            console.error("Error fetching future deliveries:", error);
+        }
+    };
+
+    const handleConfirmDelete = async () => {
+        if (selectedDelivery) {
+            setDeletingChipId(selectedDelivery.id); // Trigger zoom-out transition
+            setTimeout(async () => {
+                try {
+                    // Added validation for selectedDelivery and its id
+                    if (!selectedDelivery || !selectedDelivery.id) {
+                        console.error("Invalid selectedDelivery or missing ID:", selectedDelivery);
+                        return;
+                    }
+
+                    await deliveryService.deleteEvent(selectedDelivery.id);
+                    console.log(`Successfully deleted delivery with ID: ${selectedDelivery.id}`);
+                    console.log(`Client ID associated with the deleted delivery: ${selectedDelivery.clientId}`);
+
+                    // Remove the deleted delivery from the local state
+                    setFutureDeliveries((prev) => prev.filter((delivery) => delivery.id !== selectedDelivery.id));
+
+                    // Requery the database to ensure consistency
+                    const allEvents = await deliveryService.getEventsByClientId(selectedDelivery.clientId);
+                    const now = new Date();
+                    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+                    const futureDeliveries = allEvents.filter((event) => event.deliveryDate >= today)
+                        .sort((a, b) => new Date(a.deliveryDate).getTime() - new Date(b.deliveryDate).getTime())
+                        .slice(0, 5); // Ensure only the next 5 future deliveries are included
+
+                    const currentIds = futureDeliveriesState.map((delivery) => delivery.id);
+                    const newDeliveries = futureDeliveries.filter((delivery) => !currentIds.includes(delivery.id));
+
+                    // Add the new chip with hidden property
+                    setFutureDeliveries((prev) => [
+                        ...prev,
+                        ...newDeliveries.map((delivery) => ({ ...delivery, hidden: true })),
+                    ]);
+
+                    // Animate the new chip after the deletion process
+                    setTimeout(() => {
+                        newDeliveries.forEach((delivery) => {
+                            setZoomingInChipId(delivery.id);
+                            setFutureDeliveries((prev) => prev.map((d) =>
+                                d.id === delivery.id ? { ...d, hidden: false } : d
+                            ));
+
+                            setTimeout(() => {
+                                setZoomingInChipId(null);
+                            }, 1200); // Match zoom-in transition duration
+                        });
+                    }, 100); // Initial delay to ensure DOM readiness
+                } catch (error) {
+                    console.error("Error deleting delivery:", error);
+                }
+                setDeletingChipId(null); // Reset zoom-out state
+            }, 300); // Match zoom-out transition duration
+        }
+        setConfirmDelete(false);
+        setSelectedDelivery(null);
+    };
+
+    const handleCancelDelete = () => {
+        setConfirmDelete(false);
+        setSelectedDelivery(null);
+    };
+
+    // Apply transition styles to Chips
+    const chipStyle = (deliveryId: string, hidden = false) => {
+        if (hidden) {
+            return {
+                opacity: 0,
+                transform: "scale(0.8)", // Slightly shrink before disappearing
+                transition: "opacity 0.5s ease, transform 0.3s ease", // Smooth transition
+            };
+        }
+        if (deletingChipId === deliveryId) {
+            return {
+                transform: "scale(0.8)", // Shrink slightly before disappearing
+                opacity: 0, // Fade out
+                transition: "opacity 0.75s ease, transform 0.5s ease", // Smooth fade-out
+            };
+        }
+        if (zoomingInChipId === deliveryId) {
+            return {
+                transform: "scale(1)",
+                opacity: 1,
+                transition: "transform 0.5s ease-in-out, opacity 0.5s ease-in-out", // Smooth zoom-in
+            };
+        }
+        return {
+            opacity: 1,
+            transform: "scale(1)",
+            transition: "opacity 0.3s ease, transform 0.3s ease", // Default smooth transition
+        };
+    };
+
+    useEffect(() => {
+        setFutureDeliveries(futureDeliveries);
+    }, [futureDeliveries]);
+
     return (
         <>
+            {/* Confirmation Modal */}
+            <Dialog
+                open={confirmDelete}
+                onClose={handleCancelDelete}
+            >
+                <DialogTitle>Confirm Deletion</DialogTitle>
+                <DialogContent>
+                    <DialogContentText>
+                        Are you sure you want to delete this delivery?
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={handleCancelDelete} color="primary">
+                        Cancel
+                    </Button>
+                    <Button onClick={handleConfirmDelete} color="secondary">
+                        Delete
+                    </Button>
+                </DialogActions>
+            </Dialog>
+
             <Box
                 sx={{
                     display: "grid",
@@ -41,17 +225,20 @@ const DeliveryLogForm: React.FC<DeliveryLogProps> = ({
                         UPCOMING
                     </Typography>
                     <Stack direction="row" spacing={1} flexWrap="wrap" mb={2}>
-                        {futureDeliveries.length > 0 ? (
-                            futureDeliveries.map((delivery, index) => (
+                        {sortedFutureDeliveries.length > 0 ? (
+                            sortedFutureDeliveries.map((delivery, index) => (
                                 <Chip
                                     key={index}
                                     label={formatDate(delivery.deliveryDate)}
                                     variant="outlined"
                                     color="primary"
+                                    onClick={() => console.log('Chip clicked:', delivery)}
+                                    onDelete={() => handleDeleteClick(delivery)}
+                                    sx={chipStyle(delivery.id, delivery.hidden)}
                                 />
                             ))
                         ) : (
-                            <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                            <Typography variant="body2" sx={{ color: "text.secondary" }}>
                                 No upcoming deliveries
                             </Typography>
                         )}
@@ -62,17 +249,19 @@ const DeliveryLogForm: React.FC<DeliveryLogProps> = ({
                         PREVIOUS
                     </Typography>
                     <Stack direction="row" spacing={1} flexWrap="wrap">
-                        {pastDeliveries.length > 0 ? (
-                            pastDeliveries.map((delivery, index) => (
+                        {sortedPastDeliveries.length > 0 ? (
+                            sortedPastDeliveries.map((delivery, index) => (
                                 <Chip
                                     key={index}
                                     label={formatDate(delivery.deliveryDate)}
                                     variant="outlined"
                                     color="secondary"
+                                    clickable={false} // Ensure past Chips are not clickable
+                                    sx={{ pointerEvents: 'none' }} // Disable pointer events
                                 />
                             ))
                         ) : (
-                            <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                            <Typography variant="body2" sx={{ color: "text.secondary" }}>
                                 No previous deliveries
                             </Typography>
                         )}

--- a/my-app/src/pages/Profile/components/DeliveryLogForm.tsx
+++ b/my-app/src/pages/Profile/components/DeliveryLogForm.tsx
@@ -228,7 +228,7 @@ const DeliveryLogForm: React.FC<DeliveryLogProps> = ({
                         {sortedFutureDeliveries.length > 0 ? (
                             sortedFutureDeliveries.map((delivery, index) => (
                                 <Chip
-                                    key={index}
+                                    key={delivery.id}
                                     label={formatDate(delivery.deliveryDate)}
                                     variant="outlined"
                                     color="primary"
@@ -252,7 +252,7 @@ const DeliveryLogForm: React.FC<DeliveryLogProps> = ({
                         {sortedPastDeliveries.length > 0 ? (
                             sortedPastDeliveries.map((delivery, index) => (
                                 <Chip
-                                    key={index}
+                                    key={delivery.id}
                                     label={formatDate(delivery.deliveryDate)}
                                     variant="outlined"
                                     color="secondary"

--- a/my-app/src/services/delivery-service.ts
+++ b/my-app/src/services/delivery-service.ts
@@ -185,7 +185,7 @@ class DeliveryService {
   public async setDailyLimit(dateKey: string, limit: number): Promise<void> {
     try {
       const docRef = doc(this.db, this.dailyLimitsCollection, dateKey);
-      await setDoc(docRef, { limit });
+      await setDoc(docRef, { date: dateKey, limit });
     } catch (error) {
       console.error("Error setting daily limit:", error);
       throw error;

--- a/my-app/src/services/delivery-service.ts
+++ b/my-app/src/services/delivery-service.ts
@@ -9,6 +9,8 @@ import {
   deleteDoc,
   query,
   where,
+  orderBy,
+  limit,
   Timestamp,
 } from "firebase/firestore";
 import FirebaseService from "./firebase-service";
@@ -116,6 +118,10 @@ class DeliveryService {
    */
   public async deleteEvent(id: string): Promise<void> {
     try {
+      if (!id) {
+        throw new Error("Invalid event ID provided for deletion");
+      }
+
       await deleteDoc(doc(this.db, this.eventsCollection, id));
     } catch (error) {
       console.error("Error deleting event:", error);
@@ -147,107 +153,28 @@ class DeliveryService {
                     ? data.deliveryDate.toDate()
                     : new Date(data.deliveryDate);
 
-                // If not a custom delivery (recurrence !== "Custom"), add one day
-                if (data.recurrence !== "Custom") {
-                    deliveryDate.setDate(deliveryDate.getDate() + 1);
-                }
-
                 return {
                     id: doc.id,
                     ...data,
-                    deliveryDate
+                    deliveryDate,
                 } as DeliveryEvent;
             })
             .filter((event): event is DeliveryEvent => event !== null);
     } catch (error) {
-        console.error("Error fetching events for client:", error);
+        console.error("Error fetching events by client ID:", error);
         throw error;
-    }
-}
-
-  /**
-  * Get the previous 5 and future 5 deliveries for a client
-  * @param clientId The ID of the client
-  * @returns Object containing past and future deliveries
-  */
-  
-  public async getClientDeliveryHistory(clientId: string): Promise<{
-    pastDeliveries: DeliveryEvent[];
-    futureDeliveries: DeliveryEvent[];
-  }> {
-    try {
-      const now = new Date();
-      // Set to start of current day
-      const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-      
-      // Get all deliveries for the client
-      const allEvents = await this.getEventsByClientId(clientId);
-      console.log(allEvents);
-      // Sort events by date (oldest to newest)
-      const sortedEvents = allEvents.sort((a, b) =>
-        a.deliveryDate.getTime() - b.deliveryDate.getTime()
-      );
-  
-      // Deduplicate events based on date
-      const uniqueEvents: DeliveryEvent[] = [];
-      const seenDates = new Set<string>();
-      
-      sortedEvents.forEach((event) => {
-        // Normalize the date to start of day
-        const eventDate = new Date(
-          event.deliveryDate.getFullYear(),
-          event.deliveryDate.getMonth(),
-          event.deliveryDate.getDate()
-        );
-        const dateKey = eventDate.toISOString().split('T')[0];
-        
-        if (!seenDates.has(dateKey)) {
-          seenDates.add(dateKey);
-          uniqueEvents.push({
-            ...event,
-            deliveryDate: eventDate
-          });
-        }
-      });
-  
-      // Split into past and future
-      const pastDeliveries = uniqueEvents
-        .filter(event => event.deliveryDate < today)
-        .slice(-5)
-        .reverse(); // Most recent first
-  
-      const futureDeliveries = uniqueEvents
-        .filter(event => event.deliveryDate >= today)
-        .slice(0, 5); // Next 5 upcoming
-  
-      return { pastDeliveries, futureDeliveries };
-    } catch (error) {
-      console.error("Error fetching client delivery history:", error);
-      throw error;
     }
   }
 
   /**
-   * Get events by recurrence ID
+   * Get daily delivery limits
    */
-  public async getEventsByRecurrence(recurrenceId: string): Promise<DeliveryEvent[]> {
+  public async getDailyLimits(): Promise<{ id: string; date: string; limit: number }[]> {
     try {
-      const q = query(
-        collection(this.db, this.eventsCollection),
-        where("recurrence", "==", recurrenceId)
-      );
-
-      const querySnapshot = await getDocs(q);
-      return querySnapshot.docs.map((doc) => {
-        const data = doc.data();
-        return {
-          id: doc.id,
-          ...data,
-          deliveryDate: data.deliveryDate.toDate(), // Convert Timestamp to Date
-        } as DeliveryEvent;
-      });
+      const snapshot = await getDocs(collection(this.db, this.dailyLimitsCollection));
+      return snapshot.docs.map((doc) => doc.data() as { id: string; date: string; limit: number });
     } catch (error) {
-      console.error("Error fetching events by recurrence:", error);
+      console.error("Error fetching daily limits:", error);
       throw error;
     }
   }
@@ -258,33 +185,9 @@ class DeliveryService {
   public async setDailyLimit(dateKey: string, limit: number): Promise<void> {
     try {
       const docRef = doc(this.db, this.dailyLimitsCollection, dateKey);
-      await setDoc(
-        docRef,
-        {
-          limit,
-          date: dateKey,
-        },
-        { merge: true }
-      );
+      await setDoc(docRef, { limit });
     } catch (error) {
       console.error("Error setting daily limit:", error);
-      throw error;
-    }
-  }
-
-  /**
-   * Get daily delivery limits
-   */
-  public async getDailyLimits(): Promise<{ id: string; date: string; limit: number }[]> {
-    try {
-      const snapshot = await getDocs(collection(this.db, this.dailyLimitsCollection));
-      return snapshot.docs.map((doc) => ({
-        id: doc.id,
-        date: doc.data().date,
-        limit: doc.data().limit,
-      }));
-    } catch (error) {
-      console.error("Error getting daily limits:", error);
       throw error;
     }
   }
@@ -295,27 +198,10 @@ class DeliveryService {
   public async getWeeklyLimits(): Promise<Record<string, number>> {
     try {
       const docRef = doc(this.db, this.limitsCollection, this.limitsDocId);
-      const docSnapshot = await getDoc(docRef);
-
-      if (docSnapshot.exists()) {
-        return docSnapshot.data() as Record<string, number>;
-      }
-
-      // Default values if doc doesn't exist
-      const defaultLimits = {
-        sunday: 60,
-        monday: 60,
-        tuesday: 60,
-        wednesday: 60,
-        thursday: 90,
-        friday: 90,
-        saturday: 60,
-      };
-
-      await setDoc(docRef, defaultLimits);
-      return defaultLimits;
+      const snapshot = await getDoc(docRef);
+      return snapshot.data() as Record<string, number>;
     } catch (error) {
-      console.error("Error getting weekly limits:", error);
+      console.error("Error fetching weekly limits:", error);
       throw error;
     }
   }
@@ -326,12 +212,115 @@ class DeliveryService {
   public async updateWeeklyLimits(limits: Record<string, number>): Promise<void> {
     try {
       const docRef = doc(this.db, this.limitsCollection, this.limitsDocId);
-      await setDoc(docRef, limits, { merge: true });
+      await setDoc(docRef, limits);
     } catch (error) {
       console.error("Error updating weekly limits:", error);
       throw error;
     }
   }
+
+  /**
+   * Get the previous 5 deliveries for a client
+   */
+  public async getPreviousDeliveries(clientId: string): Promise<DeliveryEvent[]> {
+    try {
+      const now = new Date();
+      if (isNaN(now.getTime())) {
+        throw new Error("Invalid date object");
+      }
+      const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+      const pastQuery = query(
+        collection(this.db, this.eventsCollection),
+        where("clientId", "==", clientId),
+        where("deliveryDate", "<", today),
+        orderBy("deliveryDate", "desc"),
+        limit(5)
+      );
+
+      const pastSnapshot = await getDocs(pastQuery);
+      return pastSnapshot.docs.map((doc) => {
+        const data = doc.data();
+        return {
+          id: doc.id, // Ensure the document ID is included
+          ...data,
+          deliveryDate: data.deliveryDate.toDate ? data.deliveryDate.toDate() : new Date(data.deliveryDate),
+        } as DeliveryEvent;
+      });
+    } catch (error) {
+      console.error("Error fetching previous deliveries:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get the next 5 deliveries for a client
+   */
+  public async getNextDeliveries(clientId: string): Promise<DeliveryEvent[]> {
+    try {
+      const now = new Date();
+      if (isNaN(now.getTime())) {
+        throw new Error("Invalid date object");
+      }
+      const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+      const futureQuery = query(
+        collection(this.db, this.eventsCollection),
+        where("clientId", "==", clientId),
+        where("deliveryDate", ">=", today),
+        orderBy("deliveryDate", "asc"),
+        limit(5)
+      );
+
+      const futureSnapshot = await getDocs(futureQuery);
+      return futureSnapshot.docs.map((doc) => {
+        const data = doc.data();
+        return {
+          id: doc.id, // Ensure the document ID is included
+          ...data,
+          deliveryDate: data.deliveryDate.toDate ? data.deliveryDate.toDate() : new Date(data.deliveryDate),
+        } as DeliveryEvent;
+      });
+    } catch (error) {
+      console.error("Error fetching future deliveries:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get the previous 5 and future 5 deliveries for a client
+   */
+  public async getClientDeliveryHistory(clientId: string): Promise<{
+    pastDeliveries: DeliveryEvent[];
+    futureDeliveries: DeliveryEvent[];
+  }> {
+    try {
+      const [pastDeliveries, futureDeliveries] = await Promise.all([
+        this.getPreviousDeliveries(clientId),
+        this.getNextDeliveries(clientId),
+      ]);
+
+      return { pastDeliveries, futureDeliveries };
+    } catch (error) {
+      console.error("Error fetching client delivery history:", error);
+      throw error;
+    }
+  }
 }
 
-export default DeliveryService; 
+export default DeliveryService;
+
+const chipStyle = (deliveryId: string, hidden = false) => {
+        if (hidden) {
+            return {
+                opacity: 0,
+                transform: "scale(0.8)", // Slightly shrink before disappearing
+                transition: "opacity 0.3s ease, transform 0.3s ease", // Smooth transition
+            };
+        }
+        return {
+            opacity: 1,
+            transform: "scale(1)",
+            transition: "opacity 0.3s ease, transform 0.3s ease", // Default smooth transition
+        };
+    };

--- a/my-app/src/services/delivery-service.ts
+++ b/my-app/src/services/delivery-service.ts
@@ -199,6 +199,24 @@ class DeliveryService {
     try {
       const docRef = doc(this.db, this.limitsCollection, this.limitsDocId);
       const snapshot = await getDoc(docRef);
+      
+      if (!snapshot.exists()) {
+        // Return default weekly limits if document doesn't exist
+        const defaultLimits: Record<string, number> = {
+          sunday: 60,
+          monday: 60,
+          tuesday: 60,
+          wednesday: 60,
+          thursday: 90,
+          friday: 90,
+          saturday: 60,
+        };
+        
+        // Create the document with default values
+        await setDoc(docRef, defaultLimits);
+        return defaultLimits;
+      }
+      
       return snapshot.data() as Record<string, number>;
     } catch (error) {
       console.error("Error fetching weekly limits:", error);

--- a/my-app/src/types/calendar-types.ts
+++ b/my-app/src/types/calendar-types.ts
@@ -20,6 +20,8 @@ export interface DeliveryEvent extends Delivery {
   recurrence: "None" | "Weekly" | "2x-Monthly" | "Monthly" | "Custom";
   customDates?: string[];
   recurrenceId: string;
+  isZoomingOut?: boolean;
+  isZoomingIn?: boolean;
 }
 
 export interface NewDelivery {
@@ -48,4 +50,4 @@ export interface CalendarConfig {
   viewType: DayPilotViewType | ViewType;
   startDate: DayPilot.Date;
   events: CalendarEvent[];
-} 
+}

--- a/my-app/src/utils/dates.ts
+++ b/my-app/src/utils/dates.ts
@@ -82,8 +82,8 @@ export const formatDateToYYYYMMDD = (date: Date): string => {
  */
 export const formatDate = (date: Date | string): string => {
   const dateObj = typeof date === 'string' ? new Date(date) : date;
-  if (isNaN(dateObj.getTime())) {
+  if (!(dateObj instanceof Date) || isNaN(dateObj.getTime())) {
     return 'Invalid date';
   }
   return dateObj.toUTCString().split(' ').slice(0, 4).join(' ');
-}; 
+};


### PR DESCRIPTION
The test for this is going into the user's profile page and seeing their future deliveries. 

Maybe pick a user you know has more than 5 upcoming deliveries so that when you delete one of the other deliveries that isn't currently showing before you delete it comes up.

Test should be if you have 5 or more future deliveries when you delete one it should not be on the page any more or be on the page when you refresh the page to be sure it's deleting from firebase, and a new chip should animiate into view.

A second test is if there are 5 or less deliveries and you delete one it should still delete and confirm by refreshing the page to see that it was deleted from firebase, but also see that you have the expected number of chips left.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added animated transitions and confirmation dialog for deleting future deliveries in the delivery log.
  * Delivery chips now support zoom-in and zoom-out effects for improved UI responsiveness.
  * Introduced daily and weekly delivery limit management.

* **Bug Fixes**
  * Prevented deletion or editing of past events and dates in calendar and event menus.
  * Improved date formatting to handle invalid or non-date inputs gracefully.

* **Enhancements**
  * Delivery history retrieval is now modularized, with clearer separation of past and future deliveries.
  * Delivery chips for past deliveries are now non-clickable for better user experience.

* **Chores**
  * Updated dependency management for TypeScript in project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->