### PR TITLE
fixed start date validation for existing profiles

### DIFF
--- a/my-app/src/pages/Profile/Profile.tsx
+++ b/my-app/src/pages/Profile/Profile.tsx
@@ -663,7 +663,6 @@ const Profile = () => {
       | SelectChangeEvent
   ) => {
     const { name, value } = e.target;
-  
     // Always mark as unsaved when a change occurs
     setIsSaved(false);
     handlePrevClientCopying();
@@ -2495,6 +2494,7 @@ const handleMentalHealthConditionsChange = (e: React.ChangeEvent<HTMLInputElemen
               renderField={renderField}
               lastDeliveryDate={lastDeliveryDate}
               isSaved={isSaved}
+              isNewProfile={isNewProfile}
             />
           </SectionBox>
 

--- a/my-app/src/pages/Profile/components/DeliveryInfoForm.tsx
+++ b/my-app/src/pages/Profile/components/DeliveryInfoForm.tsx
@@ -14,6 +14,7 @@ interface DeliveryInfoFormProps {
   lastDeliveryDate: string | null;
   isSaved: boolean;
   onDateValidationChange?: (isValid: boolean, startDateError?: string, endDateError?: string) => void;
+  isNewProfile: boolean;
 }
 
 const fieldStyles = {
@@ -54,6 +55,7 @@ const DeliveryInfoForm: React.FC<DeliveryInfoFormProps> = ({
   lastDeliveryDate,
   isSaved,
   onDateValidationChange,
+  isNewProfile
 }) => {
   const [startDateError, setStartDateError] = useState<string>("");
   const [endDateError, setEndDateError] = useState<string>("");
@@ -62,15 +64,20 @@ const DeliveryInfoForm: React.FC<DeliveryInfoFormProps> = ({
   useEffect(() => {
     if (clientProfile.startDate || clientProfile.endDate) {
       const validation = validateDateRange(clientProfile.startDate, clientProfile.endDate);
-      const startError = validation.startDateError || "";
+      let startError = validation.startDateError || "";
       const endError = validation.endDateError || "";
-      
+
+      if (!isNewProfile && startError === "Date cannot be in the past") {
+        startError = "";
+      }
+
       setStartDateError(startError);
       setEndDateError(endError);
-      
+
       // Notify parent component of validation state
       if (onDateValidationChange) {
-        onDateValidationChange(validation.isValid, startError, endError);
+        const isValid = startError === "" && endError === "";
+        onDateValidationChange(isValid, startError, endError);
       }
     } else {
       setStartDateError("");
@@ -79,7 +86,8 @@ const DeliveryInfoForm: React.FC<DeliveryInfoFormProps> = ({
         onDateValidationChange(true);
       }
     }
-  }, [clientProfile.startDate, clientProfile.endDate, onDateValidationChange]);
+  }, [clientProfile.startDate, clientProfile.endDate, onDateValidationChange, isNewProfile]);
+
 
   return (
     <>


### PR DESCRIPTION
made it so existing profiles can set the startDate field in the past without errors, while new profiles cannot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the delivery information form to handle new and existing profiles differently when validating date fields.

* **Bug Fixes**
  * Improved validation logic for delivery date fields to provide more accurate error handling based on profile status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->