### PR TITLE
removed the filtering from the calendar page, cleaned up the bad data…

### DIFF
--- a/my-app/src/pages/Base/Base.tsx
+++ b/my-app/src/pages/Base/Base.tsx
@@ -19,6 +19,7 @@ import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
 import StorageIcon from "@mui/icons-material/Storage";
 import AddCircleIcon from "@mui/icons-material/AddCircle";
 import LogoutIcon from "@mui/icons-material/Logout";
+import DeleteIcon from "@mui/icons-material/Delete";
 import LocalShippingIcon from "@mui/icons-material/LocalShipping";
 import AssessmentIcon from "@mui/icons-material/Assessment";
 import Tab from "./NavBar/Tab";
@@ -175,6 +176,12 @@ export default function BasePage() {
     const items = [...baseNavItems];
 
     items.push({ text: "Routes", icon: <LocalShippingIcon />, link: "/routes" });
+
+    // Add Delivery Date Conversion page
+    items.push({ text: "Delivery Date Conversion", icon: <CalendarTodayIcon />, link: "/delivery-date-conversion" });
+
+    // Add Cleanup Delivery Data page
+    items.push({ text: "Cleanup Delivery Data", icon: <DeleteIcon />, link: "/cleanup-delivery-data" });
 
     if (userRole === UserType.Admin || userRole === UserType.Manager) {
       items.push({ text: "Users", icon: <AddCircleIcon />, link: "/users" });

--- a/my-app/src/pages/Base/Base.tsx
+++ b/my-app/src/pages/Base/Base.tsx
@@ -177,11 +177,7 @@ export default function BasePage() {
 
     items.push({ text: "Routes", icon: <LocalShippingIcon />, link: "/routes" });
 
-    // Add Delivery Date Conversion page
-    items.push({ text: "Delivery Date Conversion", icon: <CalendarTodayIcon />, link: "/delivery-date-conversion" });
 
-    // Add Cleanup Delivery Data page
-    items.push({ text: "Cleanup Delivery Data", icon: <DeleteIcon />, link: "/cleanup-delivery-data" });
 
     if (userRole === UserType.Admin || userRole === UserType.Manager) {
       items.push({ text: "Users", icon: <AddCircleIcon />, link: "/users" });

--- a/my-app/src/pages/Calendar/components/getEventsByViewType.ts
+++ b/my-app/src/pages/Calendar/components/getEventsByViewType.ts
@@ -1,0 +1,77 @@
+import { DayPilot } from "@daypilot/daypilot-lite-react";
+import { DateTime } from "luxon";
+import { TimeUtils } from "../../../utils/timeUtils";
+import DeliveryService from "../../../services/delivery-service";
+import { toDayPilotDateString } from '../../../utils/timestamp';
+import { ViewType, DeliveryEvent } from "../../../types/calendar-types";
+import { ClientProfile } from "../../../types/client-types";
+
+export async function getEventsByViewType({
+  viewType,
+  currentDate,
+  clients
+}: {
+  viewType: ViewType;
+  currentDate: DayPilot.Date;
+  clients: ClientProfile[];
+}) {
+  let start = new DayPilot.Date(currentDate);
+  let endDate;
+
+  switch (viewType) {
+    case "Month": {
+      const monthStart = currentDate.firstDayOfMonth();
+      const monthEnd = currentDate.lastDayOfMonth();
+      const monthStartLuxon = TimeUtils.fromJSDate(monthStart.toDate());
+      const monthEndLuxon = TimeUtils.fromJSDate(monthEnd.toDate());
+      const gridStart = monthStartLuxon.startOf('week').toJSDate();
+      const gridEnd = monthEndLuxon.endOf('week').toJSDate();
+      const extendedStart = TimeUtils.fromJSDate(gridStart).minus({ weeks: 2 }).toJSDate();
+      const extendedEnd = TimeUtils.fromJSDate(gridEnd).plus({ weeks: 2 }).toJSDate();
+      start = new DayPilot.Date(extendedStart);
+      endDate = new DayPilot.Date(extendedEnd);
+      break;
+    }
+    case "Day": {
+      const easternZone = 'America/New_York';
+      const selectedDateStr = currentDate.toString("yyyy-MM-dd");
+      const selectedLuxon = DateTime.fromISO(selectedDateStr, { zone: easternZone }).startOf('day');
+      const nextDayLuxon = selectedLuxon.plus({ days: 1 });
+      start = new DayPilot.Date(selectedLuxon.toJSDate());
+      endDate = new DayPilot.Date(nextDayLuxon.toJSDate());
+      break;
+    }
+    default:
+      endDate = start.addDays(1);
+  }
+
+  const deliveryService = DeliveryService.getInstance();
+  const fetchedEvents = await deliveryService.getEventsByDateRange(
+    start.toDate(),
+    endDate.toDate()
+  );
+
+  // Update client names in events if client exists, but do not filter out any events
+  const updatedEvents = fetchedEvents.map(event => {
+  const client = clients.find((client: ClientProfile) => client.uid === event.clientId);
+    if (client) {
+      const fullName = `${client.firstName} ${client.lastName}`.trim();
+      return {
+        ...event,
+        clientName: fullName
+      };
+    }
+    return event;
+  });
+
+  // Format for calendar config if needed
+  const formattedEvents = updatedEvents.map(event => ({
+    id: event.id,
+    text: `Client: ${event.clientName} (Driver: ${event.assignedDriverName})`,
+    start: new DayPilot.Date(toDayPilotDateString(event.deliveryDate)),
+    end: new DayPilot.Date(toDayPilotDateString(event.deliveryDate)),
+    backColor: "#257E68",
+  }));
+
+  return { updatedEvents, formattedEvents };
+}

--- a/my-app/src/pages/Delivery/ClusterMap.tsx
+++ b/my-app/src/pages/Delivery/ClusterMap.tsx
@@ -146,7 +146,7 @@ const ClusterMap: React.FC<ClusterMapProps> = ({ visibleRows, clusters, clientOv
       }
 
       const data = await response.json();
-      console.log('Fetched ward boundaries:', data);
+      //console.log('Fetched ward boundaries:', data);
       setWardData(data);
       return data;
     } catch (error) {

--- a/my-app/src/pages/Profile/Profile.tsx
+++ b/my-app/src/pages/Profile/Profile.tsx
@@ -1329,7 +1329,25 @@ const checkDuplicateClient = async (firstName: string, lastName: string, address
     }
   };
 
-  // Updated field label styles for a more modern look
+  // Helper to set time to 12:00:00 PM
+function setToNoon(date: any) {
+  let jsDate;
+  if (typeof date === 'string') {
+    jsDate = new Date(date);
+  } else if (date instanceof Date) {
+    jsDate = new Date(date.getTime());
+  } else if (date && typeof date.toDate === 'function') {
+    jsDate = new Date(date.toDate().getTime());
+  } else if (date && typeof date.toJSDate === 'function') {
+    jsDate = new Date(date.toJSDate().getTime());
+  } else {
+    jsDate = new Date(date);
+  }
+  jsDate.setHours(12, 0, 0, 0);
+  return jsDate;
+}
+
+// Updated field label styles for a more modern look
   const fieldLabelStyles = {
     fontWeight: 600,
     marginBottom: !isEditing ? "12px" : "8px",
@@ -1523,7 +1541,6 @@ if (type === "physicalAilments") {
               </Typography>
             )}
           </Box>
-{/* ...existing code... */}
 
           {/* Other title and text box */}
           <Box sx={{ width: '100%' }}>
@@ -2344,24 +2361,21 @@ const handleMentalHealthConditionsChange = (e: React.ChangeEvent<HTMLInputElemen
     const handleAddDelivery = async (newDelivery: NewDelivery) => {
       try {
         let recurrenceDates: Date[] = [];
-  
         //create unique id for each recurrence group. All events for this recurrence will have the same id
         const recurrenceId = crypto.randomUUID();
         if (newDelivery.recurrence === "Custom") {
           // Use customDates directly if recurrence is Custom
           // Ensure customDates exist and map string dates back to Date objects
           recurrenceDates = newDelivery.customDates?.map(dateStr => {
-            const date = new Date(dateStr);
-            // Adjust for timezone offset if needed, similar to how it might be handled elsewhere
-            return new Date(date.getTime() + date.getTimezoneOffset() * 60000);
+            return setToNoon(dateStr);
           }) || [];
           // Clear repeatsEndDate explicitly for custom recurrence in the submitted data
           newDelivery.repeatsEndDate = undefined;
         } else {
           // Calculate recurrence dates for standard recurrence types
-          const deliveryDate = new Date(newDelivery.deliveryDate);
+          const deliveryDate = setToNoon(newDelivery.deliveryDate);
           recurrenceDates =
-            newDelivery.recurrence === "None" ? [deliveryDate] : calculateRecurrenceDates(newDelivery);
+            newDelivery.recurrence === "None" ? [deliveryDate] : calculateRecurrenceDates(newDelivery).map(setToNoon);
         }
   
         // Filter out dates that already have a delivery for the same client

--- a/my-app/src/routesConfig.tsx
+++ b/my-app/src/routesConfig.tsx
@@ -3,8 +3,6 @@ import React from 'react';
 import Login from "./pages/Login/Login";
 import ForgotPasswordPage from "./pages/Login/forgot-password";
 import CalendarPage from "./pages/Calendar/CalendarPage";
-import DeliveryDateConversionPage from "./pages/DeliveryDateConversionPage";
-import CleanupDeliveryDataPage from "./pages/CleanupDeliveryDataPage";
 import Spreadsheet from "./components/Spreadsheet/Spreadsheet";
 import UsersSpreadsheet from "./components/UsersSpreadsheet/UsersSpreadsheet";
 import Profile from "./pages/Profile/Profile";

--- a/my-app/src/routesConfig.tsx
+++ b/my-app/src/routesConfig.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import Login from "./pages/Login/Login";
 import ForgotPasswordPage from "./pages/Login/forgot-password";
 import CalendarPage from "./pages/Calendar/CalendarPage";
+import DeliveryDateConversionPage from "./pages/DeliveryDateConversionPage";
+import CleanupDeliveryDataPage from "./pages/CleanupDeliveryDataPage";
 import Spreadsheet from "./components/Spreadsheet/Spreadsheet";
 import UsersSpreadsheet from "./components/UsersSpreadsheet/UsersSpreadsheet";
 import Profile from "./pages/Profile/Profile";

--- a/my-app/src/services/delivery-service.ts
+++ b/my-app/src/services/delivery-service.ts
@@ -72,11 +72,11 @@ class DeliveryService {
   public async getEventsByDateRange(startDate: Date, endDate: Date): Promise<DeliveryEvent[]> {
     try {
       return await retry(async () => {
-        // Always use start of day for startDate and end of day for endDate
-        const startDateTime = TimeUtils.fromJSDate(startDate).startOf('day');
-        const endDateTime = TimeUtils.fromJSDate(endDate).endOf('day');
-        const startTimestamp = Time.Firebase.toTimestamp(startDateTime);
-        const endTimestamp = Time.Firebase.toTimestamp(endDateTime);
+  // Use start of day for startDate and start of day for endDate (exclusive)
+  const startDateTime = TimeUtils.fromJSDate(startDate).startOf('day');
+  const endDateTime = TimeUtils.fromJSDate(endDate).startOf('day');
+  const startTimestamp = Time.Firebase.toTimestamp(startDateTime);
+  const endTimestamp = Time.Firebase.toTimestamp(endDateTime);
         // ...existing code...
         const q = query(
           collection(this.db, this.eventsCollection),


### PR DESCRIPTION
…, updated all events to use 12pm on the delivery date, prevented users from being allowed to assigne a client more than one delievery a day, and ensureed when new delieveries are made the time assigned is 12pm


The verification is to view that the calendar is the same with number of delieveries for day/month and on the delieveries page

Check that you cant enter a client a new delievery on the same day if he already has one
View the data to ensure when you enter a new delievery it sets the time as 12PM