### PR TITLE
Add phone number validation with formatting guidelines tooltip

### DIFF
--- a/my-app/src/pages/Profile/components/BasicInfoForm.tsx
+++ b/my-app/src/pages/Profile/components/BasicInfoForm.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Box, Typography, Select, MenuItem, Tooltip, Autocomplete, TextField } from "@mui/material";
+import InfoIcon from '@mui/icons-material/Info';
 import { ClientProfile } from '../../../types';
 import { ClientProfileKey, InputType } from '../types';
 import { CaseWorker } from "../../../types";
@@ -196,26 +197,70 @@ const BasicInfoForm: React.FC<BasicInfoFormProps> = ({
             {errors.email}
           </Typography>
         )}
-      </Box>
-
-      {/* Phone */}
-      <Box>
-        <Typography className="field-descriptor" sx={fieldLabelStyles}>
-          PHONE <span className="required-asterisk">*</span>
-        </Typography>
-        {renderField("phone", "text")}
-        {errors.phone && (
-          <Typography color="error" variant="body2">
-            {errors.phone}
+      </Box>      {/* Phone */}
+      <Box>        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <Typography className="field-descriptor" sx={fieldLabelStyles}>
+            PHONE <span className="required-asterisk">*</span>
           </Typography>
-        )}
+          <Tooltip 
+            title={
+              <React.Fragment>
+                <Typography variant="subtitle2">Allowed formats:</Typography>
+                <Typography variant="body2">(123) 456-7890</Typography>
+                <Typography variant="body2">123-456-7890</Typography>
+                <Typography variant="body2">123.456.7890</Typography>
+                <Typography variant="body2">123 456 7890</Typography>
+                <Typography variant="body2">1234567890</Typography>
+                <Typography variant="body2">+1 123-456-7890</Typography>
+              </React.Fragment>
+            } 
+            arrow
+          >
+            <InfoIcon 
+              sx={{ 
+                color: '#257E68', 
+                fontSize: '20px',
+                cursor: 'help',
+                verticalAlign: 'middle', 
+                marginTop: '-3px'
+              }} 
+            />
+          </Tooltip>
+        </Box>
+        {renderField("phone", "text")}
+        {/* Error is now displayed within the renderField component */}
       </Box>
 
-      {/* Alternative Phone */}
-      <Box>
-        <Typography className="field-descriptor" sx={fieldLabelStyles}>
-          ALTERNATIVE PHONE
-        </Typography>
+      {/* Alternative Phone */}      <Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <Typography className="field-descriptor" sx={fieldLabelStyles}>
+            ALTERNATIVE PHONE
+          </Typography>
+          <Tooltip 
+            title={
+              <React.Fragment>
+                <Typography variant="subtitle2">Allowed formats:</Typography>
+                <Typography variant="body2">(123) 456-7890</Typography>
+                <Typography variant="body2">123-456-7890</Typography>
+                <Typography variant="body2">123.456.7890</Typography>
+                <Typography variant="body2">123 456 7890</Typography>
+                <Typography variant="body2">1234567890</Typography>
+                <Typography variant="body2">+1 123-456-7890</Typography>
+              </React.Fragment>
+            } 
+            arrow
+          >
+            <InfoIcon 
+              sx={{ 
+                color: '#257E68', 
+                fontSize: '20px',
+                cursor: 'help',
+                verticalAlign: 'middle',
+                marginTop: '-3px'
+              }} 
+            />
+          </Tooltip>
+        </Box>
         {renderField("alternativePhone", "text")}
       </Box>
 

--- a/my-app/src/pages/Profile/components/BasicInfoForm.tsx
+++ b/my-app/src/pages/Profile/components/BasicInfoForm.tsx
@@ -196,8 +196,7 @@ const BasicInfoForm: React.FC<BasicInfoFormProps> = ({
           <Typography color="error" variant="body2">
             {errors.email}
           </Typography>
-        )}
-      </Box>      {/* Phone */}
+        )}      </Box>      {/* Phone */}
       <Box>        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
           <Typography className="field-descriptor" sx={fieldLabelStyles}>
             PHONE <span className="required-asterisk">*</span>
@@ -228,10 +227,12 @@ const BasicInfoForm: React.FC<BasicInfoFormProps> = ({
           </Tooltip>
         </Box>
         {renderField("phone", "text")}
-        {/* Error is now displayed within the renderField component */}
-      </Box>
-
-      {/* Alternative Phone */}      <Box>
+        {errors.phone && (
+          <Typography color="error" variant="body2" sx={{ fontSize: '0.75rem', mt: 0.5 }}>
+            {errors.phone}
+          </Typography>
+        )}
+      </Box>      {/* Alternative Phone */}      <Box>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
           <Typography className="field-descriptor" sx={fieldLabelStyles}>
             ALTERNATIVE PHONE
@@ -262,6 +263,11 @@ const BasicInfoForm: React.FC<BasicInfoFormProps> = ({
           </Tooltip>
         </Box>
         {renderField("alternativePhone", "text")}
+        {errors.alternativePhone && (
+          <Typography color="error" variant="body2" sx={{ fontSize: '0.75rem', mt: 0.5 }}>
+            {errors.alternativePhone}
+          </Typography>
+        )}
       </Box>
 
       {/* Gender */}

--- a/my-app/src/pages/Profile/components/FormField.tsx
+++ b/my-app/src/pages/Profile/components/FormField.tsx
@@ -408,9 +408,11 @@ const FormField: React.FC<FormFieldProps> = ({
           />
         );      case "text":
         if (["email"].includes(fieldPath)) minLength = 5;
-        if (["address2"].includes(fieldPath)) minLength = 5;
-        return (
-          <Box sx={{ width: "100%" }}>
+        if (["address2"].includes(fieldPath)) minLength = 5;        return (
+          <Box sx={{ 
+            width: "100%",
+            position: "relative"
+          }}>
             <CustomTextField
               type="text"
               name={fieldPath}
@@ -421,14 +423,28 @@ const FormField: React.FC<FormFieldProps> = ({
               inputRef={fieldPath === "address" ? addressInputRef : null}
               inputProps={{ minLength }}
               error={!!error}
-              sx={{ width: "100%" }}
-            />
-            {error && (
-              <Typography variant="caption" color="error" sx={{ display: 'block', mt: 0.5 }}>
+              sx={{ 
+                width: "100%",
+                "& .MuiOutlinedInput-root": {
+                  height: fieldStyles.height, // Control inner element height
+                },
+                "& .MuiInputBase-input": {
+                  height: fieldStyles.height, // Control input element height
+                }
+              }}
+            />            {error && fieldPath !== "phone" && fieldPath !== "alternativePhone" && (
+              <Typography variant="caption" color="error" sx={{ 
+                display: 'block', 
+                position: "absolute", 
+                top: "calc(100% + 2px)",
+                left: 0,
+                mt: 0 
+              }}>
                 {error}
               </Typography>
             )}
-          </Box>        );
+          </Box>
+        );
       case "textarea":
         if (fieldPath === "ward") {
           return <CustomTextField name={fieldPath} value={String(value || "")} disabled fullWidth />;

--- a/my-app/src/pages/Profile/components/FormField.tsx
+++ b/my-app/src/pages/Profile/components/FormField.tsx
@@ -35,6 +35,7 @@ interface FormFieldProps {
   isModalOpen: boolean;
   setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
   handleTag: (tag: string) => void;
+  error?: string; // Add error prop
 }
 
 const fieldStyles = {
@@ -172,6 +173,7 @@ const FormField: React.FC<FormFieldProps> = ({
   isModalOpen,
   setIsModalOpen,
   handleTag,
+  error,
 }) => {
   const capitalizeFirstLetter = (value: string) => {
     return value[0].toUpperCase() + value.slice(1);
@@ -404,21 +406,28 @@ const FormField: React.FC<FormFieldProps> = ({
             fullWidth
             inputProps={{ minLength }}
           />
-        );
-      case "text":
+        );      case "text":
         if (["email"].includes(fieldPath)) minLength = 5;
         if (["address2"].includes(fieldPath)) minLength = 5;
         return (
-          <CustomTextField
-            type="text"
-            name={fieldPath}
-            value={String(value || "")}
-            onChange={handleChange}
-            fullWidth
-            disabled={isDisabledField}
-            inputRef={fieldPath === "address" ? addressInputRef : null}
-            inputProps={{ minLength }}
-          />
+          <>
+            <CustomTextField
+              type="text"
+              name={fieldPath}
+              value={String(value || "")}
+              onChange={handleChange}
+              fullWidth
+              disabled={isDisabledField}
+              inputRef={fieldPath === "address" ? addressInputRef : null}
+              inputProps={{ minLength }}
+              error={!!error}
+            />
+            {error && (
+              <Typography variant="caption" color="error" sx={{ display: 'block', mt: 0.5 }}>
+                {error}
+              </Typography>
+            )}
+          </>
         );
       case "textarea":
         if (fieldPath === "ward") {

--- a/my-app/src/pages/Profile/components/FormField.tsx
+++ b/my-app/src/pages/Profile/components/FormField.tsx
@@ -410,7 +410,7 @@ const FormField: React.FC<FormFieldProps> = ({
         if (["email"].includes(fieldPath)) minLength = 5;
         if (["address2"].includes(fieldPath)) minLength = 5;
         return (
-          <>
+          <Box sx={{ width: "100%" }}>
             <CustomTextField
               type="text"
               name={fieldPath}
@@ -421,33 +421,30 @@ const FormField: React.FC<FormFieldProps> = ({
               inputRef={fieldPath === "address" ? addressInputRef : null}
               inputProps={{ minLength }}
               error={!!error}
+              sx={{ width: "100%" }}
             />
             {error && (
               <Typography variant="caption" color="error" sx={{ display: 'block', mt: 0.5 }}>
                 {error}
               </Typography>
             )}
-          </>
-        );
+          </Box>        );
       case "textarea":
         if (fieldPath === "ward") {
           return <CustomTextField name={fieldPath} value={String(value || "")} disabled fullWidth />;
         } else {
-          // Create block scope for lexical declaration
-          {
-            const isTallTextarea = ["lifeChallenges", "lifestyleGoals", "notes", "deliveryDetails.deliveryInstructions"].includes(fieldPath);
-            return (
-              <CustomTextField
-                name={fieldPath}
-                value={String(value || "")}
-                onChange={handleChange}
-                multiline
-                fullWidth
-                minRows={isTallTextarea ? 3 : 1}
-                inputProps={{ minLength: minLengthTextarea }}
-              />
-            );
-          }
+          const isTallTextarea = ["lifeChallenges", "lifestyleGoals", "notes", "deliveryDetails.deliveryInstructions"].includes(fieldPath);
+          return (
+            <CustomTextField
+              name={fieldPath}
+              value={String(value || "")}
+              onChange={handleChange}
+              multiline
+              fullWidth
+              minRows={isTallTextarea ? 3 : 1}
+              inputProps={{ minLength: minLengthTextarea }}
+            />
+          );
         }
       case "tags":
         return (


### PR DESCRIPTION
The test here should be to use the "i" tool tip to see what the valid phone number formats are and try to enter wrong ones, then tab out to see if it lets you for both phone and alternate phone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced phone number validation in the Profile form, supporting multiple common US formats and providing more detailed error messages.
  - Added inline error display for phone fields, showing validation messages directly beneath the inputs.
  - Introduced information icons with tooltips next to phone fields, listing allowed phone number formats.

- **Style**
  - Improved visual alignment and styling for phone field labels and info icons.
  - Refined error message styling for better readability and spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->