### PR TITLE
fixed the issue where it disapeared after merging with main

### DIFF
--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -344,6 +344,7 @@ const DeliverySpreadsheet: React.FC = () => {
   const [exportOption, setExportOption] = useState<"Routes" | "Doordash" | null>(null);
   const [emailOrDownload, setEmailOrDownload] = useState<"Email" | "Download" | null>(null);
   const [driversRefreshTrigger, setDriversRefreshTrigger] = useState<number>(0);
+  const [highlightedRowId, setHighlightedRowId] = useState<string | null>(null);
 
   // Helper function to deduplicate clusters by ID
   const deduplicateClusters = (clusters: Cluster[]): Cluster[] => {
@@ -1365,6 +1366,44 @@ const DeliverySpreadsheet: React.FC = () => {
     setSelectedRows(newSelectedRows);
   };
 
+  const handleRowClick = (clientId: string) => {
+    console.log('Row clicked for clientId:', clientId);
+    
+    // Handle special case for clearing highlight only
+    if (clientId === 'CLEAR_HIGHLIGHT_ONLY') {
+      console.log('Clearing row highlight only');
+      setHighlightedRowId(null);
+      return;
+    }
+    
+    // If clicking the same row that's already highlighted, toggle it off
+    if (highlightedRowId === clientId) {
+      console.log('Removing highlight and closing popup');
+      setHighlightedRowId(null);
+      // Close any open popup
+      if ((window as any).closeMapPopup) {
+        (window as any).closeMapPopup();
+      }
+    } else {
+      // Highlight the new row and open its popup
+      console.log('Highlighting new row and opening popup');
+      setHighlightedRowId(clientId);
+      // Open the corresponding map popup
+      if ((window as any).openMapPopup) {
+        console.log('Calling openMapPopup for:', clientId);
+        (window as any).openMapPopup(clientId);
+      } else {
+        console.log('openMapPopup function not available');
+      }
+    }
+  };
+
+  // Separate function just for clearing highlights (used by popup close handler)
+  const clearRowHighlight = () => {
+    console.log('Clearing row highlight only');
+    setHighlightedRowId(null);
+  };
+
   const clientsWithDeliveriesOnSelectedDate = rows.filter((row) =>
     deliveriesForDate.some((delivery) => delivery.clientId === row.id)
   );
@@ -1942,7 +1981,7 @@ const DeliverySpreadsheet: React.FC = () => {
           <LoadingIndicator />
         ) : visibleRows.length > 0 ? (
           <Suspense fallback={<LoadingIndicator />}>
-            <ClusterMap clusters={clusters} visibleRows={visibleRows} clientOverrides={clientOverrides} onClusterUpdate={handleIndividualClientUpdate} refreshDriversTrigger={driversRefreshTrigger} />
+            <ClusterMap clusters={clusters} visibleRows={visibleRows} clientOverrides={clientOverrides} onClusterUpdate={handleIndividualClientUpdate} onOpenPopup={handleRowClick} onClearHighlight={clearRowHighlight} refreshDriversTrigger={driversRefreshTrigger} />
           </Suspense>
         ) : (
           <Box
@@ -2275,7 +2314,20 @@ const DeliverySpreadsheet: React.FC = () => {
             </TableHead>
             <TableBody>
               {sortedRows.map((row, index) => (
-                <TableRow key={`${sortTimestamp}-${index}-${row.id}`} className="table-row delivery-anim-row">
+                <TableRow 
+                  key={`${sortTimestamp}-${index}-${row.id}`} 
+                  className="table-row delivery-anim-row"
+                  data-client-id={row.id}
+                  onClick={() => handleRowClick(row.id)}
+                  sx={{
+                    backgroundColor: highlightedRowId === row.id ? 'rgba(144, 238, 144, 0.7) !important' : 'inherit',
+                    border: highlightedRowId === row.id ? '2px solid #90EE90 !important' : 'none',
+                    cursor: 'pointer',
+                    '&:hover': {
+                      backgroundColor: 'rgba(144, 238, 144, 0.3) !important'
+                    }
+                  }}
+                >
                   {fields.map((field) => {
                     // Render the table cell based on field type
                     return (


### PR DESCRIPTION
You were 99% there, the table row when the map popup closes doesnt unhighlight, this is the fix for that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Click a table row to select and highlight it.
  - Selection syncs with the map: opens/closes the related popup and clears highlights when needed.
  - Improved coordination between table interactions and map popups.

- Style
  - Highlighted rows display a green-tinted background and border with a clear hover state.
  - Table rows are now visibly clickable for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->