### PR TITLE
Jamie/delivery date fixes

### DIFF
--- a/my-app/src/App.tsx
+++ b/my-app/src/App.tsx
@@ -1,4 +1,6 @@
 import React, { Suspense } from "react";
+import { LocalizationProvider } from '@mui/x-date-pickers';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import "./App.css";
 
@@ -54,15 +56,17 @@ function App() {
 
   return (
     <ErrorBoundary>
-      <Router>
-        <AutoLogout></AutoLogout>
-        <Suspense fallback={<LoadingIndicator />}>
-          <Routes>
-            {renderRoutes(routesConfig)}
-            <Route path="*" element={<NotFoundPage />} />
-          </Routes>
-        </Suspense>
-      </Router>
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <Router>
+          <AutoLogout />
+          <Suspense fallback={<LoadingIndicator />}>
+            <Routes>
+              {renderRoutes(routesConfig)}
+              <Route path="*" element={<NotFoundPage />} />
+            </Routes>
+          </Suspense>
+        </Router>
+      </LocalizationProvider>
     </ErrorBoundary>
   );
 }

--- a/my-app/src/pages/Calendar/components/AddDeliveryDialog.tsx
+++ b/my-app/src/pages/Calendar/components/AddDeliveryDialog.tsx
@@ -193,7 +193,7 @@ const AddDeliveryDialog: React.FC<AddDeliveryDialogProps> = ({
   }, [uniqueClients]);
 
   return (
-  <Dialog open={open} onClose={resetFormAndClose} maxWidth="sm" fullWidth className="add-delivery-modal-root">
+  <Dialog open={open} onClose={resetFormAndClose} maxWidth="sm" fullWidth className="add-delivery-modal-root" sx={{ top: '-35px' }}>
       <DialogTitle>Add Delivery</DialogTitle>
       {/* Shrink only DatePicker popups from this modal */}
       <GlobalStyles styles={{

--- a/my-app/src/pages/Calendar/components/AddDeliveryDialog.tsx
+++ b/my-app/src/pages/Calendar/components/AddDeliveryDialog.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import {
+  GlobalStyles,
   Dialog,
   DialogTitle,
   DialogContent,
@@ -71,6 +72,18 @@ const AddDeliveryDialog: React.FC<AddDeliveryDialogProps> = ({
   const [customDates, setCustomDates] = useState<Date[]>([]);
   const [startDateError, setStartDateError] = useState<string>("");
   const [endDateError, setEndDateError] = useState<string>("");
+
+  // Toggle body class for modal open state to control DatePicker popup scaling
+  useEffect(() => {
+    if (open) {
+      document.body.classList.add('add-delivery-modal-open');
+    } else {
+      document.body.classList.remove('add-delivery-modal-open');
+    }
+    return () => {
+      document.body.classList.remove('add-delivery-modal-open');
+    };
+  }, [open]);
 
   // Validate date range whenever delivery date or end date changes
   useEffect(() => {
@@ -180,8 +193,15 @@ const AddDeliveryDialog: React.FC<AddDeliveryDialogProps> = ({
   }, [uniqueClients]);
 
   return (
-    <Dialog open={open} onClose={resetFormAndClose} maxWidth="sm" fullWidth>
+  <Dialog open={open} onClose={resetFormAndClose} maxWidth="sm" fullWidth className="add-delivery-modal-root">
       <DialogTitle>Add Delivery</DialogTitle>
+      {/* Shrink only DatePicker popups from this modal */}
+      <GlobalStyles styles={{
+        'body.add-delivery-modal-open [class*="MuiPaper-root"][class*="MuiPickerPopper-paper"]': {
+          transform: 'scale(0.8) !important',
+          transformOrigin: 'right top !important',
+        }
+      }} />
       <DialogContent sx={{ maxHeight: '70vh', overflowY: 'auto', overflowX: 'hidden' }}>
         {/* Unified layout for all fields */}
         <Box display="flex" flexDirection="column" gap={2}>
@@ -430,31 +450,47 @@ const AddDeliveryDialog: React.FC<AddDeliveryDialogProps> = ({
           </FormControl>
         </Box>
         {newDelivery.recurrence === "Custom" ? (
-          <CalendarMultiSelect selectedDates={customDates} setSelectedDates={setCustomDates} />
-        ) : null}
-
-        {newDelivery.recurrence !== "None" && newDelivery.recurrence !== "Custom" ? (     
           <>
-            <Box>
-              <Typography variant="subtitle1">End Date</Typography>
-              <DateField
-                label="End Date"
-                value={newDelivery.repeatsEndDate || ""}
-                onChange={(dateStr) => setNewDelivery({
-                  ...newDelivery,
-                  repeatsEndDate: dateStr,
-                  _repeatsEndDateError: undefined,
-                })}
-                required={true}
-                error={newDelivery._repeatsEndDateError}
-                setError={(errorMsg) => setNewDelivery(prev => ({
-                  ...prev,
-                  _repeatsEndDateError: errorMsg || undefined
-                }))}
-              />
+            <Box display="flex" alignItems="center" justifyContent="space-between" sx={{ width: '100%', m: 0, p: 0 }}>
+              <Typography variant="body1" sx={{ m: 0, p: 0 }}>
+                Select Custom Dates
+              </Typography>
+              <Typography sx={{ fontSize: '0.87rem', fontWeight: 400, m: 0, p: 0 }}>
+                Current End Date - {newDelivery.repeatsEndDate || "N/A"}
+              </Typography>
             </Box>
+            <CalendarMultiSelect 
+              selectedDates={customDates} 
+              setSelectedDates={setCustomDates} 
+              endDate={newDelivery.repeatsEndDate ? new Date(newDelivery.repeatsEndDate) : new Date()} 
+            />
+          </>
+        ) : (
+          <Box display="flex" justifyContent="flex-end" alignItems="center" sx={{ m: 0, p: 0 }}>
+            <Typography sx={{ fontSize: '0.87rem', fontWeight: 400, m: 0, p: 0 }}>
+              Current End Date - {newDelivery.repeatsEndDate || "N/A"}
+            </Typography>
+          </Box>
+        )}
+        {newDelivery.recurrence !== "None" && newDelivery.recurrence !== "Custom" ? (
+          <>
+            <DateField
+              label="End Date"
+              value={newDelivery.repeatsEndDate || ""}
+              onChange={(dateStr) => setNewDelivery({
+                ...newDelivery, 
+                repeatsEndDate: dateStr,
+                _repeatsEndDateError: undefined,
+              })}
+              required={true}
+              error={newDelivery._repeatsEndDateError}
+              setError={(errorMsg) => setNewDelivery(prev => ({
+                ...prev,
+                _repeatsEndDateError: errorMsg || undefined
+              }))}
+            />
             <Typography sx={{color:"red"}}>{endDateError}</Typography>
-          </>    
+          </>
         ) : null}
       </DialogContent>
       <DialogActions>
@@ -462,7 +498,13 @@ const AddDeliveryDialog: React.FC<AddDeliveryDialogProps> = ({
         <Button
           onClick={handleSubmit}
           variant="contained"
-          disabled={!isFormValid}
+          disabled={
+            !isFormValid || (
+              newDelivery.deliveryDate !== undefined && newDelivery.repeatsEndDate !== undefined &&
+              newDelivery.deliveryDate !== "" && newDelivery.repeatsEndDate !== "" &&
+              new Date(newDelivery.deliveryDate) > new Date(newDelivery.repeatsEndDate)
+            )
+          }
         >
           Add
         </Button>

--- a/my-app/src/pages/Profile/Profile.tsx
+++ b/my-app/src/pages/Profile/Profile.tsx
@@ -2666,6 +2666,12 @@ const handleMentalHealthConditionsChange = (e: React.ChangeEvent<HTMLInputElemen
                 clientName: `${clientProfile.firstName} ${clientProfile.lastName}`,
                 clientProfile: clientProfile
               }}
+              // Pass customDates, setCustomDates, and endDate props if needed for modal logic
+              // These should be managed in Profile state, similar to Calendar page
+              // Example:
+              // customDates={customDates}
+              // setCustomDates={setCustomDates}
+              // endDate={repeatsEndDate ? new Date(repeatsEndDate) : new Date()}
             />
            <DeliveryLogForm
               pastDeliveries={pastDeliveries}


### PR DESCRIPTION
Checks here are to check the following on the Add Delivery Modals for both the Calendar page and the Profile Page

- Should have a "Current Last Date" with the display of the date per Client
- None of the delivery options should allow a delivery for if it is past the current last date
- If you change the last date then deliveries will be allowed past the text field that says current last date but not past the last date you change it to
- Add button is disabled if you attempt to add a delivery past the current last date and error message is displayed
- I had to change the calendar type to use the MUI Date Picker instead of the HTML 5 Calendar to fix the Custom Dates from adding chips as you scroll because HTML 5 would not differentiate between clicking on the scroll arrow vs an actual date, the MUI Date Picker does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Date localization enabled across the app’s date inputs and pickers.
  - Add Delivery: supports opening with a pre-selected client.

- Improvements
  - Add Delivery dialog refreshed: clearer end-date display, custom date selection with inline chips, and chronologically sorted selections.
  - Prevent selecting dates beyond the chosen end date with immediate, inline feedback.
  - Delivery date auto-prefills from the selected start date when opening the dialog.
  - Smoother modal behavior and refined popup sizing for a cleaner experience.

- Documentation
  - Added inline comments clarifying potential Add Delivery props in Profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->