### PR TITLE
the map popup now allows edits at the individual level and still upda…

### DIFF
--- a/my-app/src/pages/Delivery/ClusterMap.tsx
+++ b/my-app/src/pages/Delivery/ClusterMap.tsx
@@ -1,10 +1,19 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import "leaflet.awesome-markers";
 import "leaflet.awesome-markers/dist/leaflet.awesome-markers.css";
 import { Box, Button } from "@mui/material";
+import { collection, getDocs } from "firebase/firestore";
+import { db } from "../../auth/firebaseConfig";
 import FFAIcon from '../../assets/tsp-food-for-all-dc-logo.png'
+
+interface Driver {
+  id: string;
+  name: string;
+  phone?: string;
+  email?: string;
+}
 
 interface Coordinate {
   lat: number;
@@ -27,9 +36,17 @@ interface Cluster {
   deliveries: string[]; 
 }
 
+interface ClientOverride {
+  clientId: string;
+  driver?: string;
+  time?: string;
+}
+
 interface ClusterMapProps {
   clusters: Cluster[];
   visibleRows: Client[];
+  clientOverrides?: ClientOverride[]; // Individual client overrides
+  onClusterUpdate?: (clientId: string, newClusterId: string, newDriver?: string, newTime?: string) => void;
 }
 
 const ffaCoordinates: L.LatLngExpression = [38.914330, -77.036942];
@@ -63,9 +80,18 @@ const normalizeCoordinate = (coord: any): Coordinate => {
   return coord;
 };
 
-const ClusterMap: React.FC<ClusterMapProps> = ({ visibleRows, clusters }) => {
+// Common time slots array - same as used in delivery page
+const TIME_SLOTS = [
+  "8:00 AM", "9:00 AM", "10:00 AM", "11:00 AM", 
+  "12:00 PM", "1:00 PM", "2:00 PM", "3:00 PM", 
+  "4:00 PM", "5:00 PM"
+];
+
+const ClusterMap: React.FC<ClusterMapProps> = ({ visibleRows, clusters, clientOverrides = [], onClusterUpdate }) => {
   const mapRef = useRef<L.Map | null>(null);
   const markerGroupRef = useRef<L.FeatureGroup | null>(null);
+  const [drivers, setDrivers] = useState<Driver[]>([]);
+  const [loadingDrivers, setLoadingDrivers] = useState<boolean>(false);
   
   // Color palette for clusters
   const clusterColors = [
@@ -83,6 +109,36 @@ const ClusterMap: React.FC<ClusterMapProps> = ({ visibleRows, clusters }) => {
       L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png").addTo(mapRef.current);
       markerGroupRef.current = L.featureGroup().addTo(mapRef.current);
     }
+  }, []);
+
+  // Fetch drivers from Firebase
+  useEffect(() => {
+    const fetchDrivers = async () => {
+      setLoadingDrivers(true);
+      try {
+        const driversCollectionRef = collection(db, "Drivers");
+        const driversSnapshot = await getDocs(driversCollectionRef);
+
+        if (!driversSnapshot.empty) {
+          const driversData = driversSnapshot.docs.map((doc) => ({
+            id: doc.id,
+            name: doc.data().name || "Unknown Driver",
+            phone: doc.data().phone || "",
+            email: doc.data().email || "",
+          }));
+          setDrivers(driversData);
+        } else {
+          setDrivers([]);
+        }
+      } catch (error) {
+        console.error("Error fetching drivers:", error);
+        setDrivers([]);
+      } finally {
+        setLoadingDrivers(false);
+      }
+    };
+
+    fetchDrivers();
   }, []);
 
   useEffect(() => {
@@ -155,18 +211,213 @@ const ClusterMap: React.FC<ClusterMapProps> = ({ visibleRows, clusters }) => {
       });
 
       //build popup content
-      const popupContent = `
-        <div style="font-family: Arial, sans-serif; line-height: 1.4;">
-          <div style="font-weight: bold; margin-bottom: 5px;">${clientName}</div>
-          ${clusterId ? `
-            <div><span style="font-weight: bold;">Cluster:</span> ${clusterId}</div>
-            ${cluster?.driver ? `<div><span style="font-weight: bold;">Driver:</span> ${cluster.driver}</div>` : ''}
-          ` : 
-          `<div><span style="font-weight: bold;">Cluster:</span> No cluster Assigned</div>`}
-          ${client.ward ? `<div><span style="font-weight: bold;">Ward:</span> ${client.ward}</div>` : ''}
-          <div><span style="font-weight: bold;">Address:</span> ${address}</div>
-        </div>
-      `;
+      const createEditablePopup = (clientId: string, clientName: string, clusterId: string, cluster: Cluster | undefined, ward: string | undefined, address: string) => {
+        // Find individual client overrides
+        const clientOverride = clientOverrides.find(override => override.clientId === clientId);
+        
+        // Get effective driver and time (override takes precedence over cluster default)
+        const effectiveDriver = clientOverride?.driver || cluster?.driver;
+        const effectiveTime = clientOverride?.time || cluster?.time;
+        // Helper function to get cluster color
+        const getClusterColor = (clusterIdToCheck: string) => {
+          if (!clusterIdToCheck) return "#ffffff";
+          const match = clusterIdToCheck.match(/\d+/); 
+          const clusterNumber = match ? parseInt(match[0], 10) : 0;
+          if (!isNaN(clusterNumber)) {
+            return clusterColors[(clusterNumber - 1) % clusterColors.length];
+          } else {
+            let hash = 0;
+            for (let i = 0; i < clusterIdToCheck.length; i++) {
+              hash = clusterIdToCheck.charCodeAt(i) + ((hash << 5) - hash);
+            }
+            return clusterColors[Math.abs(hash) % clusterColors.length];
+          }
+        };
+
+        // Helper function to format time in AM/PM format
+        const formatTimeForDisplay = (time: string | undefined) => {
+          if (!time) return '';
+          
+          // If time is already in AM/PM format, return as is
+          if (time.includes('AM') || time.includes('PM')) {
+            return time;
+          }
+          
+          // If time is in military/24-hour format, convert to AM/PM
+          const timeRegex = /^(\d{1,2}):(\d{2})$/;
+          const match = time.match(timeRegex);
+          if (match) {
+            const hours = parseInt(match[1], 10);
+            const minutes = match[2];
+            const ampm = hours >= 12 ? 'PM' : 'AM';
+            const displayHours = hours % 12 || 12;
+            return `${displayHours}:${minutes} ${ampm}`;
+          }
+          
+          // If we can't parse it, return as is
+          return time;
+        };
+
+        // Helper function to convert AM/PM time to 24-hour format
+        const convertTo24Hour = (time: string) => {
+          if (!time || (!time.includes('AM') && !time.includes('PM'))) {
+            return time; // Already in 24-hour format or empty
+          }
+          
+          const [timePart, period] = time.split(' ');
+          const [hours, minutes] = timePart.split(':');
+          let hours24 = parseInt(hours, 10);
+          
+          if (period === 'AM' && hours24 === 12) {
+            hours24 = 0;
+          } else if (period === 'PM' && hours24 !== 12) {
+            hours24 += 12;
+          }
+          
+          return `${hours24.toString().padStart(2, '0')}:${minutes}`;
+        };
+
+        const popupContainer = document.createElement('div');
+        popupContainer.innerHTML = `
+          <div style="font-family: Arial, sans-serif; line-height: 1.4; min-width: 250px;">
+            <div id="view-mode-${clientId}" style="display: block;">
+              <div style="font-weight: bold; margin-bottom: 5px; display: flex; align-items: center; justify-content: space-between;">
+                <span>${clientName}</span>
+                ${clusterId ? `<span style="cursor: pointer; padding: 2px 4px; border-radius: 3px; margin-left: 10px;" id="edit-btn-${clientId}" title="Edit">✏️</span>` : ''}
+              </div>
+              ${clusterId ? `
+                <div><span style="font-weight: bold;">Cluster:</span> ${clusterId}</div>
+                ${effectiveDriver ? `<div><span style="font-weight: bold;">Driver:</span> ${effectiveDriver}</div>` : ''}
+                ${effectiveTime ? `<div><span style="font-weight: bold;">Time:</span> ${formatTimeForDisplay(effectiveTime)}</div>` : ''}
+              ` : 
+              `<div><span style="font-weight: bold;">Cluster:</span> No cluster Assigned</div>`}
+              ${ward ? `<div><span style="font-weight: bold;">Ward:</span> ${ward}</div>` : ''}
+              <div><span style="font-weight: bold;">Address:</span> ${address}</div>
+            </div>
+            <div id="edit-mode-${clientId}" style="display: none;">
+              <div style="font-weight: bold; margin-bottom: 10px;">${clientName}</div>
+              <div style="margin-bottom: 8px; display: flex; align-items: center; gap: 8px;">
+                <label style="font-weight: bold; min-width: 60px; font-size: 12px;">Cluster:</label>
+                <select id="cluster-select-${clientId}" style="flex: 1; padding: 3px; border: 1px solid #ccc; border-radius: 3px; font-size: 11px; background-color: ${clusterId ? getClusterColor(clusterId) : '#ffffff'}; color: ${clusterId ? 'white' : 'black'};">
+                  <option value="" style="background-color: #ffffff; color: black;">No cluster</option>
+                  ${clusters.map(c => `<option value="${c.id}" ${c.id === clusterId ? 'selected' : ''} style="background-color: ${getClusterColor(c.id)}; color: white;">${c.id}</option>`).join('')}
+                </select>
+              </div>
+              <div style="margin-bottom: 8px; display: flex; align-items: center; gap: 8px;">
+                <label style="font-weight: bold; min-width: 60px; font-size: 12px;">Driver:</label>
+                <select id="driver-select-${clientId}" style="flex: 1; padding: 3px; border: 1px solid #ccc; border-radius: 3px; font-size: 11px;">
+                  <option value="">No driver</option>
+                  ${drivers.map(d => `<option value="${d.name}" ${d.name === effectiveDriver ? 'selected' : ''}>${d.name}${d.phone ? ` - ${d.phone}` : ''}</option>`).join('')}
+                </select>
+              </div>
+              <div style="margin-bottom: 10px; display: flex; align-items: center; gap: 8px;">
+                <label style="font-weight: bold; min-width: 60px; font-size: 12px;">Time:</label>
+                <select id="time-select-${clientId}" style="flex: 1; padding: 3px; border: 1px solid #ccc; border-radius: 3px; font-size: 11px;">
+                  <option value="">No time</option>
+                  ${TIME_SLOTS.map(t => `<option value="${t}" ${t === formatTimeForDisplay(effectiveTime) ? 'selected' : ''}>${t}</option>`).join('')}
+                </select>
+              </div>
+              <div style="display: flex; gap: 8px;">
+                <button id="save-btn-${clientId}" style="flex: 1; padding: 6px 12px; background: #4CAF50; color: white; border: none; border-radius: 3px; cursor: pointer;">Save</button>
+                <button id="cancel-btn-${clientId}" style="flex: 1; padding: 6px 12px; background: #f44336; color: white; border: none; border-radius: 3px; cursor: pointer;">Cancel</button>
+              </div>
+              ${ward ? `<div style="margin-top: 8px;"><span style="font-weight: bold;">Ward:</span> ${ward}</div>` : ''}
+              <div style="margin-top: 8px;"><span style="font-weight: bold;">Address:</span> ${address}</div>
+            </div>
+          </div>
+        `;
+
+        // Add event listeners
+        const editBtn = popupContainer.querySelector(`#edit-btn-${clientId}`);
+        const saveBtn = popupContainer.querySelector(`#save-btn-${clientId}`);
+        const cancelBtn = popupContainer.querySelector(`#cancel-btn-${clientId}`);
+        const clusterSelect = popupContainer.querySelector(`#cluster-select-${clientId}`) as HTMLSelectElement;
+        const viewMode = popupContainer.querySelector(`#view-mode-${clientId}`) as HTMLElement;
+        const editMode = popupContainer.querySelector(`#edit-mode-${clientId}`) as HTMLElement;
+
+        // Add color change listener to cluster select
+        if (clusterSelect) {
+          clusterSelect.addEventListener('change', () => {
+            const selectedClusterId = clusterSelect.value;
+            if (selectedClusterId) {
+              const selectedColor = getClusterColor(selectedClusterId);
+              clusterSelect.style.backgroundColor = selectedColor;
+              clusterSelect.style.color = 'white';
+            } else {
+              clusterSelect.style.backgroundColor = '#ffffff';
+              clusterSelect.style.color = 'black';
+            }
+          });
+        }
+
+        if (editBtn) {
+          editBtn.addEventListener('click', () => {
+            viewMode.style.display = 'none';
+            editMode.style.display = 'block';
+          });
+        }
+
+        if (cancelBtn) {
+          cancelBtn.addEventListener('click', () => {
+            viewMode.style.display = 'block';
+            editMode.style.display = 'none';
+          });
+        }
+
+        if (saveBtn && onClusterUpdate) {
+          saveBtn.addEventListener('click', () => {
+            const clusterSelect = popupContainer.querySelector(`#cluster-select-${clientId}`) as HTMLSelectElement;
+            const driverSelect = popupContainer.querySelector(`#driver-select-${clientId}`) as HTMLSelectElement;
+            const timeSelect = popupContainer.querySelector(`#time-select-${clientId}`) as HTMLSelectElement;
+
+            const newClusterId = clusterSelect.value;
+            const newDriver = driverSelect.value || undefined;
+            const newTime = timeSelect.value || undefined;
+
+            // Convert time to 24-hour format for storage
+            const newTime24Hour = newTime ? convertTo24Hour(newTime) : undefined;
+
+            // Update the view mode content with new data
+            const viewModeContent = popupContainer.querySelector(`#view-mode-${clientId}`);
+            if (viewModeContent) {
+              viewModeContent.innerHTML = `
+                <div style="font-weight: bold; margin-bottom: 5px; display: flex; align-items: center; justify-content: space-between;">
+                  <span>${clientName}</span>
+                  ${newClusterId ? `<span style="cursor: pointer; padding: 2px 4px; border-radius: 3px; margin-left: 10px;" id="edit-btn-${clientId}" title="Edit">✏️</span>` : ''}
+                </div>
+                ${newClusterId ? `
+                  <div><span style="font-weight: bold;">Cluster:</span> ${newClusterId}</div>
+                  ${newDriver ? `<div><span style="font-weight: bold;">Driver:</span> ${newDriver}</div>` : ''}
+                  ${newTime ? `<div><span style="font-weight: bold;">Time:</span> ${newTime}</div>` : ''}
+                ` : 
+                `<div><span style="font-weight: bold;">Cluster:</span> No cluster Assigned</div>`}
+                ${ward ? `<div><span style="font-weight: bold;">Ward:</span> ${ward}</div>` : ''}
+                <div><span style="font-weight: bold;">Address:</span> ${address}</div>
+              `;
+              
+              // Re-attach the edit button event listener
+              const newEditBtn = viewModeContent.querySelector(`#edit-btn-${clientId}`);
+              if (newEditBtn) {
+                newEditBtn.addEventListener('click', () => {
+                  viewMode.style.display = 'none';
+                  editMode.style.display = 'block';
+                });
+              }
+            }
+
+            // Call the update function with 24-hour format time
+            onClusterUpdate(clientId, newClusterId, newDriver, newTime24Hour);
+            
+            // Switch back to view mode
+            viewMode.style.display = 'block';
+            editMode.style.display = 'none';
+          });
+        }
+
+        return popupContainer;
+      };
+
+      const popupContent = createEditablePopup(client.id, clientName, clusterId, cluster, client.ward, address);
 
       //add popup and marker to group
       marker
@@ -203,7 +454,7 @@ const ClusterMap: React.FC<ClusterMapProps> = ({ visibleRows, clusters }) => {
         padding: [50, 50] 
       });
     }
-  }, [visibleRows, clusters]);
+  }, [visibleRows, clusters, drivers, clientOverrides]);
 
   const invalidCount = visibleRows.filter(
     (client) => !isValidCoordinate(client.coordinates)

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -891,13 +891,13 @@ const DeliverySpreadsheet: React.FC = () => {
         }
       });
 
-      const updatedOverrides = clientOverrides.filter(override => 
-        !affectedClientIds.has(override.clientId) || !override.driver
-      ).map(override => 
-        affectedClientIds.has(override.clientId) 
-          ? { ...override, driver: undefined }
-          : override
-      ).filter(override => override.driver || override.time); // Remove overrides with no data
+      const updatedOverrides = clientOverrides.map(override => {
+        if (affectedClientIds.has(override.clientId)) {
+          // Clear the driver field for affected clients
+          return { ...override, driver: undefined };
+        }
+        return override;
+      }).filter(override => override.driver || override.time); // Remove overrides with no data
 
       setClientOverrides(updatedOverrides);
 
@@ -970,13 +970,13 @@ const DeliverySpreadsheet: React.FC = () => {
           }
         });
 
-        const updatedOverrides = clientOverrides.filter(override => 
-          !affectedClientIds.has(override.clientId) || !override.time
-        ).map(override => 
-          affectedClientIds.has(override.clientId) 
-            ? { ...override, time: undefined }
-            : override
-        ).filter(override => override.driver || override.time); // Remove overrides with no data
+        const updatedOverrides = clientOverrides.map(override => {
+          if (affectedClientIds.has(override.clientId)) {
+            // Clear the time field for affected clients
+            return { ...override, time: undefined };
+          }
+          return override;
+        }).filter(override => override.driver || override.time); // Remove overrides with no data
 
         setClientOverrides(updatedOverrides);
 


### PR DESCRIPTION
…tes the map and table and the table still updates the map

The test is the following

When you have a cluster pick one of the items on the map click the edit pencil and edit the data, watch it update the table. 

The go update the table and watch it update the map.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to edit cluster, driver, and delivery time assignments directly from map popups for individual clients.
  * Introduced support for per-client overrides of driver and delivery time, supplementing cluster-level assignments.
  * Map and spreadsheet views now reflect and prioritize individual client overrides.

* **Bug Fixes**
  * Improved UI consistency by disabling pointer events and ripple effects on certain UI elements.

* **Chores**
  * Enhanced data synchronization between map and spreadsheet views to ensure updates are propagated correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->