### PR TITLE
Jamie/dietary options

### DIFF
--- a/my-app/src/components/Spreadsheet/Spreadsheet.tsx
+++ b/my-app/src/components/Spreadsheet/Spreadsheet.tsx
@@ -1345,39 +1345,64 @@ const StyleChip = styled(Chip)({
                         ) : (field as any).compute ? (
                           field.key === "deliveryDetails.dietaryRestrictions" ? (
                             (() => {
-                              const restrictions = (field as any).compute(row);
-                              if (restrictions === "None") {
+                              const dr = row.deliveryDetails?.dietaryRestrictions;
+                              if (!dr) {
                                 return (
-                                  <Typography sx={{ 
-                                    fontSize: '0.875rem',
-                                    color: "#757575",
-                                    fontStyle: "italic"
-                                  }}>
-                                    None
-                                  </Typography>
+                                  <Typography sx={{ fontSize: '0.875rem', color: '#757575', fontStyle: 'italic' }}>None</Typography>
+                                );
+                              }
+                              const chips: { label: string; color: string; border: string; textColor: string }[] = [];
+                              // Boolean restrictions (green)
+                              [
+                                { key: 'halal', label: 'Halal' },
+                                { key: 'kidneyFriendly', label: 'Kidney Friendly' },
+                                { key: 'lowSodium', label: 'Low Sodium' },
+                                { key: 'lowSugar', label: 'Low Sugar' },
+                                { key: 'microwaveOnly', label: 'Microwave Only' },
+                                { key: 'noCookingEquipment', label: 'No Cooking Equipment' },
+                                { key: 'softFood', label: 'Soft Food' },
+                                { key: 'vegan', label: 'Vegan' },
+                                { key: 'vegetarian', label: 'Vegetarian' },
+                                { key: 'heartFriendly', label: 'Heart Friendly' },
+                              ].forEach(opt => {
+                                // Use type assertion to ensure key is keyof typeof dr
+                                if (dr[opt.key as keyof typeof dr]) {
+                                  chips.push({ label: opt.label, color: '#e8f5e9', border: '#c8e6c9', textColor: '#2E5B4C' });
+                                }
+                              });
+                              // Allergies (light red)
+                              if (Array.isArray(dr.foodAllergens) && dr.foodAllergens.length > 0) {
+                                dr.foodAllergens.forEach((allergy: string) => {
+                                  if (allergy && allergy.trim()) {
+                                    chips.push({ label: allergy, color: '#FFEBEE', border: '#FFCDD2', textColor: '#C62828' });
+                                  }
+                                });
+                              }
+                              // Other (light purple)
+                              if (dr.otherText && dr.otherText.trim()) {
+                                chips.push({ label: dr.otherText, color: '#F3E8FF', border: '#CEB8FF', textColor: '#6C2EB7' });
+                              }
+                              if (chips.length === 0) {
+                                return (
+                                  <Typography sx={{ fontSize: '0.875rem', color: '#757575', fontStyle: 'italic' }}>None</Typography>
                                 );
                               }
                               return (
                                 <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, maxWidth: '250px' }}>
-                                  {restrictions.split(", ").map((restriction: string, i: number) => (
+                                  {chips.map((chip, i) => (
                                     <Chip
                                       key={i}
-                                      label={restriction}
+                                      label={chip.label}
                                       size="small"
                                       sx={{
-                                        backgroundColor: "#e8f5e9",
-                                        color: "#2E5B4C",
-                                        fontSize: "0.75rem",
-                                        height: "20px",
+                                        backgroundColor: chip.color,
+                                        color: chip.textColor,
+                                        fontSize: '0.75rem',
+                                        height: '20px',
                                         fontWeight: 500,
-                                        border: "1px solid #c8e6c9",
-                                        "& .MuiChip-label": {
-                                          px: 1
-                                        },
-                                        "&:hover": {
-                                          backgroundColor: "#e8f5e9",
-                                          cursor: "default"
-                                        }
+                                        border: `1px solid ${chip.border}`,
+                                        '& .MuiChip-label': { px: 1 },
+                                        '&:hover': { backgroundColor: chip.color, cursor: 'default' }
                                       }}
                                     />
                                   ))}

--- a/my-app/src/pages/Profile/Profile.tsx
+++ b/my-app/src/pages/Profile/Profile.tsx
@@ -1379,6 +1379,7 @@ if (type === "physicalAilments") {
               onChange={handlePhysicalAilmentsChange}
               name={option.name}
               label={option.label}
+              isEditing={isEditing}
             />
           ))}
           <HealthCheckbox
@@ -1389,6 +1390,7 @@ if (type === "physicalAilments") {
             showOtherText={true}
             otherTextValue={clientProfile.physicalAilments?.otherText || ""}
             placeholder="Please specify other physical ailments"
+            isEditing={isEditing}
           />
         </>
       );
@@ -1404,6 +1406,7 @@ if (type === "physicalAilments") {
           showOtherText={true}
           otherTextValue={clientProfile.physicalDisability?.otherText || ""}
           placeholder="Please specify other physical disabilities"
+          isEditing={isEditing}
         />
       );
     }
@@ -1418,6 +1421,7 @@ if (type === "physicalAilments") {
           showOtherText={true}
           otherTextValue={clientProfile.mentalHealthConditions?.otherText || ""}
           placeholder="Please specify other mental health conditions"
+          isEditing={isEditing}
         />
       );
     }
@@ -1461,157 +1465,118 @@ if (type === "physicalAilments") {
 
       return (
         <>
-          {dietaryOptions.map((option: DietaryOption) => (
-            <FormControlLabel
-              key={option.name}
-              control={
-                <Checkbox
-                  checked={Boolean(clientProfile.deliveryDetails?.dietaryRestrictions?.[option.name])}
-                  onChange={handleDietaryRestrictionChange}
-                  name={option.name}
-                  sx={{
-                    "&:focus": { outline: "none" },
-                    "&.Mui-focusVisible": {
-                      outline: "none",
-                      "& .MuiSvgIcon-root": {
-                        color: "#257E68",
-                        filter: "drop-shadow(0 0 8px rgba(37, 126, 104, 0.4)) drop-shadow(0 0 16px rgba(37, 126, 104, 0.2))",
-                      },
-                    },
-                    "& input:focus + .MuiSvgIcon-root": {
-                      color: "#257E68",
-                      filter: "drop-shadow(0 0 8px rgba(37, 126, 104, 0.4)) drop-shadow(0 0 16px rgba(37, 126, 104, 0.2))",
-                    },
-                  }}
-                />
-              }
-              label={option.label}
-            />
-          ))}
+          {dietaryOptions.map((option: DietaryOption) => {
+            return (
+              <HealthCheckbox
+                key={option.name}
+                checked={Boolean(clientProfile.deliveryDetails?.dietaryRestrictions?.[option.name])}
+                onChange={handleDietaryRestrictionChange}
+                name={option.name}
+                label={option.label}
+                isEditing={isEditing}
+              />
+            );
+          })}
 
-          {/* Allergies checkbox and always-visible text box */}
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={
-                    typeof clientProfile.deliveryDetails?.dietaryRestrictions?.allergiesText === "string" &&
-                    clientProfile.deliveryDetails?.dietaryRestrictions?.allergiesText.trim() !== ""
-                  }
-                  onChange={handleDietaryRestrictionChange}
-                  name="allergies"
-                  sx={{
-                    "&:focus": { outline: "none" },
-                    "&.Mui-focusVisible": {
-                      outline: "none",
-                      "& .MuiSvgIcon-root": {
-                        color: "#257E68",
-                        filter: "drop-shadow(0 0 8px rgba(37, 126, 104, 0.4)) drop-shadow(0 0 16px rgba(37, 126, 104, 0.2))",
-                      },
-                    },
-                    "& input:focus + .MuiSvgIcon-root": {
-                      color: "#257E68",
-                      filter: "drop-shadow(0 0 8px rgba(37, 126, 104, 0.4)) drop-shadow(0 0 16px rgba(37, 126, 104, 0.2))",
-                    },
-                  }}
-                />
-              }
-              label="Allergies"
-            />
-            <TextField
-              name="foodAllergensText"
-              value={isEditing
-                ? foodAllergensText
-                : clientProfile.deliveryDetails?.dietaryRestrictions?.foodAllergens?.join(", ") || ""
-              }
-              onChange={e => {
-                setFoodAllergensText(e.target.value);
-              }}
-              onBlur={e => {
-                // On blur, update state and array
-                const value = e.target.value;
-                handlePrevClientCopying();
-                setClientProfile(prev => ({
-                  ...prev,
-                  deliveryDetails: {
-                    ...prev.deliveryDetails,
-                    dietaryRestrictions: {
-                      ...prev.deliveryDetails.dietaryRestrictions,
-                      foodAllergens: value.split(",").map(s => s.trim()).filter(Boolean),
-                      allergiesText: value,
+          {/* Allergies title and text box */}
+          <Box sx={{ width: '100%' }}>
+            <Typography className="field-descriptor" sx={{ fontWeight: 700, fontSize: '1rem', mb: '10px' }}>
+              ALLERGIES
+            </Typography>
+            {isEditing ? (
+              <CustomTextField
+                name="foodAllergensText"
+                value={foodAllergensText}
+                onChange={e => {
+                  setFoodAllergensText(e.target.value);
+                }}
+                onBlur={e => {
+                  // On blur, update state and array
+                  const value = e.target.value;
+                  handlePrevClientCopying();
+                  setClientProfile(prev => ({
+                    ...prev,
+                    deliveryDetails: {
+                      ...prev.deliveryDetails,
+                      dietaryRestrictions: {
+                        ...prev.deliveryDetails.dietaryRestrictions,
+                        foodAllergens: value.split(",").map(s => s.trim()).filter(Boolean),
+                        allergiesText: value,
+                      }
                     }
-                  }
-                }));
-              }}
-              placeholder="Please specify allergies (e.g. peanuts, shellfish)"
-              variant="outlined"
-              size="small"
-              sx={{ flexGrow: 1, marginTop: '5%', '& .MuiOutlinedInput-root': { '&.Mui-focused fieldset': { borderColor: '#257E68' } } }}
-            />
-      </Box>
+                  }));
+                }}
+                placeholder="Please specify allergies (e.g. peanuts, shellfish)"
+                variant="outlined"
+                size="small"
+                multiline
+                minRows={2}
+                sx={{ width: '105%', marginLeft: 0, resize: 'vertical', '& textarea': { resize: 'vertical' }, '& .MuiOutlinedInput-root': { '&.Mui-focused fieldset': { borderColor: '#257E68' } } }}
+              />
+            ) : (
+              <Typography sx={{ width: '105%', fontSize: '1rem', padding: '10px', minHeight: '48px', textAlign: 'left' }}>
+                {clientProfile.deliveryDetails?.dietaryRestrictions?.foodAllergens?.join(", ") || ""}
+              </Typography>
+            )}
+          </Box>
 {/* ...existing code... */}
 
-          {/* Other checkbox and conditional text box */}
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={clientProfile.deliveryDetails?.dietaryRestrictions?.other || false}
-                  onChange={handleDietaryRestrictionChange}
-                  name="other"
-                  sx={{
-                    "&:focus": { outline: "none" },
-                    "&.Mui-focusVisible": {
-                      outline: "none",
-                      "& .MuiSvgIcon-root": {
-                        color: "#257E68",
-                        filter: "drop-shadow(0 0 8px rgba(37, 126, 104, 0.4)) drop-shadow(0 0 16px rgba(37, 126, 104, 0.2))",
-                      },
-                    },
-                    "& input:focus + .MuiSvgIcon-root": {
-                      color: "#257E68",
-                      filter: "drop-shadow(0 0 8px rgba(37, 126, 104, 0.4)) drop-shadow(0 0 16px rgba(37, 126, 104, 0.2))",
-                    },
-                  }}
-                />
-              }
-              label="Other"
-            />
-            {clientProfile.deliveryDetails?.dietaryRestrictions?.other && (
-              <TextField
+          {/* Other title and text box */}
+          <Box sx={{ width: '100%' }}>
+            <Typography className="field-descriptor" sx={{ fontWeight: 700, fontSize: '1rem', mb: '10px' }}>
+              OTHER
+            </Typography>
+            {isEditing ? (
+              <CustomTextField
                 name="otherText"
                 value={clientProfile.deliveryDetails?.dietaryRestrictions?.otherText || ""}
                 onChange={handleDietaryRestrictionChange}
                 placeholder="Please specify other dietary restrictions"
                 variant="outlined"
                 size="small"
-                sx={{ flexGrow: 1, marginTop: '5%', '& .MuiOutlinedInput-root': { '&.Mui-focused fieldset': { borderColor: "#257E68" } } }}
+                multiline
+                minRows={2}
+                sx={{ width: '105%', marginLeft: 0, resize: 'vertical', '& textarea': { resize: 'vertical' }, '& .MuiOutlinedInput-root': { '&.Mui-focused fieldset': { borderColor: "#257E68" } } }}
               />
+            ) : (
+              <Typography sx={{ width: '105%', fontSize: '1rem', padding: '10px', minHeight: '48px', textAlign: 'left' }}>
+                {clientProfile.deliveryDetails?.dietaryRestrictions?.otherText || ""}
+              </Typography>
             )}
           </Box>
 
             {/* Dietary Preferences textarea */}
-            <Box sx={{ width: '100%' }}>
-              <Typography className="field-descriptor" sx={{ fontWeight: 700, fontSize: '1rem', mb: 3 }}>
+            {/* Dietary Preferences Subsection Heading */}
+            <Box sx={{ width: '100%', mt: 3 }}>
+              <SectionTitle sx={{ textAlign: 'left', width: '100%' }}>
+                Dietary Preferences
+              </SectionTitle>
+              <Typography className="field-descriptor" sx={{ fontWeight: 700, fontSize: '1rem', mb: '10px' }}>
                 DIETARY PREFERENCES
               </Typography>
-              <FormField
-                fieldPath="deliveryDetails.dietaryRestrictions.dietaryPreferences"
-                value={typeof clientProfile.deliveryDetails?.dietaryRestrictions?.dietaryPreferences === 'string'
-                  ? clientProfile.deliveryDetails?.dietaryRestrictions?.dietaryPreferences
-                  : ''}
-                type="textarea"
-                isEditing={isEditing}
-                handleChange={handleChange}
-                handleDietaryRestrictionChange={handleDietaryRestrictionChange}
-                getNestedValue={getNestedValue}
-                tags={tags}
-                allTags={allTags}
-                isModalOpen={isModalOpen}
-                setIsModalOpen={setIsModalOpen}
-                handleTag={handleTag}
-                error={errors["deliveryDetails.dietaryRestrictions.dietaryPreferences"]}
-              />
+              {isEditing ? (
+                <CustomTextField
+                  name="dietaryPreferences"
+                  value={typeof clientProfile.deliveryDetails?.dietaryRestrictions?.dietaryPreferences === 'string'
+                    ? clientProfile.deliveryDetails?.dietaryRestrictions?.dietaryPreferences
+                    : ''}
+                  onChange={handleDietaryRestrictionChange}
+                  placeholder="Please specify dietary preferences (e.g. kosher, gluten-free)"
+                  variant="outlined"
+                  size="small"
+                  multiline
+                  minRows={2}
+                  error={!!errors["deliveryDetails.dietaryRestrictions.dietaryPreferences"]}
+                  sx={{ width: '105%', marginLeft: 0, resize: 'vertical', '& textarea': { resize: 'vertical', textAlign: 'left !important' }, '& .MuiOutlinedInput-root': { '&.Mui-focused fieldset': { borderColor: '#257E68' } } }}
+                  inputProps={{ style: { textAlign: 'left' } }}
+                />
+              ) : (
+                <Typography sx={{ width: '105%', fontSize: '1rem', padding: '10px', minHeight: '48px', textAlign: 'left' }}>
+                  {typeof clientProfile.deliveryDetails?.dietaryRestrictions?.dietaryPreferences === 'string'
+                    ? clientProfile.deliveryDetails?.dietaryRestrictions?.dietaryPreferences
+                    : ''}
+                </Typography>
+              )}
             </Box>
         </>
       );

--- a/my-app/src/pages/Profile/Profile.tsx
+++ b/my-app/src/pages/Profile/Profile.tsx
@@ -215,19 +215,21 @@ const Profile = () => {
     deliveryDetails: {
       deliveryInstructions: "",
       dietaryRestrictions: {
-        lowSugar: false,
-        kidneyFriendly: false,
-        vegan: false,
-        vegetarian: false,
-        halal: false,
-        microwaveOnly: false,
-        softFood: false,
-        lowSodium: false,
-        noCookingEquipment: false,
-        heartFriendly: false,
-        foodAllergens: [],
-        otherText: "",
-        other: false,     // Changed from string to boolean
+  lowSugar: false,
+  kidneyFriendly: false,
+  vegan: false,
+  vegetarian: false,
+  halal: false,
+  microwaveOnly: false,
+  softFood: false,
+  lowSodium: false,
+  noCookingEquipment: false,
+  heartFriendly: false,
+  allergies: false,
+  allergiesText: "",
+  foodAllergens: [],
+  otherText: "",
+  other: false,     // Changed from string to boolean
 
       },
     },
@@ -236,7 +238,7 @@ const Profile = () => {
     notesTimestamp: null,
     deliveryInstructionsTimestamp: null, // New timestamp field for delivery instructions
     lifeChallengesTimestamp: null,       // New timestamp field for life challenges
-    lifestyleGoalsTimestamp: null,
+    lifestyleGoalsTimestamp: null,  
     lifestyleGoals: "",
     language: "",
     createdAt: TimeUtils.now().toJSDate(),
@@ -284,6 +286,16 @@ const Profile = () => {
   const [pastDeliveries, setPastDeliveries] = useState<DeliveryEvent[]>([]);
   const [futureDeliveries, setFutureDeliveries] = useState<DeliveryEvent[]>([]);
   const [events, setEvents] = useState<DeliveryEvent[]>([]);
+
+    // Allergies textbox state for editing
+    const [foodAllergensText, setFoodAllergensText] = useState<string>("");
+  // Sync allergies textbox with foodAllergens array when entering edit mode or when array changes
+  useEffect(() => {
+    if (isEditing) {
+      const allergensArr = clientProfile.deliveryDetails?.dietaryRestrictions?.foodAllergens;
+      setFoodAllergensText(Array.isArray(allergensArr) && allergensArr.length > 0 ? allergensArr.join(", ") : "");
+    }
+  }, [isEditing, clientProfile.deliveryDetails?.dietaryRestrictions?.foodAllergens]);
 
   // Add clients state for fetchClients()
   const [clients, setClients] = useState<ClientProfile[]>([]);
@@ -1359,7 +1371,7 @@ if (type === "physicalAilments") {
       ];
       
       return (
-        <>
+  <>
           {options.map((option) => (
             <HealthCheckbox
               key={option.name}
@@ -1437,95 +1449,170 @@ if (type === "physicalAilments") {
         vegetarian: boolean;
         halal: boolean;
         microwaveOnly: boolean;
-        softFood: boolean;
-        lowSodium: boolean;
-        noCookingEquipment: boolean;
-        heartFriendly: boolean;
-        other: boolean;
-        otherText: string;
+  softFood: boolean;
+  lowSodium: boolean;
+  noCookingEquipment: boolean;
+  heartFriendly: boolean;
+  allergies: boolean;
+  allergiesText: string;
+  other: boolean;
+  otherText: string;
       }
 
       return (
-        <>          {dietaryOptions.map((option: DietaryOption) => (
-  <FormControlLabel
-    key={option.name}
-    control={      <Checkbox
-        checked={Boolean(clientProfile.deliveryDetails?.dietaryRestrictions?.[option.name])}
-        onChange={handleDietaryRestrictionChange}
-        name={option.name}
-        sx={{
-          "&:focus": {
-            outline: "none",
-          },
-          "&.Mui-focusVisible": {
-            outline: "none",
-            "& .MuiSvgIcon-root": {
-              color: "#257E68",
-              filter: "drop-shadow(0 0 8px rgba(37, 126, 104, 0.4)) drop-shadow(0 0 16px rgba(37, 126, 104, 0.2))",
-            },
-          },
-          "& input:focus + .MuiSvgIcon-root": {
-            color: "#257E68",
-            filter: "drop-shadow(0 0 8px rgba(37, 126, 104, 0.4)) drop-shadow(0 0 16px rgba(37, 126, 104, 0.2))",
-          },
-        }}
-      />
-    }
-    label={option.label}
-  />
-))}
+        <>
+          {dietaryOptions.map((option: DietaryOption) => (
+            <FormControlLabel
+              key={option.name}
+              control={
+                <Checkbox
+                  checked={Boolean(clientProfile.deliveryDetails?.dietaryRestrictions?.[option.name])}
+                  onChange={handleDietaryRestrictionChange}
+                  name={option.name}
+                  sx={{
+                    "&:focus": { outline: "none" },
+                    "&.Mui-focusVisible": {
+                      outline: "none",
+                      "& .MuiSvgIcon-root": {
+                        color: "#257E68",
+                        filter: "drop-shadow(0 0 8px rgba(37, 126, 104, 0.4)) drop-shadow(0 0 16px rgba(37, 126, 104, 0.2))",
+                      },
+                    },
+                    "& input:focus + .MuiSvgIcon-root": {
+                      color: "#257E68",
+                      filter: "drop-shadow(0 0 8px rgba(37, 126, 104, 0.4)) drop-shadow(0 0 16px rgba(37, 126, 104, 0.2))",
+                    },
+                  }}
+                />
+              }
+              label={option.label}
+            />
+          ))}
 
-<Box sx={{ 
-  display: 'flex', 
-  alignItems: 'center',
-  gap: 1,
-  width: '100%',
-}}>
-  <FormControlLabel
-    control={      <Checkbox
-        checked={clientProfile.deliveryDetails?.dietaryRestrictions?.other || false}
-        onChange={handleDietaryRestrictionChange}
-        name="other"
-        sx={{
-          "&:focus": {
-            outline: "none",
-          },
-          "&.Mui-focusVisible": {
-            outline: "none",
-            "& .MuiSvgIcon-root": {
-              color: "#257E68",
-              filter: "drop-shadow(0 0 8px rgba(37, 126, 104, 0.4)) drop-shadow(0 0 16px rgba(37, 126, 104, 0.2))",
-            },
-          },
-          "& input:focus + .MuiSvgIcon-root": {
-            color: "#257E68",
-            filter: "drop-shadow(0 0 8px rgba(37, 126, 104, 0.4)) drop-shadow(0 0 16px rgba(37, 126, 104, 0.2))",
-          },
-        }}
-      />
-    }
-    label="Other"
-  />
-  {clientProfile.deliveryDetails?.dietaryRestrictions?.other && (    <TextField
-      name="otherText"
-      value={clientProfile.deliveryDetails?.dietaryRestrictions?.otherText || ""}
-      onChange={handleDietaryRestrictionChange}
-      placeholder="Please specify other dietary restrictions"
-      variant="outlined"
-      size="small"
-      sx={{ 
-        flexGrow: 1, 
-        marginTop: '5%',        '& .MuiOutlinedInput-root': {
-          '&.Mui-focused fieldset': {
-            borderColor: "#257E68",
-            border: "2px solid #257E68",
-            boxShadow: "0 0 8px rgba(37, 126, 104, 0.4), 0 0 16px rgba(37, 126, 104, 0.2)",
-          },
-        },
-      }}
-    />
-  )}
-</Box>
+          {/* Allergies checkbox and always-visible text box */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={
+                    typeof clientProfile.deliveryDetails?.dietaryRestrictions?.allergiesText === "string" &&
+                    clientProfile.deliveryDetails?.dietaryRestrictions?.allergiesText.trim() !== ""
+                  }
+                  onChange={handleDietaryRestrictionChange}
+                  name="allergies"
+                  sx={{
+                    "&:focus": { outline: "none" },
+                    "&.Mui-focusVisible": {
+                      outline: "none",
+                      "& .MuiSvgIcon-root": {
+                        color: "#257E68",
+                        filter: "drop-shadow(0 0 8px rgba(37, 126, 104, 0.4)) drop-shadow(0 0 16px rgba(37, 126, 104, 0.2))",
+                      },
+                    },
+                    "& input:focus + .MuiSvgIcon-root": {
+                      color: "#257E68",
+                      filter: "drop-shadow(0 0 8px rgba(37, 126, 104, 0.4)) drop-shadow(0 0 16px rgba(37, 126, 104, 0.2))",
+                    },
+                  }}
+                />
+              }
+              label="Allergies"
+            />
+            <TextField
+              name="foodAllergensText"
+              value={isEditing
+                ? foodAllergensText
+                : clientProfile.deliveryDetails?.dietaryRestrictions?.foodAllergens?.join(", ") || ""
+              }
+              onChange={e => {
+                setFoodAllergensText(e.target.value);
+              }}
+              onBlur={e => {
+                // On blur, update state and array
+                const value = e.target.value;
+                handlePrevClientCopying();
+                setClientProfile(prev => ({
+                  ...prev,
+                  deliveryDetails: {
+                    ...prev.deliveryDetails,
+                    dietaryRestrictions: {
+                      ...prev.deliveryDetails.dietaryRestrictions,
+                      foodAllergens: value.split(",").map(s => s.trim()).filter(Boolean),
+                      allergiesText: value,
+                    }
+                  }
+                }));
+              }}
+              placeholder="Please specify allergies (e.g. peanuts, shellfish)"
+              variant="outlined"
+              size="small"
+              sx={{ flexGrow: 1, marginTop: '5%', '& .MuiOutlinedInput-root': { '&.Mui-focused fieldset': { borderColor: '#257E68' } } }}
+            />
+      </Box>
+{/* ...existing code... */}
+
+          {/* Other checkbox and conditional text box */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={clientProfile.deliveryDetails?.dietaryRestrictions?.other || false}
+                  onChange={handleDietaryRestrictionChange}
+                  name="other"
+                  sx={{
+                    "&:focus": { outline: "none" },
+                    "&.Mui-focusVisible": {
+                      outline: "none",
+                      "& .MuiSvgIcon-root": {
+                        color: "#257E68",
+                        filter: "drop-shadow(0 0 8px rgba(37, 126, 104, 0.4)) drop-shadow(0 0 16px rgba(37, 126, 104, 0.2))",
+                      },
+                    },
+                    "& input:focus + .MuiSvgIcon-root": {
+                      color: "#257E68",
+                      filter: "drop-shadow(0 0 8px rgba(37, 126, 104, 0.4)) drop-shadow(0 0 16px rgba(37, 126, 104, 0.2))",
+                    },
+                  }}
+                />
+              }
+              label="Other"
+            />
+            {clientProfile.deliveryDetails?.dietaryRestrictions?.other && (
+              <TextField
+                name="otherText"
+                value={clientProfile.deliveryDetails?.dietaryRestrictions?.otherText || ""}
+                onChange={handleDietaryRestrictionChange}
+                placeholder="Please specify other dietary restrictions"
+                variant="outlined"
+                size="small"
+                sx={{ flexGrow: 1, marginTop: '5%', '& .MuiOutlinedInput-root': { '&.Mui-focused fieldset': { borderColor: "#257E68" } } }}
+              />
+            )}
+          </Box>
+
+            {/* Dietary Preferences textarea */}
+            <Box sx={{ width: '100%' }}>
+              <Typography className="field-descriptor" sx={{ fontWeight: 700, fontSize: '1rem', mb: 3 }}>
+                DIETARY PREFERENCES
+              </Typography>
+              <FormField
+                fieldPath="deliveryDetails.dietaryRestrictions.dietaryPreferences"
+                value={typeof clientProfile.deliveryDetails?.dietaryRestrictions?.dietaryPreferences === 'string'
+                  ? clientProfile.deliveryDetails?.dietaryRestrictions?.dietaryPreferences
+                  : ''}
+                type="textarea"
+                isEditing={isEditing}
+                handleChange={handleChange}
+                handleDietaryRestrictionChange={handleDietaryRestrictionChange}
+                getNestedValue={getNestedValue}
+                tags={tags}
+                allTags={allTags}
+                isModalOpen={isModalOpen}
+                setIsModalOpen={setIsModalOpen}
+                handleTag={handleTag}
+                error={errors["deliveryDetails.dietaryRestrictions.dietaryPreferences"]}
+              />
+            </Box>
         </>
       );
     }
@@ -1950,12 +2037,12 @@ if (type === "physicalAilments") {
   };
 
   // Updated handler for dietary restrictions
-  const handleDietaryRestrictionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleDietaryRestrictionChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, type } = e.target;
     handlePrevClientCopying();
 
     if (type === "checkbox") {
-      const { checked } = e.target;
+  const checked = (e.target as HTMLInputElement).checked;
       setClientProfile((prevState) => ({
         ...prevState,
         deliveryDetails: {
@@ -1971,16 +2058,17 @@ if (type === "physicalAilments") {
           },
         },
       }));
-    } else if (type === "text" && name === "otherText") {
-      const value = e.target.value;
+    } else if ((type === "text" || type === "textarea") && (name === "otherText" || name === "allergiesText" || name === "dietaryPreferences")) {
+      const value = (e.target as HTMLInputElement | HTMLTextAreaElement).value;
       setClientProfile((prevState) => ({
         ...prevState,
         deliveryDetails: {
           ...prevState.deliveryDetails,
           dietaryRestrictions: {
             ...prevState.deliveryDetails.dietaryRestrictions,
-            otherText: value,
-            other: true // Ensure the checkbox stays checked when typing
+            [name]: value,
+            ...(name === "otherText" && { other: true }), // Ensure the checkbox stays checked when typing in otherText
+            ...(name === "allergiesText" && { allergies: value.trim() !== "" }) // Checkbox checked if textbox not empty
           },
         },
       }));
@@ -2559,7 +2647,7 @@ const handleMentalHealthConditionsChange = (e: React.ChangeEvent<HTMLInputElemen
 
           {/* Dietary Preferences Section */}
           <SectionBox mb={3}>
-            <SectionTitle sx={{ textAlign: 'left', width: '100%' }}>Dietary Preferences</SectionTitle>
+            <SectionTitle sx={{ textAlign: 'left', width: '100%' }}>Dietary Options</SectionTitle>
             <DietaryPreferencesForm
               isEditing={isEditing}
               fieldLabelStyles={fieldLabelStyles}

--- a/my-app/src/pages/Profile/components/FormField.tsx
+++ b/my-app/src/pages/Profile/components/FormField.tsx
@@ -91,7 +91,7 @@ const CustomTextField = styled(TextField)({
       boxShadow: "0 0 8px rgba(37, 126, 104, 0.4), 0 0 16px rgba(37, 126, 104, 0.2)",
     },
   },
-  "& .MuiInputBase-inputMultiline": {
+  "& .MuiInputBase-inputMultiline, & textarea": {
     backgroundColor: "white",
     width: "100%",
     minHeight: "56px",
@@ -105,7 +105,7 @@ const CustomTextField = styled(TextField)({
     wordWrap: "break-word",
     overflowWrap: "break-word",
     wordBreak: "break-word",
-    resize: "vertical",
+    resize: "vertical !important",
     "&:focus": {
       border: "2px solid #257E68",
       outline: "none",
@@ -663,6 +663,7 @@ const FormField: React.FC<FormFieldProps> = ({
             maxRows={4}
             inputProps={{ minLength: minLengthTextarea }}
             sx={{ minHeight: 120, width: '100%' }}
+            style={{ width: '100%' }}
             disabled={fieldPath === "ward"}
           />
         );

--- a/my-app/src/pages/Profile/components/FormField.tsx
+++ b/my-app/src/pages/Profile/components/FormField.tsx
@@ -212,6 +212,15 @@ const CustomCheckbox = styled(Checkbox)({
       color: "rgba(37, 126, 104, 1)",
     },
   },
+  "&.MuiCheckbox-root .MuiSvgIcon-root": {
+    color: "#257E68",
+  },
+  "&.Mui-checked .MuiSvgIcon-root": {
+    color: "#257E68",
+  },
+  "& .MuiSvgIcon-root": {
+    color: "#257E68",
+  },
 });
 
 const DateFieldComponent = ({
@@ -364,17 +373,24 @@ const FormField: React.FC<FormFieldProps> = ({
           {Object.entries(restrictions)
             .filter(([key, value]) => typeof value === "boolean")
             .map(([key, value]) => (
-              <Grid key={key}>                <FormControlLabel
-                sx={{ textAlign: "left" }}
-                control={
-                  <CustomCheckbox
-                    name={key}
-                    checked={value as boolean}
-                    onChange={handleDietaryRestrictionChange}
-                  />
-                }
-                label={capitalizeFirstLetter(key.replace(/([A-Z])/g, " $1").trim())}
-              />
+              <Grid key={key}>
+                <FormControlLabel
+                  sx={{ textAlign: "left" }}
+                  control={
+                    <CustomCheckbox
+                      name={key}
+                      checked={value as boolean}
+                      onChange={handleDietaryRestrictionChange}
+                  sx={!isEditing ? {
+                    '&.MuiCheckbox-root .MuiSvgIcon-root': { color: '#B6E5D8 !important' },
+                    '&.Mui-checked .MuiSvgIcon-root': { color: '#B6E5D8 !important' },
+                    '& .MuiSvgIcon-root': { color: '#B6E5D8 !important' },
+                  } : {}}
+                      disabled={!isEditing}
+                    />
+                  }
+                  label={capitalizeFirstLetter(key.replace(/([A-Z])/g, " $1").trim())}
+                />
               </Grid>
             ))}
         </Grid>

--- a/my-app/src/pages/Profile/components/HealthCheckbox.tsx
+++ b/my-app/src/pages/Profile/components/HealthCheckbox.tsx
@@ -9,6 +9,7 @@ interface HealthCheckboxProps {
   showOtherText?: boolean;
   otherTextValue?: string;
   placeholder?: string;
+  isEditing?: boolean;
 }
 
 const checkboxStyles = {
@@ -45,16 +46,31 @@ const HealthCheckbox: React.FC<HealthCheckboxProps> = ({
   label,
   showOtherText = false,
   otherTextValue = "",
-  placeholder = "Please specify"
+  placeholder = "Please specify",
+  isEditing = true
 }) => {
+  // Only change color in read-only mode, keep default style
+  const checkboxProps = !isEditing
+    ? {
+      sx: {
+        '&.MuiCheckbox-root .MuiSvgIcon-root': { color: '#B6E5D8 !important' },
+        '&.Mui-checked .MuiSvgIcon-root': { color: '#B6E5D8 !important' },
+        '& .MuiSvgIcon-root': { color: '#B6E5D8 !important' },
+      },
+      disabled: true,
+    }
+    : {
+      sx: checkboxStyles,
+      disabled: false,
+    };
   if (name === "other" && showOtherText) {
     return (
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
         <FormControlLabel
-          control={<Checkbox checked={checked} onChange={onChange} name={name} sx={checkboxStyles} />}
-          label={label}
+          control={<Checkbox checked={checked} onChange={onChange} name={name} {...checkboxProps} />}
+          label={<span style={{ color: 'black' }}>{label}</span>}
         />
-        {checked && (
+        {checked && isEditing && (
           <TextField
             name="otherText"
             value={otherTextValue}
@@ -71,8 +87,8 @@ const HealthCheckbox: React.FC<HealthCheckboxProps> = ({
 
   return (
     <FormControlLabel
-      control={<Checkbox checked={checked} onChange={onChange} name={name} sx={checkboxStyles} />}
-      label={label}
+      control={<Checkbox checked={checked} onChange={onChange} name={name} {...checkboxProps} />}
+      label={<span style={{ color: 'black' }}>{label}</span>}
     />
   );
 };

--- a/my-app/src/pages/Profile/types.ts
+++ b/my-app/src/pages/Profile/types.ts
@@ -10,6 +10,7 @@ export type NestedKeyOf<T> = {
 export type ClientProfileKey =
   | keyof ClientProfile
   | "deliveryDetails.dietaryRestrictions"
+  | "deliveryDetails.dietaryRestrictions.dietaryPreferences"
   | "deliveryDetails.deliveryInstructions"
   | "tefapCert"
   | "famStartDate";

--- a/my-app/src/styles/checkbox-override.css
+++ b/my-app/src/styles/checkbox-override.css
@@ -1,3 +1,7 @@
+/* Globally override checked color for all MUI checkboxes */
+.MuiCheckbox-root .MuiSvgIcon-root {
+  color: #257E68 !important;
+}
 /* Override Material-UI checkbox focus ring globally */
 .MuiCheckbox-root:focus-visible,
 .MuiCheckbox-root.Mui-focusVisible {

--- a/my-app/src/styles/form-field-global.css
+++ b/my-app/src/styles/form-field-global.css
@@ -76,9 +76,6 @@ textarea.error,
 }
 
 /* Fix for double outline on select fields */
-.MuiOutlinedInput-notchedOutline {
-  border: none !important; /* Remove the default MUI outline */
-}
 
 .MuiSelect-select:focus {
   background-color: transparent !important;


### PR DESCRIPTION
The test for this is to see the 3 colors of chips in the dietary options section as well as the profile page has allergies and options as text areas now, the dietary preferences also is a text area with its own subsection, then also all fields are now either read only or editable depending on if you are in read only mode or not. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Profile: Introduced “Dietary Options” with expanded allergies support, an “ALLERGIES” section with text input, an “OTHER” text field, and a new “Dietary Preferences” field. Editing uses streamlined health checkboxes; view mode shows concise summaries.
  - Spreadsheet: Dietary restrictions now display as colored chips (preferences, allergens, other) across table and mobile/card views, with clear “None” when applicable.

- Style
  - Consistent checkbox icon colors.
  - Restored outlined input borders.
  - Improved textarea width and vertical resizing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->