### PR TITLE
TEFAP and Fam Start Dates

### DIFF
--- a/my-app/src/pages/Profile/components/DeliveryInfoForm.tsx
+++ b/my-app/src/pages/Profile/components/DeliveryInfoForm.tsx
@@ -94,18 +94,12 @@ const DeliveryInfoForm: React.FC<DeliveryInfoFormProps> = ({
       <Box
         sx={{
           display: "grid",
-          gap: isEditing ? 3 : 5,
-          gridTemplateColumns: {
-            xs: "1fr",
-            sm: "repeat(2, 1fr)",
-            md: "repeat(3, 1fr)",
-          },
-          alignItems: "flex-start",
+          gridTemplateColumns: '350px 350px 1fr',
         }}
         className="info-grid"
       >
         {/* Start Date */}
-        <Box>
+        <Box sx={{ width: 350 }}>
           <Typography className="field-descriptor" sx={fieldLabelStyles}>
             START DATE <span className="required-asterisk">*</span>
           </Typography>
@@ -128,7 +122,7 @@ const DeliveryInfoForm: React.FC<DeliveryInfoFormProps> = ({
         </Box>
 
         {/* End Date */}
-        <Box>
+        <Box sx={{ width: 350 }}>
           <Typography className="field-descriptor" sx={fieldLabelStyles}>
             END DATE <span className="required-asterisk">*</span>
           </Typography>
@@ -170,20 +164,9 @@ const DeliveryInfoForm: React.FC<DeliveryInfoFormProps> = ({
 
         {/* Delivery Instructions */}
         <Box sx={{ 
-          gridColumn: { xs: '1', sm: 'span 1' },
           width: '100%',
-          '& .MuiTextField-root': {
-            width: '100%',
-            '& .MuiInputBase-root': {
-              minHeight: '56px',
-              height: 'auto',
-              alignItems: 'flex-start',
-            },
-            '& .MuiInputBase-inputMultiline': {
-              minHeight: '80px !important',
-              padding: '16px 14px !important',
-            }
-          }
+          minHeight: '80px',
+          padding: '16px 14px',
         }}>
           <Typography className="field-descriptor" sx={fieldLabelStyles}>
             DELIVERY INSTRUCTIONS
@@ -208,20 +191,9 @@ const DeliveryInfoForm: React.FC<DeliveryInfoFormProps> = ({
 
         {/* Notes */}
         <Box sx={{ 
-          gridColumn: { xs: '1', sm: 'span 1' },
           width: '100%',
-          '& .MuiTextField-root': {
-            width: '100%',
-            '& .MuiInputBase-root': {
-              minHeight: '56px',
-              height: 'auto',
-              alignItems: 'flex-start',
-            },
-            '& .MuiInputBase-inputMultiline': {
-              minHeight: '80px !important',
-              padding: '16px 14px !important',
-            }
-          }
+          minHeight: '80px',
+          padding: '16px 14px',
         }}>
           <Typography className="field-descriptor" sx={fieldLabelStyles}>
             ADMIN NOTES

--- a/my-app/src/pages/Profile/components/MiscellaneousForm.tsx
+++ b/my-app/src/pages/Profile/components/MiscellaneousForm.tsx
@@ -43,7 +43,7 @@ const MiscellaneousForm: React.FC<MiscellaneousFormProps> = ({
           {isEditing ? (
             <Box sx={{ minHeight: 120, width: '100%' }}>{renderField("famStartDate", "date")}</Box>
           ) : (
-            <Typography sx={{ fontWeight: 400, fontSize: '1.15rem', lineHeight: 1, mt: 0, mb: 0, pt: 0, textAlign: 'left', pl: 0 }}>{clientProfile.startDate ? String(clientProfile.startDate) : "N/A"}</Typography>
+            <Typography sx={{ fontWeight: 400, fontSize: '1.15rem', lineHeight: 1, mt: 0, mb: 0, pt: 0, textAlign: 'left', pl: 0 }}>{clientProfile.famStartDate ? String(clientProfile.famStartDate) : "N/A"}</Typography>
           )}
         </Box>
         <Box>

--- a/my-app/src/types/client-types.ts
+++ b/my-app/src/types/client-types.ts
@@ -23,6 +23,7 @@ export interface DeliveryDetails {
 }
 
 export interface ClientProfile {
+  famStartDate?: string | null;
   uid: string;
   firstName: string;
   lastName: string;


### PR DESCRIPTION
This is two stories 

TEFAP date cant be saved if trying to set it in the future
FAM Start Date is saved as famStartDate in the database one mode was reading that and the other was reading startDate, I set it so they both are using famStartDate now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * FAMILY START DATE in the profile now displays the correct value.

* **Style**
  * Delivery Info form updated to a fixed three-column layout for more consistent alignment.
  * Start and End Date fields use fixed widths to match the new layout.
  * Delivery Instructions and Notes now span full width with improved padding and minimum height for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->