### PR TITLE
fixed the search to use key/value progressive searching

### DIFF
--- a/my-app/src/hooks/useCustomColumns.ts
+++ b/my-app/src/hooks/useCustomColumns.ts
@@ -13,10 +13,7 @@ export const allowedPropertyKeys = [
   "phone",
   "referralEntity",
   "tefapCert",
-  "tags",
   "dob",
-  "ward",
-  "zipCode",
   "lastDeliveryDate"
 ];
 


### PR DESCRIPTION
Search uses key/value to search now. It also is progressive meaning it you can add to it and is activated by the colon for each search

So something like this should work

"name: ja" "phone: 12"