### PR TITLE
Display Delivery Count on Routes Page

### DIFF
--- a/my-app/src/components/EventCountHeader.tsx
+++ b/my-app/src/components/EventCountHeader.tsx
@@ -2,8 +2,9 @@ import React from "react";
 import { Box, Typography } from "@mui/material";
 import LocalShippingIcon from "@mui/icons-material/LocalShipping";
 import { Delivery } from "../types";
+import { RowData } from "./Spreadsheet/export";
 interface DeliveryCountHeaderProps {
-    events: Delivery[]
+    events: any[]
 }
 export default function DeliveryCountHeader({events}: DeliveryCountHeaderProps) {
     return (

--- a/my-app/src/components/EventCountHeader.tsx
+++ b/my-app/src/components/EventCountHeader.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { Box, Typography } from "@mui/material";
 import LocalShippingIcon from "@mui/icons-material/LocalShipping";
-import { Delivery } from "../types";
-import { RowData } from "./Spreadsheet/export";
 interface DeliveryCountHeaderProps {
     events: any[]
 }

--- a/my-app/src/components/EventCountHeader.tsx
+++ b/my-app/src/components/EventCountHeader.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { Box, Typography } from "@mui/material";
 import LocalShippingIcon from "@mui/icons-material/LocalShipping";
+import { Delivery } from "../types";
 interface DeliveryCountHeaderProps {
-    events: any[]
+    events: Delivery[]
 }
 export default function DeliveryCountHeader({events}: DeliveryCountHeaderProps) {
     return (

--- a/my-app/src/components/EventCountHeader.tsx
+++ b/my-app/src/components/EventCountHeader.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { Box, Typography } from "@mui/material";
+import LocalShippingIcon from "@mui/icons-material/LocalShipping";
+interface DeliveryCountHeaderProps {
+    events: any[]
+}
+export default function DeliveryCountHeader({events}: DeliveryCountHeaderProps) {
+    return (
+        <Box
+            sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "flex-start",
+                marginBottom: 2.4,
+                padding: 1.9,
+                backgroundColor: "#f8fffe",
+                borderRadius: 2,
+                borderLeft: "4px solid #257E68",
+                boxShadow: "0 2px 4px rgba(0,0,0,0.1)",
+                width: "100%",
+                boxSizing: "border-box",
+            }}
+        >
+            <Box
+                sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    width: 30,
+                    height: 30,
+                    backgroundColor: "#257E68",
+                    borderRadius: "50%",
+                    marginRight: 1.6,
+                }}
+            >
+                <LocalShippingIcon sx={{ color: "#fff", fontSize: "1rem" }} />
+            </Box>
+            <Box>
+                <Typography
+                    variant="h5"
+                    sx={{
+                        fontWeight: 700,
+                        color: "#257E68",
+                        lineHeight: 1,
+                        marginBottom: 0.4,
+                        minWidth: "2ch", // Ensures consistent width for numbers
+                    }}
+                >
+                    {events.length}
+                </Typography>
+                <Typography
+                    variant="body2"
+                    sx={{
+                        color: "#666",
+                        fontWeight: 500,
+                        textTransform: "uppercase",
+                        fontSize: "0.75rem",
+                        letterSpacing: "0.4px",
+                        whiteSpace: "nowrap", // Prevents text wrapping
+                    }}
+                >
+                    {events.length === 1 ? "Delivery" : "Deliveries"} Today
+                </Typography>
+            </Box>
+        </Box>
+    )
+}

--- a/my-app/src/pages/Calendar/components/DayView.tsx
+++ b/my-app/src/pages/Calendar/components/DayView.tsx
@@ -4,6 +4,8 @@ import LocalShippingIcon from "@mui/icons-material/LocalShipping";
 import { DeliveryEvent } from "../../../types/calendar-types";
 import { ClientProfile } from "../../../types/client-types";
 import DeliveryCard from "./DeliveryCard";
+import EventCountHeader from "../../../components/EventCountHeader";
+
 
 interface DayViewProps {
   events: DeliveryEvent[];
@@ -14,63 +16,7 @@ interface DayViewProps {
 const DayView: React.FC<DayViewProps> = ({ events, clients, onEventModified }) => {
   return (
     <Box sx={{ padding: 2, width: "100%", maxWidth: "100%" }}>
-      {/* Delivery Count Header */}
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "flex-start",
-          marginBottom: 2.4,
-          padding: 1.9,
-          backgroundColor: "#f8fffe",
-          borderRadius: 2,
-          borderLeft: "4px solid #257E68",
-          boxShadow: "0 2px 4px rgba(0,0,0,0.1)",
-          width: "100%",
-          boxSizing: "border-box",
-        }}
-      >
-        <Box
-          sx={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            width: 30,
-            height: 30,
-            backgroundColor: "#257E68",
-            borderRadius: "50%",
-            marginRight: 1.6,
-          }}
-        >
-          <LocalShippingIcon sx={{ color: "#fff", fontSize: "1rem" }} />
-        </Box>        <Box>
-          <Typography
-            variant="h5"
-            sx={{
-              fontWeight: 700,
-              color: "#257E68",
-              lineHeight: 1,
-              marginBottom: 0.4,
-              minWidth: "2ch", // Ensures consistent width for numbers
-            }}
-          >
-            {events.length}
-          </Typography>
-          <Typography
-            variant="body2"
-            sx={{
-              color: "#666",
-              fontWeight: 500,
-              textTransform: "uppercase",
-              fontSize: "0.75rem",
-              letterSpacing: "0.4px",
-              whiteSpace: "nowrap", // Prevents text wrapping
-            }}
-          >
-            {events.length === 1 ? "Delivery" : "Deliveries"} Today
-          </Typography>
-        </Box>
-      </Box>
+      <EventCountHeader events = {events}/>
 
       {events.length === 0 ? (
         <Typography>No deliveries scheduled for this day.</Typography>

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -59,6 +59,7 @@ import ClientService from "../../services/client-service";
 import { LatLngTuple } from "leaflet";
 import { UserType } from "../../types";
 import { useAuth } from "../../auth/AuthProvider";
+import EventCountHeader from "../../components/EventCountHeader";
 // interface Driver {
 //   id: string;
 //   name: string;
@@ -1486,7 +1487,7 @@ const DeliverySpreadsheet: React.FC = () => {
           </Box>
         </Box>
       </Box>
-
+      <EventCountHeader events = {rows}/>
       <Box
         sx={{
           flex: 1,


### PR DESCRIPTION
Abstracted the delivery count header to a new component EventCountHeader in the components folder, and updated it in both the calendar page and the delivery routes page. The new component takes an "event" array for any event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new header component that visually displays the count of deliveries with an icon and styled label.
  * Added the delivery count header to both the daily calendar view and the delivery spreadsheet for improved visibility of delivery totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->