### PR TITLE
Preserve Cluster Selection After Assigning Driver and Time

### DIFF
--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -671,8 +671,6 @@ const DeliverySpreadsheet: React.FC = () => {
     setPopupMode("");
     setExportOption(null);
     setEmailOrDownload(null);
-    setSelectedClusters(new Set());
-    setSelectedRows(new Set());
   };
 
   //Handle assigning driver


### PR DESCRIPTION
Modified the resetSelections() method to not deselect clusters after performing cluster actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted selection reset behavior so that selected clusters and rows are no longer cleared when resetting selections in the delivery spreadsheet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->