### PR TITLE
fixed assign driver modal

### DIFF
--- a/my-app/src/components/DriverManagementModal.tsx
+++ b/my-app/src/components/DriverManagementModal.tsx
@@ -178,7 +178,12 @@ const DriverManagementModal: React.FC<DriverManagementModalProps> = ({
           // Add new driver
           const driversCollectionRef = collection(db, "Drivers");
           const docRef = await addDoc(driversCollectionRef, driver);
-          onDriversChange([...drivers, { ...driver, id: docRef.id }]);
+          //add new driver to the top but under DoorDash
+          onDriversChange([
+            drivers[0],                           
+            { ...driver, id: docRef.id },        
+            ...drivers.slice(1)                  
+          ]);
           setIsAddingDriver(false);
           setNewDriver({ name: "", phone: "", email: "" });
         }

--- a/my-app/src/pages/Delivery/components/AssignDriverPopup.tsx
+++ b/my-app/src/pages/Delivery/components/AssignDriverPopup.tsx
@@ -82,10 +82,7 @@ export default function AssignDriverPopup({ assignDriver, setPopupMode, onDriver
                     driver.name.toLowerCase().includes(state.inputValue.toLowerCase())
                   );
 
-                  // Limit total displayed items to 10, including the special option
-                  const limitedDrivers = filteredDrivers.slice(0, 9); // 9 + 1 = 10 total
-
-                  return [specialOption, ...limitedDrivers];
+                  return [specialOption, ...filteredDrivers];
                 }}
                 value={driver}
                 onChange={(event, newValue) => {


### PR DESCRIPTION
Removed the 10 driver limit so that newly created drivers don't get hidden. Instead, they are now added to the top of the list right under DoorDash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Newly added drivers now appear immediately after the first driver in the drivers list for improved visibility.

* **Improvements**
  * All available driver options are now displayed in the autocomplete dropdown, removing the previous limit on the number of visible options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->