### PR TITLE
End Date Fixes

### DIFF
--- a/my-app/src/pages/Profile/Profile.tsx
+++ b/my-app/src/pages/Profile/Profile.tsx
@@ -427,15 +427,76 @@ const Profile = () => {
           const q = query(
             eventsRef,
             where("clientId", "==", clientId),
-            orderBy("deliveryDate", "desc"),
-            limit(1)
+            orderBy("deliveryDate", "desc")
           );
           const querySnapshot = await getDocs(q);
 
           if (!querySnapshot.empty) {
-            const lastEvent = querySnapshot.docs[0].data();
-            const deliveryDate = lastEvent.deliveryDate.toDate();
-            setLastDeliveryDate(deliveryDate.toISOString().split("T")[0]);
+            let latestEndDateString: string | null = null;
+            
+            // Group events by series to find the most recently created delivery series
+            const seriesMap = new Map<string, any[]>();
+            
+            querySnapshot.forEach((doc) => {
+              const eventData = doc.data();
+              const recurrenceId = eventData.recurrenceId || 'single-' + doc.id;
+              
+              if (!seriesMap.has(recurrenceId)) {
+                seriesMap.set(recurrenceId, []);
+              }
+              seriesMap.get(recurrenceId)!.push({...eventData, docId: doc.id});
+            });
+
+            // Find the most recently created delivery series based on seriesStartDate
+            let mostRecentSeriesEndDate: string | null = null;
+            let mostRecentSeriesStartDate: string | null = null;
+
+            for (const [recurrenceId, events] of seriesMap.entries()) {
+              const firstEvent = events[0];
+              
+              // Get the series start date to determine which series is most recent
+              let seriesStartDate: string | null = null;
+              if (firstEvent.seriesStartDate) {
+                seriesStartDate = firstEvent.seriesStartDate;
+              } else if (firstEvent.deliveryDate) {
+                const deliveryDate = firstEvent.deliveryDate.toDate();
+                if (!isNaN(deliveryDate.getTime())) {
+                  seriesStartDate = deliveryDate.toISOString().split("T")[0];
+                }
+              }
+              
+              if (seriesStartDate) {
+                // If this series is more recent than our current most recent, use it
+                if (!mostRecentSeriesStartDate || seriesStartDate > mostRecentSeriesStartDate) {
+                  mostRecentSeriesStartDate = seriesStartDate;
+                  
+                  // For this series, get the end date
+                  if (firstEvent.repeatsEndDate) {
+                    const endDate = new Date(firstEvent.repeatsEndDate);
+                    if (!isNaN(endDate.getTime())) {
+                      mostRecentSeriesEndDate = endDate.toISOString().split("T")[0];
+                    }
+                  } else if (firstEvent.recurrence === "None" && firstEvent.deliveryDate) {
+                    // For single deliveries, the end date is the delivery date itself
+                    const deliveryDate = firstEvent.deliveryDate.toDate();
+                    if (!isNaN(deliveryDate.getTime())) {
+                      mostRecentSeriesEndDate = deliveryDate.toISOString().split("T")[0];
+                    }
+                  }
+                }
+              }
+            }
+
+            latestEndDateString = mostRecentSeriesEndDate;
+
+            if (latestEndDateString) {
+              setLastDeliveryDate(latestEndDateString);
+            } else {
+              // Fallback to most recent delivery date if no end dates found
+              const lastEvent = querySnapshot.docs[0].data();
+              const deliveryDate = lastEvent.deliveryDate.toDate();
+              setLastDeliveryDate(deliveryDate.toISOString().split("T")[0]);
+            }
           } else {
             setLastDeliveryDate("No deliveries found");
           }


### PR DESCRIPTION
The Last Delivery Date now matces End Date on the Profile Page modal and the Day Calendar modal where you edit.

It uses the Event's repeatsEndDate for the profile in question, if the profile only has a one off single delivery it uses the delivery date for that single delivery instead as the "end date"  