### PR TITLE
two stories 1 pr, this is the overflow on the buttons on the deliveri…

### DIFF
--- a/my-app/src/components/Spreadsheet/Spreadsheet.tsx
+++ b/my-app/src/components/Spreadsheet/Spreadsheet.tsx
@@ -1050,7 +1050,19 @@ const StyleChip = styled(Chip)({
                     }}
                   >
                     {fields.map((field) => (
-                      <TableCell key={field.key} sx={{ py: 2 }}>
+                      <TableCell 
+                        key={field.key} 
+                        sx={{ 
+                          py: 2,
+                          // Add word-wrap styles for delivery instructions and dietary restrictions
+                          ...(field.key === "deliveryDetails.deliveryInstructions" && {
+                            maxWidth: '200px',
+                            wordWrap: 'break-word',
+                            overflowWrap: 'anywhere',
+                            whiteSpace: 'pre-wrap'
+                          })
+                        }}
+                      >
                         {editingRowId === row.id ? (
                           field.key === "fullname" ? (
                             <>
@@ -1120,11 +1132,11 @@ const StyleChip = styled(Chip)({
                               {row.firstName} {row.lastName}
                             </Typography>
                           )
-                        ) : field.compute ? (
+                        ) : "compute" in field ? (
                           field.key === "deliveryDetails.dietaryRestrictions" ? (
                             <Stack direction="row" spacing={0.5} flexWrap="wrap">
-                              {field.compute?.(row)?.split(", ").map((restriction, i) => (
-                                restriction !== "None" && (
+                              {(field as any).compute(row)?.split(", ").map((restriction: string, i: number) => 
+                                restriction !== "None" ? (
                                   <Chip
                                     key={i}
                                     label={restriction}
@@ -1136,11 +1148,20 @@ const StyleChip = styled(Chip)({
                                       mb: 0.5
                                     }}
                                   />
-                                )
-                              )) || null}
+                                ) : null
+                              )}
                             </Stack>
+                          ) : field.key === "deliveryDetails.deliveryInstructions" ? (
+                            <div style={{
+                              maxWidth: '200px',
+                              wordWrap: 'break-word',
+                              overflowWrap: 'anywhere',
+                              whiteSpace: 'pre-wrap'
+                            }}>
+                              {(field as any).compute(row)}
+                            </div>
                           ) : (
-                            field.compute(row)
+                            (field as any).compute(row)
                           )
                         ) : (
                           row[field.key]
@@ -1149,7 +1170,19 @@ const StyleChip = styled(Chip)({
                     ))}
 
                     {customColumns.map((col) => (
-                      <TableCell key={col.id} sx={{ py: 2 }}>
+                      <TableCell 
+                        key={col.id} 
+                        sx={{ 
+                          py: 2,
+                          // Add word-wrap styles for text-heavy columns
+                          ...((col.propertyKey.includes('notes') || col.propertyKey.includes('deliveryInstructions')) && {
+                            maxWidth: '200px',
+                            wordWrap: 'break-word',
+                            overflowWrap: 'anywhere',
+                            whiteSpace: 'pre-wrap'
+                          })
+                        }}
+                      >
                         {editingRowId === row.id ? (
                           col.propertyKey !== "none" ? (
                             <TextField
@@ -1189,7 +1222,16 @@ const StyleChip = styled(Chip)({
                                   }}
                                 />
                               ))
-                            : (row[col.propertyKey as keyof RowData]?.toString() ?? "N/A")
+                            : col.propertyKey.includes('notes') || col.propertyKey.includes('deliveryInstructions') ? (
+                              <div style={{
+                                maxWidth: '200px',
+                                wordWrap: 'break-word',
+                                overflowWrap: 'anywhere',
+                                whiteSpace: 'pre-wrap'
+                              }}>
+                                {row[col.propertyKey as keyof RowData]?.toString() ?? "N/A"}
+                              </div>
+                            ) : (row[col.propertyKey as keyof RowData]?.toString() ?? "N/A")
                           ) : (
                             "N/A"
                           )}

--- a/my-app/src/components/Spreadsheet/Spreadsheet.tsx
+++ b/my-app/src/components/Spreadsheet/Spreadsheet.tsx
@@ -1132,24 +1132,22 @@ const StyleChip = styled(Chip)({
                               {row.firstName} {row.lastName}
                             </Typography>
                           )
-                        ) : "compute" in field ? (
+                        ) : (field as any).compute ? (
                           field.key === "deliveryDetails.dietaryRestrictions" ? (
                             <Stack direction="row" spacing={0.5} flexWrap="wrap">
-                              {(field as any).compute(row)?.split(", ").map((restriction: string, i: number) => 
-                                restriction !== "None" ? (
-                                  <Chip
-                                    key={i}
-                                    label={restriction}
-                                    size="small"
-                                    onClick={(e) => e.preventDefault()}
-                                    sx={{
-                                      backgroundColor: "#e8f5e9",
-                                      color: "#2E5B4C",
-                                      mb: 0.5
-                                    }}
-                                  />
-                                ) : null
-                              )}
+                              {(field as any).compute(row)?.split(", ").filter((restriction: string) => restriction !== "None").map((restriction: string, i: number) => (
+                                <Chip
+                                  key={i}
+                                  label={restriction}
+                                  size="small"
+                                  onClick={(e) => e.preventDefault()}
+                                  sx={{
+                                    backgroundColor: "#e8f5e9",
+                                    color: "#2E5B4C",
+                                    mb: 0.5
+                                  }}
+                                />
+                              ))}
                             </Stack>
                           ) : field.key === "deliveryDetails.deliveryInstructions" ? (
                             <div style={{
@@ -1164,7 +1162,7 @@ const StyleChip = styled(Chip)({
                             (field as any).compute(row)
                           )
                         ) : (
-                          row[field.key]
+                          row[field.key as keyof RowData]
                         )}
                       </TableCell>
                     ))}

--- a/my-app/src/components/common/Button/Button.module.css
+++ b/my-app/src/components/common/Button/Button.module.css
@@ -1,14 +1,58 @@
 .button {
   height: var(--button-height);
-  padding: var(--spacing-sm) var(--spacing-xl);
+  padding: var(--spacing-sm) calc(var(--spacing-xl) + 8px);
   border-radius: var(--border-radius-xl);
   font-weight: bold;
   font-size: var(--font-size-base);
   cursor: pointer;
   border: none;
-  transition: background-color 0.3s ease;
+  transition: background-color 0.3s ease, width 0.3s ease;
   text-transform: none;
   box-shadow: var(--shadow-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-width: fit-content;
+  overflow: visible;
+}
+
+.icon {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  font-size: 18px;
+}
+
+.icon svg {
+  width: 18px;
+  height: 18px;
+}
+
+.text {
+  white-space: nowrap;
+  overflow: visible;
+  text-overflow: clip;
+  transition: opacity 0.3s ease, width 0.3s ease;
+  flex-shrink: 0;
+}
+
+.text.hidden {
+  opacity: 0;
+  width: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.iconOnly {
+  min-width: 40px;
+  width: auto;
+  padding: var(--spacing-sm);
+}
+
+.iconOnly.small {
+  min-width: 32px;
+  padding: var(--spacing-xs);
 }
 
 .primary {
@@ -36,7 +80,16 @@
 
 .small {
   height: auto;
-  padding: var(--spacing-xs) var(--spacing-md);
+  padding: var(--spacing-xs) calc(var(--spacing-md) + 4px);
   font-size: var(--font-size-sm);
   border-radius: var(--border-radius-md);
+}
+
+.small .icon {
+  font-size: 16px;
+}
+
+.small .icon svg {
+  width: 16px;
+  height: 16px;
 }

--- a/my-app/src/components/common/Button/Button.tsx
+++ b/my-app/src/components/common/Button/Button.tsx
@@ -1,11 +1,13 @@
-import React from 'react';
-import { Button as MuiButton, ButtonProps as MuiButtonProps } from '@mui/material';
+import React, { useRef, useEffect, useState } from 'react';
+import { Button as MuiButton, ButtonProps as MuiButtonProps, Tooltip } from '@mui/material';
 import styles from './Button.module.css';
 
 interface ButtonProps extends Omit<MuiButtonProps, 'variant'> {
   variant?: 'primary' | 'secondary';
   size?: 'small' | 'medium';
   fullWidth?: boolean;
+  icon?: React.ReactNode;
+  tooltipText?: string;
 }
 
 const Button: React.FC<ButtonProps> = ({
@@ -13,22 +15,101 @@ const Button: React.FC<ButtonProps> = ({
   size = 'medium',
   fullWidth = false,
   className = '',
+  icon,
+  tooltipText,
   children,
+  style,
   ...props
 }) => {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const textRef = useRef<HTMLSpanElement>(null);
+  const [showIconOnly, setShowIconOnly] = useState(false);
+
+  useEffect(() => {
+    // For now, we'll disable the overflow detection so both icon and text show together
+    // This can be re-enabled later when we determine the specific conditions for icon-only mode
+    const checkOverflow = () => {
+      // Temporarily disabled - always show both icon and text
+      setShowIconOnly(false);
+      
+      // Original overflow detection logic (commented out for now):
+      // if (buttonRef.current && textRef.current && icon) {
+      //   const buttonWidth = buttonRef.current.offsetWidth;
+      //   const textWidth = textRef.current.scrollWidth;
+      //   const padding = 40; // Account for increased padding
+      //   const iconSpace = 24; // Space for smaller icon and gap
+      //   
+      //   const overflow = textWidth + iconSpace + padding > buttonWidth;
+      //   setShowIconOnly(overflow);
+      // }
+    };
+
+    // Initial check
+    checkOverflow();
+    
+    // Use setTimeout to recheck after render
+    const timeoutId = setTimeout(checkOverflow, 100);
+    
+    // Listen for window resize
+    const handleResize = () => checkOverflow();
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      clearTimeout(timeoutId);
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [icon, children]);
+
   const buttonClasses = [
     styles.button,
     styles[variant],
     size === 'small' ? styles.small : '',
     fullWidth ? styles.fullWidth : '',
+    showIconOnly ? styles.iconOnly : '',
     className
   ].filter(Boolean).join(' ');
 
-  return (
-    <MuiButton className={buttonClasses} {...props}>
-      {children}
+  // Merge styles to ensure proper text display
+  const mergedStyle = {
+    minWidth: 'fit-content',
+    width: 'auto',
+    overflow: 'visible',
+    ...style, // Allow style overrides but ensure text visibility
+  };
+
+  const buttonContent = (
+    <>
+      {icon && <span className={styles.icon}>{icon}</span>}
+      <span 
+        ref={textRef} 
+        className={styles.text}
+      >
+        {children}
+      </span>
+    </>
+  );
+
+  const button = (
+    <MuiButton 
+      ref={buttonRef}
+      className={buttonClasses} 
+      style={mergedStyle}
+      {...props}
+    >
+      {buttonContent}
     </MuiButton>
   );
+
+  // Show tooltip only when explicitly provided
+  if (tooltipText) {
+    return (
+      <Tooltip title={tooltipText} arrow>
+        {button}
+      </Tooltip>
+    );
+  }
+
+  return button;
 };
 
 export default Button;

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -7,6 +7,12 @@ import { format, addDays } from "date-fns";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import AddIcon from "@mui/icons-material/Add";
 import DeleteIcon from "@mui/icons-material/Delete";
+import AssignmentIndIcon from "@mui/icons-material/AssignmentInd";
+import AccessTimeIcon from "@mui/icons-material/AccessTime";
+import FileDownloadIcon from "@mui/icons-material/FileDownload";
+import GroupWorkIcon from "@mui/icons-material/GroupWork";
+import PersonAddIcon from "@mui/icons-material/PersonAdd";
+import TodayIcon from "@mui/icons-material/Today";
 
 import "./DeliverySpreadsheet.css";
 import "leaflet/dist/leaflet.css";
@@ -231,6 +237,15 @@ const fields: Field[] = [
       hours12 = hours12 ? hours12 : 12; // Convert 0 to 12 for 12 AM
 
       return `${hours12}:${minutes} ${ampm}`;
+    },
+  },
+  {
+    key: "deliveryDetails.deliveryInstructions",
+    label: "Delivery Instructions",
+    type: "text",
+    compute: (data: DeliveryRowData) => {
+      const instructions = data.deliveryDetails?.deliveryInstructions;
+      return instructions && instructions.trim() !== '' ? instructions : 'No instructions';
     },
   },
 ];
@@ -1279,8 +1294,14 @@ const DeliverySpreadsheet: React.FC = () => {
   
         <Button
           variant="secondary"
-          size="small"
-          style={{ width: 50, fontSize: 12, marginLeft: 16 }}
+          size="medium"
+          icon={<TodayIcon />}
+          style={{ 
+            fontSize: 12, 
+            marginLeft: 16, 
+            height: "2.5rem",
+            minHeight: "2.5rem"
+          }}
           onClick={() => setSelectedDate(new Date())}
         >
           Today
@@ -1292,12 +1313,11 @@ const DeliverySpreadsheet: React.FC = () => {
       <Button
         variant="primary"
         size="medium"
+        icon={<PersonAddIcon />}
         disabled={userRole === UserType.ClientIntake}
         style={{
           whiteSpace: "nowrap",
-          padding: "0% 2%",
           borderRadius: 5,
-          width: "auto",
           marginRight: '16px'
         }}
         onClick={() => setPopupMode("ManualClusters")}
@@ -1308,12 +1328,11 @@ const DeliverySpreadsheet: React.FC = () => {
       <Button
         variant="primary"
         size="medium"
+        icon={<GroupWorkIcon />}
         disabled={userRole === UserType.ClientIntake}
         style={{
           whiteSpace: "nowrap",
-          padding: "0% 2%",
           borderRadius: 5,
-          width: "auto",
           marginRight: '16px'
         }}
         onClick={() => setPopupMode("Clusters")}
@@ -1389,33 +1408,35 @@ const DeliverySpreadsheet: React.FC = () => {
           </Box>
           <Box sx={{ display: "flex", justifyContent: "space-between", marginTop: "16px" }}>
             {/* Left group: Assign Driver and Assign Time */}
-            <Box sx={{ display: "flex", width: "100%", gap: "2%" }}>
+            <Box sx={{ display: "flex", width: "100%", gap: "8px", flexWrap: "wrap" }}>
               <Button
                 variant="primary"
                 size="medium"
+                icon={<AssignmentIndIcon />}
                 disabled={selectedRows.size <= 0}
                 style={{
                   whiteSpace: "nowrap",
-                  padding: "0% 2%",
                   borderRadius: 5,
-                  width: "10%",
+                  marginRight: '8px'
                 }}
                 onClick={() => setPopupMode("Driver")}
               >
                 Assign Driver
               </Button>
               <Button
+                variant="primary"
+                size="medium"
                 id="demo-positioned-button"
                 aria-controls={open ? 'demo-positioned-menu' : undefined}
                 aria-haspopup="true"
                 aria-expanded={open ? 'true' : undefined}
+                icon={<AccessTimeIcon />}
                 onClick={handleClick}
                 disabled={selectedRows.size <= 0}
                 style={{
                   whiteSpace: "nowrap",
-                  padding: "0% 2%",
                   borderRadius: 5,
-                  width: "10%",
+                  marginRight: '8px'
                 }}
               >
                 Assign Time
@@ -1449,11 +1470,13 @@ const DeliverySpreadsheet: React.FC = () => {
               <Button
                 variant="primary"
                 size="medium"
+                icon={<FileDownloadIcon />}
                 style={{
                   whiteSpace: "nowrap",
-                  padding: "0% 2%",
                   borderRadius: 5,
-                  width: "6rem",
+                  marginRight: '8px',
+                  padding: 'var(--spacing-sm) calc(var(--spacing-xl) + 8px)',
+                  height: 'var(--button-height)'
                 }}
                 onClick={() => setPopupMode("Export")}
               >
@@ -1483,7 +1506,7 @@ const DeliverySpreadsheet: React.FC = () => {
             width: "100%",
           }}
         >
-          <Table>
+          <Table sx={{ tableLayout: 'auto', width: '100%' }}>
             <TableHead>
               <TableRow>
                 {fields.map((field) => (
@@ -1602,6 +1625,10 @@ const DeliverySpreadsheet: React.FC = () => {
                           textAlign: "center",
                           padding: "10px",
                           minWidth: field.type === "select" ? "150px" : "auto",
+                          maxWidth: field.key === "address" || field.key === "deliveryDetails.deliveryInstructions" ? "200px" : "auto",
+                          wordWrap: "break-word",
+                          overflowWrap: "anywhere",
+                          whiteSpace: "pre-wrap",
                         }}
                       >
                         {field.type === "checkbox" ? (
@@ -1652,8 +1679,17 @@ const DeliverySpreadsheet: React.FC = () => {
                           // Render computed fields (other than the select)
                           field.key === "assignedDriver" || field.key === "assignedTime" ? (
                             field.compute(row, clusters)
-                          ) : (
-                            field.key === "tags" ? (
+                          ) : field.key === "deliveryDetails.deliveryInstructions" ? (
+                            // Render delivery instructions with word wrapping
+                            <div style={{ 
+                              maxWidth: '200px', 
+                              wordWrap: 'break-word', 
+                              overflowWrap: 'anywhere', 
+                              whiteSpace: 'pre-wrap' 
+                            }}>
+                              {(field as Extract<Field, { key: "deliveryDetails.deliveryInstructions" }>).compute(row)}
+                            </div>
+                          ) : field.key === "tags" ? (
                               // Render tags field
                               row.tags && row.tags.length > 0 ? (
                                 <Box sx={{ display: "flex", flexWrap: "wrap", gap: "2px" }}>
@@ -1671,10 +1707,14 @@ const DeliverySpreadsheet: React.FC = () => {
                               ) : (
                                 "No Tags"
                               )
+                            ) : field.key === "fullname" ? (
+                              // Handle fullname compute function (one parameter)
+                              (field as Extract<Field, { key: "fullname" }>).compute(row)
                             ) : ( 
-                            field.compute(row)
-                          ) // Assumes other compute fields don't need clusters
-                        )) : isRegularField(field) ? (
+                            // Handle other compute functions (shouldn't reach here)
+                            null
+                          )
+                        ) : isRegularField(field) ? (
                           // Render regular fields (address, ward)
                           // Cast to string as these are the only expected types here
                           String(row[field.key as "address" | "ward"] ?? "")
@@ -1684,7 +1724,17 @@ const DeliverySpreadsheet: React.FC = () => {
                     ); // End return for TableCell
                   })}
                    {customColumns.map((col) => (
-                        <TableCell key={col.id} sx={{ py: 2 }}>
+                        <TableCell 
+                          key={col.id} 
+                          sx={{ 
+                            py: 2,
+                            maxWidth: '200px',
+                            overflow: 'hidden',
+                            wordWrap: 'break-word',
+                            overflowWrap: 'anywhere',
+                            whiteSpace: 'pre-wrap'
+                          }}
+                        >
                           {editingRowId === row.id ? (
                             col.propertyKey !== "none" ? (
                               <TextField
@@ -1700,6 +1750,8 @@ const DeliverySpreadsheet: React.FC = () => {
                                 variant="outlined"
                                 size="small"
                                 fullWidth
+                                multiline={col.propertyKey.includes('deliveryInstructions') || col.propertyKey.includes('notes')}
+                                maxRows={4}
                               />
                             ) : (
                               "N/A"
@@ -1710,7 +1762,13 @@ const DeliverySpreadsheet: React.FC = () => {
                             col.propertyKey === 'referralEntity' && typeof row.referralEntity === 'object' && row.referralEntity !== null ?
                             // Format as "Name, Organization"
                             `${row.referralEntity.name ?? 'N/A'}, ${row.referralEntity.organization ?? 'N/A'}`
-                            : (row[col.propertyKey as keyof DeliveryRowData]?.toString() ?? "N/A") // Fallback for other types
+                            : col.propertyKey.includes('deliveryInstructions') ? (
+                              // Handle nested delivery instructions access
+                              (() => {
+                                const instructions = row.deliveryDetails?.deliveryInstructions;
+                                return instructions && instructions.trim() !== '' ? instructions : 'No instructions';
+                              })()
+                            ) : (row[col.propertyKey as keyof DeliveryRowData]?.toString() ?? "N/A") // Fallback for other types
                           ) : (
                             "N/A"
                           )} 

--- a/my-app/src/pages/Profile/components/DeliveryInfoForm.tsx
+++ b/my-app/src/pages/Profile/components/DeliveryInfoForm.tsx
@@ -102,7 +102,20 @@ const DeliveryInfoForm: React.FC<DeliveryInfoFormProps> = ({
         </Box>
 
         {/* Delivery Instructions */}
-        <Box sx={{ gridColumn: { xs: '1', sm: 'span 1' } }}>
+        <Box sx={{ 
+          gridColumn: { xs: '1', sm: 'span 1' },
+          overflow: 'hidden !important',
+          maxWidth: '100% !important',
+          width: '100% !important',
+          wordWrap: 'break-word !important',
+          overflowWrap: 'anywhere !important',
+          '& *': {
+            wordWrap: 'break-word !important',
+            overflowWrap: 'anywhere !important',
+            wordBreak: 'break-all !important',
+            whiteSpace: 'pre-wrap !important'
+          }
+        }}>
           <Typography className="field-descriptor" sx={fieldLabelStyles}>
             DELIVERY INSTRUCTIONS
           </Typography>
@@ -125,7 +138,20 @@ const DeliveryInfoForm: React.FC<DeliveryInfoFormProps> = ({
         </Box>
 
         {/* Notes */}
-        <Box sx={{ gridColumn: { xs: '1', sm: 'span 1' } }}>
+        <Box sx={{ 
+          gridColumn: { xs: '1', sm: 'span 1' },
+          overflow: 'hidden !important',
+          maxWidth: '100% !important',
+          width: '100% !important',
+          wordWrap: 'break-word !important',
+          overflowWrap: 'anywhere !important',
+          '& *': {
+            wordWrap: 'break-word !important',
+            overflowWrap: 'anywhere !important',
+            wordBreak: 'break-all !important',
+            whiteSpace: 'pre-wrap !important'
+          }
+        }}>
           <Typography className="field-descriptor" sx={fieldLabelStyles}>
             ADMIN NOTES
           </Typography>

--- a/my-app/src/pages/Profile/components/FormField.tsx
+++ b/my-app/src/pages/Profile/components/FormField.tsx
@@ -76,6 +76,26 @@ const CustomTextField = styled(TextField)({
       boxShadow: "0 0 8px rgba(37, 126, 104, 0.4), 0 0 16px rgba(37, 126, 104, 0.2)",
     },
   },
+  "& .MuiInputBase-inputMultiline": {
+    backgroundColor: "white",
+    width: "100%",
+    minHeight: "1.813rem",
+    height: "auto",
+    padding: "0.5rem",
+    borderRadius: "5px",
+    border: ".1rem solid black",
+    marginTop: "0px",
+    whiteSpace: "normal",
+    wordWrap: "break-word",
+    overflowWrap: "break-word",
+    wordBreak: "break-word",
+    resize: "vertical",
+    "&:focus": {
+      border: "2px solid #257E68",
+      outline: "none",
+      boxShadow: "0 0 8px rgba(37, 126, 104, 0.4), 0 0 16px rgba(37, 126, 104, 0.2)",
+    },
+  },
   "& .MuiInputBase-input.Mui-disabled": {
     backgroundColor: "#e0e0e0",
     color: "#757575",
@@ -477,7 +497,24 @@ const FormField: React.FC<FormFieldProps> = ({
   }
 
   return (
-    <Typography variant="body1" sx={{ fontWeight: 600, textAlign: "left" }}>
+    <Typography 
+      variant="body1" 
+      sx={{ 
+        fontWeight: 600, 
+        textAlign: "left",
+        whiteSpace: "pre-wrap !important",
+        wordWrap: "break-word !important",
+        overflowWrap: "anywhere !important",
+        wordBreak: "break-all !important",
+        maxWidth: "100% !important",
+        width: "100% !important",
+        display: "block !important",
+        overflow: "hidden !important",
+        // Additional CSS to ensure wrapping works
+        hyphens: "auto",
+        lineBreak: "anywhere"
+      }}
+    >
       {renderFieldValue(fieldPath, value)}
     </Typography>
   );


### PR DESCRIPTION
…es page as well as the text on the client page for notes and instructions not wrapping, I also not have it wrapping on the spreadsheet

Test for this is to check the delivery page and verify the buttons
Test for the client page is to enter a long string of text in the instructions and notes fields and see that they wrap now 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying and editing "Delivery Instructions" in the delivery spreadsheet, including a new field and improved text formatting for long instructions.
  * Enhanced button components with optional icons and tooltips for improved usability and visual clarity.

* **Style**
  * Improved word wrapping, overflow handling, and layout for long text fields such as delivery instructions, dietary restrictions, and notes across spreadsheet, forms, and profile pages.
  * Updated button styles for better alignment, spacing, and icon display, including new icon-only and small button variants.

* **Bug Fixes**
  * Refined rendering and type checking for computed fields to ensure accurate display and formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->