### PR TITLE
monthly deliveries should be ever 28 days so they fall on the same da…

### DIFF
--- a/my-app/src/pages/Calendar/components/AddDeliveryDialog.tsx
+++ b/my-app/src/pages/Calendar/components/AddDeliveryDialog.tsx
@@ -418,7 +418,7 @@ const AddDeliveryDialog: React.FC<AddDeliveryDialogProps> = ({
               <MenuItem value="None">None</MenuItem>
               <MenuItem value="Weekly">Weekly</MenuItem>
               <MenuItem value="2x-Monthly">2x-Monthly</MenuItem>
-              <MenuItem value="Monthly">Monthly</MenuItem>
+              <MenuItem value="Monthly">Monthly (Every 4 Weeks)</MenuItem>
               <MenuItem value="Custom">Custom (Select Dates)</MenuItem>
             </Select>
           </FormControl>

--- a/my-app/src/pages/Calendar/components/EventMenu.tsx
+++ b/my-app/src/pages/Calendar/components/EventMenu.tsx
@@ -326,7 +326,7 @@ const EventMenu: React.FC<EventMenuProps> = ({ event, onEventModified }) => {
                   <MenuItem value="None">None</MenuItem>
                   <MenuItem value="Weekly">Weekly</MenuItem>
                   <MenuItem value="2x-Monthly">2x-Monthly</MenuItem>
-                  <MenuItem value="Monthly">Monthly</MenuItem>
+                  <MenuItem value="Monthly">Monthly (Every 4 Weeks)</MenuItem>
                 </Select>
               </FormControl>
 

--- a/my-app/src/pages/Profile/components/FormField.tsx
+++ b/my-app/src/pages/Profile/components/FormField.tsx
@@ -548,7 +548,7 @@ const FormField: React.FC<FormFieldProps> = ({
               <MenuItem key="None" value="None">None</MenuItem>,
               <MenuItem key="Weekly" value="Weekly">Weekly</MenuItem>,
               <MenuItem key="2x-Monthly" value="2x-Monthly">2x-Monthly</MenuItem>,
-              <MenuItem key="Monthly" value="Monthly">Monthly</MenuItem>,
+              <MenuItem key="Monthly" value="Monthly">Monthly (Every 4 Weeks)</MenuItem>,
             ]}
             {fieldPath === "ethnicity" && [
               <MenuItem key="" value="" disabled>Select</MenuItem>,

--- a/my-app/src/utils/timeUtils.ts
+++ b/my-app/src/utils/timeUtils.ts
@@ -222,28 +222,9 @@ export class RecurrenceUtils {
    * Calculate next monthly occurrence handling edge cases like 5th week
    */
   static getNextMonthlyDate(originalDate: DateTime, currentDate: DateTime, targetDay?: number): DateTime {
-    const nextMonth = currentDate.plus({ months: 1 }).startOf('month');
-    const originalWeek = Math.ceil(originalDate.day / 7);
-    const targetWeek = originalWeek > 4 ? -1 : originalWeek; // Handle 5th week as last occurrence
-    const targetWeekday = targetDay ?? originalDate.weekday;
-
-    let targetDate: DateTime;
-
-    if (targetWeek === -1) {
-      // Find last occurrence of target weekday in month
-      targetDate = nextMonth.endOf('month');
-      while (targetDate.weekday !== targetWeekday) {
-        targetDate = targetDate.minus({ days: 1 });
-      }
-    } else {
-      // Find specific week occurrence
-      targetDate = nextMonth.plus({ days: (targetWeek - 1) * 7 });
-      while (targetDate.weekday !== targetWeekday) {
-        targetDate = targetDate.plus({ days: 1 });
-      }
-    }
-
-    return targetDate;
+  // Instead of monthly, schedule every 4 weeks (28 days) from originalDate
+  const nextDate = originalDate.plus({ days: 28 });
+  return nextDate;
   }
 
   /**
@@ -261,9 +242,10 @@ export class RecurrenceUtils {
     }
 
     let currentDate = deliveryDate;
-    const interval = recurrence === 'Weekly' ? { weeks: 1 } : 
-                    recurrence === '2x-Monthly' ? { weeks: 2 } : 
-                    { months: 1 };
+  const interval = recurrence === 'Weekly' ? { weeks: 1 } : 
+          recurrence === '2x-Monthly' ? { weeks: 2 } : 
+          recurrence === 'Monthly' ? { days: 28 } : 
+          { months: 1 };
 
     while (currentDate < endDate) {
       currentDate = currentDate.plus(interval);


### PR DESCRIPTION
…y of the week they were assigned, I also changed the dropdowns to be 'Monthly (Every 4 weeks)' so that it is more clear

Test for this is to assign a delivery on a specific day of the week and use the Monthly (Every 4 weeks) dropdown both on the calendar page and on the profile page to see it assign the next delivery 4 weeks from the day that you assigned it."

So it you assign it on a tuesday the next delivery should be 4 weeks from that tuesday, on a tuesday.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Monthly recurrence now follows a consistent 28-day (4-week) cadence across scheduling, editing, and “this and following events” flows.
  - Other recurrence options (weekly, twice-monthly) remain unchanged.

- Style
  - Updated recurrence selector labels to “Monthly (Every 4 Weeks)” to clarify scheduling behavior in Calendar and Profile forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->