### PR TITLE
Bug: driver state

### DIFF
--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -322,6 +322,7 @@ const DeliverySpreadsheet: React.FC = () => {
   const [selectedClusters, setSelectedClusters] = useState<Set<any>>(new Set());
   const [exportOption, setExportOption] = useState<"Routes" | "Doordash" | null>(null);
   const [emailOrDownload, setEmailOrDownload] = useState<"Email" | "Download" | null>(null);
+  const [driversRefreshTrigger, setDriversRefreshTrigger] = useState<number>(0);
 
   const parseDateFromUrl = (dateString: string | null): Date => {
     if (!dateString) return new Date();
@@ -363,6 +364,10 @@ const DeliverySpreadsheet: React.FC = () => {
     handleCustomColumnChange,
   } = useCustomColumns({page: 'DeliverySpreadsheet'});
 
+  // Function to trigger driver refresh across components
+  const triggerDriverRefresh = () => {
+    setDriversRefreshTrigger(prev => prev + 1);
+  };
 
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
@@ -1949,7 +1954,7 @@ const DeliverySpreadsheet: React.FC = () => {
           // Revert to rendering the indicator directly
           <LoadingIndicator />
         ) : visibleRows.length > 0 ? (
-          <ClusterMap clusters={clusters} visibleRows={visibleRows as any} clientOverrides={clientOverrides} onClusterUpdate={handleIndividualClientUpdate} />
+          <ClusterMap clusters={clusters} visibleRows={visibleRows} clientOverrides={clientOverrides} onClusterUpdate={handleIndividualClientUpdate} refreshDriversTrigger={driversRefreshTrigger} />
         ) : (
           <Box
             sx={{
@@ -2411,7 +2416,11 @@ const DeliverySpreadsheet: React.FC = () => {
       <Dialog open={popupMode === "Driver"} onClose={resetSelections} maxWidth="xs" fullWidth>
         <DialogTitle>Assign Driver</DialogTitle>
         <DialogContent>
-          <AssignDriverPopup assignDriver={assignDriver} setPopupMode={setPopupMode} />
+          <AssignDriverPopup 
+            assignDriver={assignDriver} 
+            setPopupMode={setPopupMode}
+            onDriversUpdated={triggerDriverRefresh}
+          />
         </DialogContent>
       </Dialog>
 


### PR DESCRIPTION
Fixed the following issue:
**Description:**

On the **Route** page, when a driver is added to the driver list, they do not appear as an option when assigning a driver to a cluster. The **Add Delivery** component needs to refresh its driver list to include any newly created drivers without requiring a full page reload.

**Acceptance Criteria:**

- After a new driver is added, they should immediately appear in the driver dropdown when assigning a driver to a cluster.
- No need to refresh the entire page to see updated driver options. THE LIST DIDNT UPDATE EVEN WHEN REFRESHING THE PAGE.
- Test case: Create a new driver, then immediately assign them to a cluster without having to refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to refresh the driver list externally in the delivery map and spreadsheet views.
  * Assigning a driver now triggers an automatic refresh of the driver list.

* **Refactor**
  * Improved driver data fetching by centralizing logic and using a service for better maintainability.
  * Enhanced component props to support new refresh and update mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->