### PR TITLE
On navbar, change delivery to be named routes. Also change page routing for it too.

### DIFF
--- a/my-app/src/__tests__/navigation-bar.test.tsx
+++ b/my-app/src/__tests__/navigation-bar.test.tsx
@@ -23,7 +23,7 @@ describe("Navigation Bar Tests", () => {
     expect(screen.getByText(/clients/i)).toBeInTheDocument();
     expect(screen.getByText(/calendar/i)).toBeInTheDocument();
     expect(screen.getByText(/users/i)).toBeInTheDocument();
-    expect(screen.getByText(/delivery/i)).toBeInTheDocument();
+    expect(screen.getByText(/routes/i)).toBeInTheDocument();
   });
 
   it("renders correct links for Driver", () => {
@@ -35,7 +35,7 @@ describe("Navigation Bar Tests", () => {
     );
     expect(screen.getByText(/clients/i)).toBeInTheDocument();
     expect(screen.getByText(/calendar/i)).toBeInTheDocument();
-    expect(screen.getByText(/delivery/i)).toBeInTheDocument();
+    expect(screen.getByText(/routes/i)).toBeInTheDocument();
     expect(screen.queryByText(/users/i)).not.toBeInTheDocument();
   });
 

--- a/my-app/src/__tests__/route-config.test.tsx
+++ b/my-app/src/__tests__/route-config.test.tsx
@@ -56,7 +56,7 @@ const routesToTest = [
   { path: "/clients", text: /clients/i },
   { path: "/calendar", text: /calendar/i },
   { path: "/users", text: /users/i },
-  { path: "/delivery", text: /delivery/i },
+  { path: "/routes", text: /routes/i },
 ];
 
 describe("Route Config Tests", () => {

--- a/my-app/src/pages/Base/Base.tsx
+++ b/my-app/src/pages/Base/Base.tsx
@@ -120,9 +120,9 @@ export default function BasePage() {
     } else if (currentPath === "/users") {
       setPageTitle("Users");
       setTab("Users");
-    } else if (currentPath === "/delivery") {
-      setPageTitle("Delivery");
-      setTab("Delivery");
+    } else if (currentPath === "/routes") {
+      setPageTitle("Routes");
+      setTab("Routes");
     } else if (currentPath.startsWith("/reports")) {
       // Handle reports routes
       if (currentPath === "/reports/summary") {
@@ -172,7 +172,7 @@ export default function BasePage() {
   const navItems = useMemo(() => {
     const items = [...baseNavItems];
 
-    items.push({ text: "Delivery", icon: <LocalShippingIcon />, link: "/delivery" });
+    items.push({ text: "Routes", icon: <LocalShippingIcon />, link: "/routes" });
 
     if (userRole === UserType.Admin || userRole === UserType.Manager) {
       items.push({ text: "Users", icon: <AddCircleIcon />, link: "/users" });

--- a/my-app/src/routesConfig.tsx
+++ b/my-app/src/routesConfig.tsx
@@ -64,9 +64,9 @@ export const routesConfig: AppRoute[] = [
         meta: { title: "Profile", description: "Client profile page", icon: "person" },
       },
       {
-        path: "delivery",
+        path: "routes",
         element: <DeliverySpreadsheet />,
-        meta: { title: "Delivery", description: "Delivery management", icon: "local_shipping" },
+        meta: { title: "Routes", description: "Route management", icon: "local_shipping" },
       },
       {
         path: "reports/summary",


### PR DESCRIPTION
On navbar, change delivery to be named routes. Also change page routing for it too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Renamed “Delivery” to “Routes” across the app.
  - Updated route path from /delivery to /routes.
  - Adjusted navigation drawer/menu item, page title, and route metadata (title/description) to match “Routes”.
  - Existing icon and underlying behavior remain unchanged.

- Tests
  - Updated navigation and route configuration tests to expect “Routes” and /routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->