### PR TITLE
Jamie/search filter bug

### DIFF
--- a/my-app/src/components/Spreadsheet/Spreadsheet.tsx
+++ b/my-app/src/components/Spreadsheet/Spreadsheet.tsx
@@ -68,6 +68,7 @@ import DeliveryService from "../../services/delivery-service";
 import { exportQueryResults, exportAllClients } from "./export";
 import "./Spreadsheet.css";
 import DeleteClientModal from "./DeleteClientModal";
+import { getLastDeliveryDateForClient } from "../../utils/lastDeliveryDate";
 
 // Define TypeScript types for row data
 export interface RowData {
@@ -114,10 +115,17 @@ export interface RowData {
   dob?: string;
   ward?: string;
   zipCode?: string;
+  lastDeliveryDate?: string;
 }
 // Place helper functions after RowData type and StyleChip definition
 function getCustomColumnValue(row: RowData, propertyKey: string): string {
   if (!propertyKey || propertyKey === "none") return "";
+  
+  // Handle lastDeliveryDate (computed field, return empty for editing)
+  if (propertyKey === "lastDeliveryDate") {
+    return row.lastDeliveryDate || "";
+  }
+  
   if (propertyKey.includes(".")) {
     const keys = propertyKey.split(".");
     let value: any = row;
@@ -131,8 +139,35 @@ function getCustomColumnValue(row: RowData, propertyKey: string): string {
   return val !== undefined && val !== null ? val.toString() : "";
 }
 
+// Component to handle async loading of last delivery date
+const LastDeliveryDateCell: React.FC<{ clientId: string }> = ({ clientId }) => {
+  const [lastDeliveryDate, setLastDeliveryDate] = useState<string>("Loading...");
+
+  useEffect(() => {
+    let isMounted = true;
+    getLastDeliveryDateForClient(clientId).then((date) => {
+      if (isMounted) {
+        setLastDeliveryDate(date || "No deliveries");
+      }
+    }).catch(() => {
+      if (isMounted) {
+        setLastDeliveryDate("Error");
+      }
+    });
+    return () => { isMounted = false; };
+  }, [clientId]);
+
+  return <span>{lastDeliveryDate}</span>;
+};
+
 function getCustomColumnDisplay(row: RowData, propertyKey: string): React.ReactNode {
   if (!propertyKey || propertyKey === "none") return "N/A";
+  
+  // Handle lastDeliveryDate (async computed field)
+  if (propertyKey === "lastDeliveryDate") {
+    return <LastDeliveryDateCell clientId={row.uid} />;
+  }
+  
   // Handle referralEntity (object)
   if (propertyKey === "referralEntity" && row.referralEntity) {
     const entity = row.referralEntity;
@@ -1235,12 +1270,14 @@ const Spreadsheet: React.FC = () => {
                               if (key === "gender") label = "Gender";
                               if (key === "language") label = "Language";
                               if (key === "notes") label = "Notes";
+                              if (key === "phone") label = "Phone";
                               if (key === "referralEntity") label = "Referral Entity";
                               if (key === "tefapCert") label = "TEFAP Cert";
                               if (key === "tags") label = "Tags";
                               if (key === "dob") label = "DOB";
                               if (key === "ward") label = "Ward";
                               if (key === "zipCode") label = "Zip Code";
+                              if (key === "lastDeliveryDate") label = "Last Delivery Date";
                               return <MenuItem key={key} value={key}>{label}</MenuItem>;
                             })}
                           </Select>

--- a/my-app/src/components/Spreadsheet/export.tsx
+++ b/my-app/src/components/Spreadsheet/export.tsx
@@ -83,11 +83,13 @@ export const exportQueryResults = (rows: RowData[], customColumns: Array<{id: st
                         case "gender": return "Gender";
                         case "language": return "Language";
                         case "notes": return "Notes";
+                        case "phone": return "Phone";
                         case "referralEntity": return "Referral Entity";
                         case "tefapCert": return "TEFAP Cert";
                         case "tags": return "Tags";
                         case "dob": return "Date of Birth";
                         case "ward": return "Ward";
+                        case "lastDeliveryDate": return "Last Delivery Date";
                         default: return propertyKey.charAt(0).toUpperCase() + propertyKey.slice(1);
                     }
                 };
@@ -98,6 +100,9 @@ export const exportQueryResults = (rows: RowData[], customColumns: Array<{id: st
                 if (col.propertyKey === 'referralEntity' && value) {
                     // Handle referralEntity object specially
                     baseData[columnLabel] = `${value.name || 'N/A'}, ${value.organization || 'N/A'}`;
+                } else if (col.propertyKey === 'lastDeliveryDate') {
+                    // Handle lastDeliveryDate specially - it might be computed asynchronously
+                    baseData[columnLabel] = value || "Loading...";
                 } else if (Array.isArray(value)) {
                     // Handle arrays (like tags)
                     baseData[columnLabel] = value.join(", ");

--- a/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.tsx
+++ b/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.tsx
@@ -28,6 +28,12 @@ import {
 } from "@mui/material";
 import { onAuthStateChanged } from "firebase/auth";
 import React, { useEffect, useState, useCallback, useMemo } from "react";
+import {
+  parseSearchTermsProgressively,
+  checkStringContains,
+  isPartialFieldName,
+  extractKeyValue
+} from "../../utils/searchFilter";
 import { useNavigate } from "react-router-dom";
 import { auth } from "../../auth/firebaseConfig";
 import { authUserService } from "../../services/AuthUserService";
@@ -269,109 +275,33 @@ const UsersSpreadsheet: React.FC<UsersSpreadsheetProps> = ({ onAuthStateChangedO
     setCreateModalOpen(true);
   };
 
-  // Advanced search logic with progressive filtering
   const safeSortedRows = Array.isArray(sortedRows) ? sortedRows : [];
   const visibleRows = safeSortedRows.filter((row) => {
     const trimmedSearchQuery = searchQuery.trim();
-    
-    //if search is empty then show all rows
     if (!trimmedSearchQuery) {
       return true;
     }
 
-    //parse search terms progressively - extract complete quoted terms and partial terms
-    const searchTerms = [];
-    let inQuote = false;
-    let quoteChar = '';
-    let currentTerm = '';
-    
-    for (let i = 0; i < trimmedSearchQuery.length; i++) {
-      const char = trimmedSearchQuery[i];
-      
-      if (!inQuote && (char === '"' || char === "'")) {
-        // Starting a quoted term - save any existing unquoted term first
-        if (currentTerm.trim()) {
-          searchTerms.push(currentTerm.trim());
-          currentTerm = '';
-        }
-        inQuote = true;
-        quoteChar = char;
-        // Don't include the quote character in the term
-      } else if (inQuote && char === quoteChar) {
-        // Ending a quoted term
-        if (currentTerm.trim()) {
-          searchTerms.push(currentTerm.trim());
-        }
-        currentTerm = '';
-        inQuote = false;
-        quoteChar = '';
-        // Don't include the closing quote character
-      } else if (!inQuote && char === ' ') {
-        // Space outside quotes - end current term
-        if (currentTerm.trim()) {
-          searchTerms.push(currentTerm.trim());
-          currentTerm = '';
-        }
-      } else {
-        // Regular character (including characters inside quotes) - add to current term
-        currentTerm += char;
-      }
-    }
-    
-    // Add any remaining term (including partial quoted terms)
-    if (currentTerm.trim()) {
-      searchTerms.push(currentTerm.trim());
-    }
-    
-    //filter out empty terms and lone quote marks
-    const validSearchTerms = searchTerms.filter(term => {
-      return term.length > 0 && term !== '"' && term !== "'";
-    });
-
-    //if no valid search terms, show all rows
+    const validSearchTerms = parseSearchTermsProgressively(trimmedSearchQuery);
     if (validSearchTerms.length === 0) {
       return true;
     }
 
-    //function to check if a value contains the search query string
-    const checkStringContains = (value: any, query: string): boolean => {
-      if (value === undefined || value === null) {
-        return false;
-      }
-      return String(value).toLowerCase().includes(query.toLowerCase());
-    };
-
     return validSearchTerms.every(term => {
-      //check if this is a key:value search
-      const colonIndex = term.indexOf(':');
-      let isKeyValueSearch = false;
-      let keyword = "";
-      let searchValue = "";
+      const { keyword, searchValue, isKeyValue: isKeyValueSearch } = extractKeyValue(term);
 
-      if (colonIndex !== -1) {
-        keyword = term.substring(0, colonIndex).trim().toLowerCase();
-        searchValue = term.substring(colonIndex + 1).trim();
-        isKeyValueSearch = true; // Even if searchValue is empty, it's still a key:value attempt
-      } else {
-        // Check if this term looks like a partial key (common field names for users)
-        const lowerTerm = term.toLowerCase();
-        const isPartialKey = [
-          'name', 'role', 'phone', 'email'
-        ].some(fieldName => fieldName.startsWith(lowerTerm) || lowerTerm.startsWith(fieldName.substring(0, Math.min(3, fieldName.length))));
-        
-        if (isPartialKey) {
-          // This looks like someone typing a field name, show all rows until they add a colon
+      if (!isKeyValueSearch) {
+        const userFieldNames = ['name', 'role', 'phone', 'email'];
+        if (isPartialFieldName(term, userFieldNames)) {
           return true;
         }
       }
 
       if (isKeyValueSearch) {
-        //if no search value yet (just typing the key), show all rows (waiting for value)
         if (!searchValue) {
           return true;
         }
 
-        //key value search logic with actual value
         switch (keyword) {
           case "name":
             return checkStringContains(row.name, searchValue);
@@ -382,21 +312,16 @@ const UsersSpreadsheet: React.FC<UsersSpreadsheetProps> = ({ onAuthStateChangedO
           case "email":
             return checkStringContains(row.email, searchValue);
           default:
-            //if unknown key, do global search with the searchValue
             return checkStringContains(row.name, searchValue) ||
                    checkStringContains(getRoleDisplayName(row.role), searchValue) ||
                    checkStringContains(row.phone, searchValue) ||
                    checkStringContains(row.email, searchValue);
         }
       } else {
-        //global search for this term
-        const globalSearchValue = term.toLowerCase();
-        
-        //check all relevant fields
-        return checkStringContains(row.name, globalSearchValue) ||
-               checkStringContains(getRoleDisplayName(row.role), globalSearchValue) ||
-               checkStringContains(row.phone, globalSearchValue) ||
-               checkStringContains(row.email, globalSearchValue);
+        return checkStringContains(row.name, term) ||
+               checkStringContains(getRoleDisplayName(row.role), term) ||
+               checkStringContains(row.phone, term) ||
+               checkStringContains(row.email, term);
       }
     });
   });

--- a/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.tsx
+++ b/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.tsx
@@ -510,7 +510,7 @@ const UsersSpreadsheet: React.FC<UsersSpreadsheetProps> = ({ onAuthStateChangedO
             <TableContainer
               component={Paper}
               sx={{
-                maxHeight: 520,
+                maxHeight: "60vh",
                 overflowY: "auto",
                 boxShadow: "0 4px 12px rgba(0,0,0,0.05)",
                 borderRadius: "12px",

--- a/my-app/src/hooks/useCustomColumns.ts
+++ b/my-app/src/hooks/useCustomColumns.ts
@@ -10,12 +10,14 @@ export const allowedPropertyKeys = [
   "gender",
   "language",
   "notes",
+  "phone",
   "referralEntity",
   "tefapCert",
   "tags",
   "dob",
   "ward",
-  "zipCode"
+  "zipCode",
+  "lastDeliveryDate"
 ];
 
 // useCustomColumns.ts

--- a/my-app/src/pages/Calendar/components/AddDeliveryDialog.tsx
+++ b/my-app/src/pages/Calendar/components/AddDeliveryDialog.tsx
@@ -23,8 +23,9 @@ import CalendarMultiSelect from "./CalendarMultiSelect";
 import DateField from "./DateField";
 import { DayPilot } from "@daypilot/daypilot-lite-react";
 import { validateDeliveryDateRange } from "../../../utils/dateValidation";
-import { collection, getDocs, query, where, orderBy } from "firebase/firestore";
+import { collection, getDocs, query, where, orderBy, deleteDoc, doc } from "firebase/firestore";
 import { db } from "../../../auth/firebaseConfig";
+import { getLastDeliveryDateForClient } from "../../../utils/lastDeliveryDate";
 
 interface AddDeliveryDialogProps {
   open: boolean;
@@ -39,6 +40,47 @@ interface AddDeliveryDialogProps {
     clientProfile: ClientProfile;
   };
 }
+
+// Helper function to delete deliveries that are later than the new end date
+const deleteDeliveriesAfterEndDate = async (clientId: string, newEndDate: string) => {
+  try {
+    const eventsRef = collection(db, "events");
+    const q = query(
+      eventsRef,
+      where("clientId", "==", clientId)
+    );
+    const querySnapshot = await getDocs(q);
+
+    const deletionPromises: Promise<void>[] = [];
+    const newEndDateTime = new Date(newEndDate);
+
+    querySnapshot.forEach((docSnapshot) => {
+      const eventData = docSnapshot.data();
+      if (eventData.deliveryDate) {
+        const deliveryDate = eventData.deliveryDate.toDate();
+        // Normalize both dates to YYYY-MM-DD format for accurate comparison
+        const deliveryDateStr = deliveryDate.toISOString().split('T')[0];
+        const endDateStr = newEndDateTime.toISOString().split('T')[0];
+        
+        // Only delete deliveries that are strictly after the end date (not on the end date)
+        if (deliveryDateStr > endDateStr) {
+          console.log(`Deleting delivery on ${deliveryDateStr} (after new end date ${endDateStr})`);
+          deletionPromises.push(deleteDoc(doc(db, "events", docSnapshot.id)));
+        } else if (deliveryDateStr === endDateStr) {
+          console.log(`Keeping delivery on ${deliveryDateStr} (matches end date ${endDateStr})`);
+        }
+      }
+    });
+
+    if (deletionPromises.length > 0) {
+      await Promise.all(deletionPromises);
+      console.log(`Deleted ${deletionPromises.length} deliveries that were after the new end date`);
+    }
+  } catch (error) {
+    console.error("Error deleting deliveries after end date:", error);
+    throw error;
+  }
+};
 
 const AddDeliveryDialog: React.FC<AddDeliveryDialogProps> = (props: AddDeliveryDialogProps) => {
   const { open, onClose, onAddDelivery, clients, startDate, preSelectedClient } = props;
@@ -99,89 +141,23 @@ const AddDeliveryDialog: React.FC<AddDeliveryDialogProps> = (props: AddDeliveryD
   const [endDateError, setEndDateError] = useState<string>("");
   const [currentLastDeliveryDate, setCurrentLastDeliveryDate] = useState<string>("");
 
-  // Fetch current last delivery date when client is selected
+  // Fetch current last delivery date when client is selected or modal opens
   useEffect(() => {
     const fetchCurrentLastDeliveryDate = async () => {
-      if (newDelivery.clientId) {
+      if (newDelivery.clientId && open) {
         try {
-          const eventsRef = collection(db, "events");
-          const q = query(
-            eventsRef,
-            where("clientId", "==", newDelivery.clientId),
-            orderBy("deliveryDate", "desc")
-          );
-          const querySnapshot = await getDocs(q);
+          const latestEndDate = await getLastDeliveryDateForClient(newDelivery.clientId);
 
-          if (!querySnapshot.empty) {
-            // Group events by series to find the most recently created delivery series
-            const seriesMap = new Map<string, any[]>();
+          if (latestEndDate) {
+            const formattedDate = convertToMMDDYYYY(latestEndDate);
+            setCurrentLastDeliveryDate(formattedDate);
             
-            querySnapshot.forEach((doc) => {
-              const eventData = doc.data();
-              const recurrenceId = eventData.recurrenceId || 'single-' + doc.id;
-              
-              if (!seriesMap.has(recurrenceId)) {
-                seriesMap.set(recurrenceId, []);
-              }
-              seriesMap.get(recurrenceId)!.push({...eventData, docId: doc.id});
-            });
-
-            // Find the most recently created delivery series based on seriesStartDate
-            let mostRecentSeriesEndDate: string | null = null;
-            let mostRecentSeriesStartDate: string | null = null;
-
-            for (const [recurrenceId, events] of seriesMap.entries()) {
-              const firstEvent = events[0];
-              
-              // Get the series start date to determine which series is most recent
-              let seriesStartDate: string | null = null;
-              if (firstEvent.seriesStartDate) {
-                seriesStartDate = firstEvent.seriesStartDate;
-              } else if (firstEvent.deliveryDate) {
-                const deliveryDate = firstEvent.deliveryDate.toDate();
-                if (!isNaN(deliveryDate.getTime())) {
-                  seriesStartDate = deliveryDate.toISOString().split("T")[0];
-                }
-              }
-              
-              if (seriesStartDate) {
-                // If this series is more recent than our current most recent, use it
-                if (!mostRecentSeriesStartDate || seriesStartDate > mostRecentSeriesStartDate) {
-                  mostRecentSeriesStartDate = seriesStartDate;
-                  
-                  // For this series, get the end date
-                  if (firstEvent.repeatsEndDate) {
-                    const endDate = new Date(firstEvent.repeatsEndDate);
-                    if (!isNaN(endDate.getTime())) {
-                      mostRecentSeriesEndDate = endDate.toISOString().split("T")[0];
-                    }
-                  } else if (firstEvent.recurrence === "None" && firstEvent.deliveryDate) {
-                    // For single deliveries, the end date is the delivery date itself
-                    const deliveryDate = firstEvent.deliveryDate.toDate();
-                    if (!isNaN(deliveryDate.getTime())) {
-                      mostRecentSeriesEndDate = deliveryDate.toISOString().split("T")[0];
-                    }
-                  }
-                }
-              }
-            }
-
-            const latestEndDate = mostRecentSeriesEndDate;
-
-            if (latestEndDate) {
-              const formattedDate = convertToMMDDYYYY(latestEndDate);
-              setCurrentLastDeliveryDate(formattedDate);
-              
-              // Pre-populate the End Date field with the current end date as a starting point
-              if (!newDelivery.repeatsEndDate) {
-                setNewDelivery(prev => ({
-                  ...prev,
-                  repeatsEndDate: formattedDate
-                }));
-              }
-            } else {
-              setCurrentLastDeliveryDate("");
-            }
+            // Pre-populate the End Date field with the current end date as a starting point
+            // Always update with fresh data to ensure synchronization
+            setNewDelivery(prev => ({
+              ...prev,
+              repeatsEndDate: formattedDate
+            }));
           } else {
             setCurrentLastDeliveryDate("");
           }
@@ -195,7 +171,7 @@ const AddDeliveryDialog: React.FC<AddDeliveryDialogProps> = (props: AddDeliveryD
     };
 
     fetchCurrentLastDeliveryDate();
-  }, [newDelivery.clientId]);
+  }, [newDelivery.clientId, open]);
 
   // Toggle body class for modal open state to control DatePicker popup scaling
   useEffect(() => {
@@ -279,9 +255,36 @@ const AddDeliveryDialog: React.FC<AddDeliveryDialogProps> = (props: AddDeliveryD
           // Compare only the date part (ignore time)
           return eventDate.toISOString().split("T")[0] === deliveryDateStr;
         });
+        
+        // Check if this is an end date update scenario:
+        // If the delivery date matches the end date and there are existing deliveries,
+        // this is likely changing the end date to an existing delivery date
+        
+        // Normalize dates to YYYY-MM-DD format for comparison
+        const normalizeDate = (dateStr: string) => {
+          if (!dateStr) return '';
+          // If already in YYYY-MM-DD format, return as-is
+          if (/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return dateStr;
+          // Convert MM/DD/YYYY to YYYY-MM-DD
+          if (/^\d{2}\/\d{2}\/\d{4}$/.test(dateStr)) {
+            const [month, day, year] = dateStr.split('/');
+            return `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
+          }
+          return dateStr;
+        };
+        
+        const normalizedDeliveryDate = normalizeDate(newDelivery.deliveryDate);
+        const normalizedEndDate = normalizeDate(newDelivery.repeatsEndDate || '');
+        
+        const isEndDateUpdate = normalizedDeliveryDate === normalizedEndDate && 
+                               events.length > 0 &&
+                               newDelivery.recurrence !== "None";
+        
+        // Clear any existing duplicate error - we'll handle duplicates silently
+        setDuplicateError("");
+        
         if (hasDuplicate) {
-          setDuplicateError("This client already has a delivery scheduled for that day.");
-          return;
+          console.log("Duplicate delivery detected - will be handled by Profile logic without error");
         }
         // No duplicate, proceed
         const deliveryToSubmit: Partial<NewDelivery> = { ...newDelivery };
@@ -290,6 +293,11 @@ const AddDeliveryDialog: React.FC<AddDeliveryDialogProps> = (props: AddDeliveryD
           deliveryToSubmit.deliveryDate = customDates[0]?.toISOString().split("T")[0] || "";
           deliveryToSubmit.repeatsEndDate = undefined;
         }
+
+        // Signal that deliveries have been modified for other components
+        localStorage.setItem('deliveriesModified', Date.now().toString());
+        
+        // ALWAYS call onAddDelivery - Profile logic will handle duplicates properly
         onAddDelivery(deliveryToSubmit as NewDelivery);
         setCustomDates([]);
         resetFormAndClose();

--- a/my-app/src/pages/Calendar/components/AddDeliveryDialog.tsx
+++ b/my-app/src/pages/Calendar/components/AddDeliveryDialog.tsx
@@ -276,17 +276,15 @@ const AddDeliveryDialog: React.FC<AddDeliveryDialogProps> = (props: AddDeliveryD
         const normalizedDeliveryDate = normalizeDate(newDelivery.deliveryDate);
         const normalizedEndDate = normalizeDate(newDelivery.repeatsEndDate || '');
         
-        const isEndDateUpdate = normalizedDeliveryDate === normalizedEndDate && 
+        const isEndDateUpdate = normalizedDeliveryDate === normalizedEndDate &&
                                events.length > 0 &&
                                newDelivery.recurrence !== "None";
-        
-        // Clear any existing duplicate error - we'll handle duplicates silently
+
         setDuplicateError("");
-        
+
         if (hasDuplicate) {
-          console.log("Duplicate delivery detected - will be handled by Profile logic without error");
+          console.log("Duplicate delivery detected - Profile page handles deduplication during creation");
         }
-        // No duplicate, proceed
         const deliveryToSubmit: Partial<NewDelivery> = { ...newDelivery };
         if (newDelivery.recurrence === "Custom") {
           deliveryToSubmit.customDates = customDates.map(date => date.toISOString().split("T")[0]);
@@ -294,10 +292,7 @@ const AddDeliveryDialog: React.FC<AddDeliveryDialogProps> = (props: AddDeliveryD
           deliveryToSubmit.repeatsEndDate = undefined;
         }
 
-        // Signal that deliveries have been modified for other components
         localStorage.setItem('deliveriesModified', Date.now().toString());
-        
-        // ALWAYS call onAddDelivery - Profile logic will handle duplicates properly
         onAddDelivery(deliveryToSubmit as NewDelivery);
         setCustomDates([]);
         resetFormAndClose();

--- a/my-app/src/pages/Calendar/components/DayView.tsx
+++ b/my-app/src/pages/Calendar/components/DayView.tsx
@@ -37,6 +37,7 @@ const DayView: React.FC<DayViewProps> = ({ events, clients, onEventModified, dai
                 event={event}
                 client={client}
                 onEventModified={onEventModified}
+                allEvents={events}
               />
             );
           })}

--- a/my-app/src/pages/Calendar/components/DeliveryCard.tsx
+++ b/my-app/src/pages/Calendar/components/DeliveryCard.tsx
@@ -11,9 +11,10 @@ interface DeliveryCardProps {
   event: DeliveryEvent;
   client?: ClientProfile;
   onEventModified: () => void;
+  allEvents?: DeliveryEvent[];
 }
 
-const DeliveryCard: React.FC<DeliveryCardProps> = ({ event, client, onEventModified }) => {
+const DeliveryCard: React.FC<DeliveryCardProps> = ({ event, client, onEventModified, allEvents }) => {
   const formatPhoneNumber = (phone: string): string => {
     const cleaned = ("" + phone).replace(/\D/g, ""); // Remove non-numeric characters
     const match = cleaned.match(/^(\d{3})(\d{3})(\d{4})$/); // Match the phone number pattern
@@ -57,7 +58,7 @@ const DeliveryCard: React.FC<DeliveryCardProps> = ({ event, client, onEventModif
             {event.clientName}
           </Typography>
           {/* Displays if the delivery is apart of a recurrence and also shows the date range */}
-          <DeliveryRecurrenceDisplay event={event} />
+          <DeliveryRecurrenceDisplay event={event} allEvents={allEvents} />
         </Box>
       </Box>
 

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -2105,7 +2105,7 @@ const DeliverySpreadsheet: React.FC = () => {
         <TableContainer
           component={Paper}
           sx={{
-            maxHeight: 520,
+            maxHeight: "60vh",
             overflowY: "auto",
             width: "100%",
           }}

--- a/my-app/src/pages/Profile/Profile.tsx
+++ b/my-app/src/pages/Profile/Profile.tsx
@@ -317,7 +317,39 @@ const Profile = () => {
     const docRef = doc(db, "clients", id);
     const docSnap = await getDoc(docRef);
     if (docSnap.exists()) {
-      return docSnap.data() as ClientProfile;
+      const data = docSnap.data();
+      
+      // Ensure deliveryDetails structure exists and other potentially undefined fields
+      const normalizedData = {
+        ...data,
+        notes: data.notes || "",
+        lifeChallenges: data.lifeChallenges || "",
+        lifestyleGoals: data.lifestyleGoals || "",
+        deliveryDetails: {
+          deliveryInstructions: data.deliveryDetails?.deliveryInstructions || "",
+          dietaryRestrictions: {
+            lowSugar: data.deliveryDetails?.dietaryRestrictions?.lowSugar || false,
+            kidneyFriendly: data.deliveryDetails?.dietaryRestrictions?.kidneyFriendly || false,
+            vegan: data.deliveryDetails?.dietaryRestrictions?.vegan || false,
+            vegetarian: data.deliveryDetails?.dietaryRestrictions?.vegetarian || false,
+            halal: data.deliveryDetails?.dietaryRestrictions?.halal || false,
+            microwaveOnly: data.deliveryDetails?.dietaryRestrictions?.microwaveOnly || false,
+            softFood: data.deliveryDetails?.dietaryRestrictions?.softFood || false,
+            lowSodium: data.deliveryDetails?.dietaryRestrictions?.lowSodium || false,
+            noCookingEquipment: data.deliveryDetails?.dietaryRestrictions?.noCookingEquipment || false,
+            heartFriendly: data.deliveryDetails?.dietaryRestrictions?.heartFriendly || false,
+            allergies: data.deliveryDetails?.dietaryRestrictions?.allergies || false,
+            allergiesText: data.deliveryDetails?.dietaryRestrictions?.allergiesText || "",
+            foodAllergens: data.deliveryDetails?.dietaryRestrictions?.foodAllergens || [],
+            otherText: data.deliveryDetails?.dietaryRestrictions?.otherText || "",
+            other: data.deliveryDetails?.dietaryRestrictions?.other || false,
+            dietaryPreferences: data.deliveryDetails?.dietaryRestrictions?.dietaryPreferences || "",
+            ...data.deliveryDetails?.dietaryRestrictions
+          }
+        }
+      };
+      
+      return normalizedData as ClientProfile;
     } else {
       console.log("No such document!");
       return null;
@@ -1600,7 +1632,7 @@ if (type === "physicalAilments") {
                     deliveryDetails: {
                       ...prev.deliveryDetails,
                       dietaryRestrictions: {
-                        ...prev.deliveryDetails.dietaryRestrictions,
+                        ...prev.deliveryDetails?.dietaryRestrictions,
                         foodAllergens: value.split(",").map(s => s.trim()).filter(Boolean),
                         allergiesText: value,
                       }
@@ -2113,12 +2145,12 @@ if (type === "physicalAilments") {
         deliveryDetails: {
           ...prevState.deliveryDetails,
           dietaryRestrictions: {
-            ...prevState.deliveryDetails.dietaryRestrictions,
+            ...prevState.deliveryDetails?.dietaryRestrictions,
             [name]: checked,
             ...(name === "other" && {
               other: checked,
               // Keep the existing otherText when checking, clear it when unchecking
-              otherText: checked ? prevState.deliveryDetails.dietaryRestrictions.otherText : ""
+              otherText: checked ? prevState.deliveryDetails?.dietaryRestrictions?.otherText || "" : ""
             })
           },
         },
@@ -2130,7 +2162,7 @@ if (type === "physicalAilments") {
         deliveryDetails: {
           ...prevState.deliveryDetails,
           dietaryRestrictions: {
-            ...prevState.deliveryDetails.dietaryRestrictions,
+            ...prevState.deliveryDetails?.dietaryRestrictions,
             [name]: value,
             ...(name === "otherText" && { other: true }), // Ensure the checkbox stays checked when typing in otherText
             ...(name === "allergiesText" && { allergies: value.trim() !== "" }) // Checkbox checked if textbox not empty
@@ -2812,7 +2844,7 @@ const handleMentalHealthConditionsChange = (e: React.ChangeEvent<HTMLInputElemen
             <DietaryPreferencesForm
               isEditing={isEditing}
               fieldLabelStyles={fieldLabelStyles}
-              dietaryRestrictions={clientProfile.deliveryDetails.dietaryRestrictions}
+              dietaryRestrictions={clientProfile.deliveryDetails?.dietaryRestrictions || {}}
               renderField={renderField}
             />
           </SectionBox>
@@ -2823,7 +2855,7 @@ const handleMentalHealthConditionsChange = (e: React.ChangeEvent<HTMLInputElemen
             <HealthConditionsForm
               isEditing={isEditing}
               fieldLabelStyles={fieldLabelStyles}
-              dietaryRestrictions={clientProfile.deliveryDetails.dietaryRestrictions}
+              dietaryRestrictions={clientProfile.deliveryDetails?.dietaryRestrictions || {}}
               renderField={renderField}
             />
           </SectionBox>

--- a/my-app/src/pages/Profile/Profile.tsx
+++ b/my-app/src/pages/Profile/Profile.tsx
@@ -427,15 +427,76 @@ const Profile = () => {
           const q = query(
             eventsRef,
             where("clientId", "==", clientId),
-            orderBy("deliveryDate", "desc"),
-            limit(1)
+            orderBy("deliveryDate", "desc")
           );
           const querySnapshot = await getDocs(q);
 
           if (!querySnapshot.empty) {
-            const lastEvent = querySnapshot.docs[0].data();
-            const deliveryDate = lastEvent.deliveryDate.toDate();
-            setLastDeliveryDate(deliveryDate.toISOString().split("T")[0]);
+            let latestEndDateString: string | null = null;
+            
+            // Group events by series to find the most recently created delivery series
+            const seriesMap = new Map<string, any[]>();
+            
+            querySnapshot.forEach((doc) => {
+              const eventData = doc.data();
+              const recurrenceId = eventData.recurrenceId || 'single-' + doc.id;
+              
+              if (!seriesMap.has(recurrenceId)) {
+                seriesMap.set(recurrenceId, []);
+              }
+              seriesMap.get(recurrenceId)!.push({...eventData, docId: doc.id});
+            });
+
+            // Find the most recently created delivery series based on seriesStartDate
+            let mostRecentSeriesEndDate: string | null = null;
+            let mostRecentSeriesStartDate: string | null = null;
+
+            for (const [recurrenceId, events] of seriesMap.entries()) {
+              const firstEvent = events[0];
+              
+              // Get the series start date to determine which series is most recent
+              let seriesStartDate: string | null = null;
+              if (firstEvent.seriesStartDate) {
+                seriesStartDate = firstEvent.seriesStartDate;
+              } else if (firstEvent.deliveryDate) {
+                const deliveryDate = firstEvent.deliveryDate.toDate();
+                if (!isNaN(deliveryDate.getTime())) {
+                  seriesStartDate = deliveryDate.toISOString().split("T")[0];
+                }
+              }
+              
+              if (seriesStartDate) {
+                // If this series is more recent than our current most recent, use it
+                if (!mostRecentSeriesStartDate || seriesStartDate > mostRecentSeriesStartDate) {
+                  mostRecentSeriesStartDate = seriesStartDate;
+                  
+                  // For this series, get the end date
+                  if (firstEvent.repeatsEndDate) {
+                    const endDate = new Date(firstEvent.repeatsEndDate);
+                    if (!isNaN(endDate.getTime())) {
+                      mostRecentSeriesEndDate = endDate.toISOString().split("T")[0];
+                    }
+                  } else if (firstEvent.recurrence === "None" && firstEvent.deliveryDate) {
+                    // For single deliveries, the end date is the delivery date itself
+                    const deliveryDate = firstEvent.deliveryDate.toDate();
+                    if (!isNaN(deliveryDate.getTime())) {
+                      mostRecentSeriesEndDate = deliveryDate.toISOString().split("T")[0];
+                    }
+                  }
+                }
+              }
+            }
+
+            latestEndDateString = mostRecentSeriesEndDate;
+
+            if (latestEndDateString) {
+              setLastDeliveryDate(latestEndDateString);
+            } else {
+              // Fallback to most recent delivery date if no end dates found
+              const lastEvent = querySnapshot.docs[0].data();
+              const deliveryDate = lastEvent.deliveryDate.toDate();
+              setLastDeliveryDate(deliveryDate.toISOString().split("T")[0]);
+            }
           } else {
             setLastDeliveryDate("No deliveries found");
           }

--- a/my-app/src/pages/Profile/components/DeliveryInfoForm.tsx
+++ b/my-app/src/pages/Profile/components/DeliveryInfoForm.tsx
@@ -172,7 +172,7 @@ const DeliveryInfoForm: React.FC<DeliveryInfoFormProps> = ({
             DELIVERY INSTRUCTIONS
           </Typography>
           {renderField("deliveryDetails.deliveryInstructions", "textarea")}
-          {clientProfile.deliveryDetails.deliveryInstructions.trim() !== "" && (
+          {clientProfile.deliveryDetails?.deliveryInstructions?.trim() !== "" && (
             <p id="timestamp">
               Last edited:{" "}
               {clientProfile.deliveryInstructionsTimestamp &&
@@ -199,7 +199,7 @@ const DeliveryInfoForm: React.FC<DeliveryInfoFormProps> = ({
             ADMIN NOTES
           </Typography>
           {renderField("notes", "textarea")}
-          {clientProfile.notes.trim() !== "" && (
+          {clientProfile.notes?.trim() !== "" && (
             <p id="timestamp">
               Last edited:{" "}
               {clientProfile.notesTimestamp &&

--- a/my-app/src/pages/Profile/components/MiscellaneousForm.tsx
+++ b/my-app/src/pages/Profile/components/MiscellaneousForm.tsx
@@ -51,7 +51,7 @@ const MiscellaneousForm: React.FC<MiscellaneousFormProps> = ({
           {isEditing ? (
             <>
               <Box sx={{ minHeight: 120, width: '100%' }}>{renderField("lifeChallenges", "textarea")}</Box>
-              {clientProfile.lifeChallenges && clientProfile.lifeChallenges.trim() !== "" && (
+              {clientProfile.lifeChallenges && clientProfile.lifeChallenges?.trim() !== "" && (
                 <span id="timestamp">
                   Last edited: {clientProfile.lifeChallengesTimestamp && clientProfile.lifeChallengesTimestamp.timestamp && new Date(
                     typeof clientProfile.lifeChallengesTimestamp.timestamp === 'object' &&
@@ -73,7 +73,7 @@ const MiscellaneousForm: React.FC<MiscellaneousFormProps> = ({
           {isEditing ? (
             <>
               <Box sx={{ minHeight: 120, width: '100%' }}>{renderField("lifestyleGoals", "textarea")}</Box>
-              {clientProfile.lifestyleGoals && clientProfile.lifestyleGoals.trim() !== "" && (
+              {clientProfile.lifestyleGoals && clientProfile.lifestyleGoals?.trim() !== "" && (
                 <span id="timestamp">
                   Last edited: {clientProfile.lifestyleGoalsTimestamp && clientProfile.lifestyleGoalsTimestamp.timestamp && new Date(
                     typeof clientProfile.lifestyleGoalsTimestamp.timestamp === 'object' &&

--- a/my-app/src/utils/lastDeliveryDate.ts
+++ b/my-app/src/utils/lastDeliveryDate.ts
@@ -1,0 +1,80 @@
+import { collection, getDocs, query, where, orderBy } from "firebase/firestore";
+import { db } from "../auth/firebaseConfig";
+
+/**
+ * Shared utility function to get the last delivery date for a client
+ * This ensures both the profile page and modal use identical logic
+ */
+export const getLastDeliveryDateForClient = async (clientId: string): Promise<string | null> => {
+  try {
+    const eventsRef = collection(db, "events");
+    const q = query(
+      eventsRef,
+      where("clientId", "==", clientId),
+      orderBy("deliveryDate", "desc")
+    );
+    const querySnapshot = await getDocs(q);
+
+    if (!querySnapshot.empty) {
+      // Group events by series to find the most recently created delivery series
+      const seriesMap = new Map<string, any[]>();
+      
+      querySnapshot.forEach((doc) => {
+        const eventData = doc.data();
+        const recurrenceId = eventData.recurrenceId || 'single-' + doc.id;
+        
+        if (!seriesMap.has(recurrenceId)) {
+          seriesMap.set(recurrenceId, []);
+        }
+        seriesMap.get(recurrenceId)!.push({...eventData, docId: doc.id});
+      });
+
+      // Find the most recently created delivery series based on seriesStartDate
+      let mostRecentSeriesEndDate: string | null = null;
+      let mostRecentSeriesStartDate: string | null = null;
+
+      for (const [recurrenceId, events] of seriesMap.entries()) {
+        const firstEvent = events[0];
+        
+        // Get the series start date to determine which series is most recent
+        let seriesStartDate: string | null = null;
+        if (firstEvent.seriesStartDate) {
+          seriesStartDate = firstEvent.seriesStartDate;
+        } else if (firstEvent.deliveryDate) {
+          const deliveryDate = firstEvent.deliveryDate.toDate();
+          if (!isNaN(deliveryDate.getTime())) {
+            seriesStartDate = deliveryDate.toISOString().split("T")[0];
+          }
+        }
+        
+        if (seriesStartDate) {
+          // If this series is more recent than our current most recent, use it
+          if (!mostRecentSeriesStartDate || seriesStartDate > mostRecentSeriesStartDate) {
+            mostRecentSeriesStartDate = seriesStartDate;
+            
+            // For this series, get the end date
+            if (firstEvent.repeatsEndDate) {
+              const endDate = new Date(firstEvent.repeatsEndDate);
+              if (!isNaN(endDate.getTime())) {
+                mostRecentSeriesEndDate = endDate.toISOString().split("T")[0];
+              }
+            } else if (firstEvent.recurrence === "None" && firstEvent.deliveryDate) {
+              // For single deliveries, the end date is the delivery date itself
+              const deliveryDate = firstEvent.deliveryDate.toDate();
+              if (!isNaN(deliveryDate.getTime())) {
+                mostRecentSeriesEndDate = deliveryDate.toISOString().split("T")[0];
+              }
+            }
+          }
+        }
+      }
+
+      return mostRecentSeriesEndDate;
+    }
+
+    return null;
+  } catch (error) {
+    console.error("Error fetching last delivery date:", error);
+    return null;
+  }
+};

--- a/my-app/src/utils/searchFilter.ts
+++ b/my-app/src/utils/searchFilter.ts
@@ -1,0 +1,77 @@
+export interface SearchFilterConfig {
+  checkStringContains: (value: any, query: string) => boolean;
+  getSearchableFields: (searchValue: string) => boolean;
+}
+
+export const parseSearchTermsProgressively = (trimmedSearchQuery: string): string[] => {
+  const searchTerms: string[] = [];
+  let inQuote = false;
+  let quoteChar = '';
+  let currentTerm = '';
+
+  for (let i = 0; i < trimmedSearchQuery.length; i++) {
+    const char = trimmedSearchQuery[i];
+
+    if (!inQuote && (char === '"' || char === "'")) {
+      if (currentTerm.trim()) {
+        searchTerms.push(currentTerm.trim());
+        currentTerm = '';
+      }
+      inQuote = true;
+      quoteChar = char;
+    } else if (inQuote && char === quoteChar) {
+      if (currentTerm.trim()) {
+        searchTerms.push(currentTerm.trim());
+      }
+      currentTerm = '';
+      inQuote = false;
+      quoteChar = '';
+    } else if (!inQuote && char === ' ') {
+      if (currentTerm.trim()) {
+        searchTerms.push(currentTerm.trim());
+        currentTerm = '';
+      }
+    } else {
+      currentTerm += char;
+    }
+  }
+
+  if (currentTerm.trim()) {
+    searchTerms.push(currentTerm.trim());
+  }
+
+  return searchTerms.filter(term => term.length > 0 && term !== '"' && term !== "'");
+};
+
+export const checkStringContains = (value: any, query: string): boolean => {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  return String(value).toLowerCase().includes(query.toLowerCase());
+};
+
+export const isPartialFieldName = (term: string, fieldNames: string[]): boolean => {
+  const lowerTerm = term.toLowerCase();
+  return fieldNames.some(fieldName =>
+    fieldName.startsWith(lowerTerm) ||
+    lowerTerm.startsWith(fieldName.substring(0, Math.min(3, fieldName.length)))
+  );
+};
+
+export const extractKeyValue = (term: string): { keyword: string; searchValue: string; isKeyValue: boolean } => {
+  const colonIndex = term.indexOf(':');
+
+  if (colonIndex !== -1) {
+    return {
+      keyword: term.substring(0, colonIndex).trim().toLowerCase(),
+      searchValue: term.substring(colonIndex + 1).trim(),
+      isKeyValue: true
+    };
+  }
+
+  return {
+    keyword: '',
+    searchValue: '',
+    isKeyValue: false
+  };
+};


### PR DESCRIPTION
You can now on each page that has a filter use "progressive fitlering"

Meaning if you start you filter with something like "Phone:123" the fitler doesnt apply until you type the colon, and each filter stays applied while you add additional filters so typing something like 

"Phone:123" "Name: bob" 

will fitler to bob that has a phone number with 123 in it

Also the filter now works for each page that has a filter the same way

In addition the filter only applies to columns that are displayed so items that are in the dataset but not added to the page with the + column adding are not fitlered 

So as an example on the Routes page Phone is not a default column and wont filter unless you add it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added “Last Delivery Date” column across spreadsheets with selection, sorting, export support and async loading.
  - Progressive search: key:value, quoted phrases, partial-key typing across Clients, Users, and Deliveries, including custom columns.
  - Calendar and delivery UI: recurrence date ranges shown; dialogs prefill and manage end dates; delivery lists refresh after edits.

- Bug Fixes
  - Safer rendering for optional fields to prevent runtime errors.
  - Editing/deleting end dates now cleans up future deliveries to keep data consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->