### PR TITLE
Fix: keep routes map mounted during loading

### DIFF
--- a/my-app/src/pages/Delivery/ClusterMap.tsx
+++ b/my-app/src/pages/Delivery/ClusterMap.tsx
@@ -712,12 +712,14 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
   }, [showWardOverlays, addWardOverlays]);
 
   useEffect(() => {
-    if (!mapRef.current || !markerGroupRef.current || visibleRows.length < 1) return;
+    if (!mapRef.current || !markerGroupRef.current) return;
 
     markerGroupRef.current.clearLayers();
 
     // Clear markers map when recreating markers
     markersMapRef.current.clear();
+
+    if (visibleRows.length < 1) return;
 
     // create a map of client ids for quick lookup
     const clientClusterMap = new Map<string, Cluster>();

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -2526,13 +2526,10 @@ const DeliverySpreadsheet: React.FC = () => {
           height: "400px",
           width: "100%",
           backgroundColor: "var(--color-background-main)",
-          // Removed position: "relative"
+          position: "relative",
         }}
       >
-        {isMainLoading ? (
-          // Revert to rendering the indicator directly
-          <LoadingIndicator />
-        ) : visibleRows.length > 0 ? (
+        {rows.length > 0 && (
           <Suspense fallback={<LoadingIndicator />}>
             <ClusterMap
               clusters={clusters}
@@ -2546,15 +2543,35 @@ const DeliverySpreadsheet: React.FC = () => {
               refreshDriversTrigger={driversRefreshTrigger}
             />
           </Suspense>
-        ) : (
+        )}
+
+        {isMainLoading && (
           <Box
             sx={{
+              position: "absolute",
+              inset: 0,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              zIndex: 1100,
+              backgroundColor: "rgba(255, 255, 255, 0.85)",
+              borderRadius: "4px",
+            }}
+          >
+            <LoadingIndicator minHeight="100%" text="Loading deliveries..." />
+          </Box>
+        )}
+
+        {!isMainLoading && rows.length === 0 && (
+          <Box
+            sx={{
+              position: "absolute",
+              inset: 0,
               display: "flex",
               justifyContent: "center",
               alignItems: "center",
-              height: "400px", // Explicitly set to match container height
-              width: "100%",
-              backgroundColor: "var(--color-background-body)",
+              zIndex: 1100,
+              backgroundColor: "rgba(255, 255, 255, 0.92)",
               borderRadius: "4px",
               border: "1px solid var(--color-border-light)",
             }}


### PR DESCRIPTION
This update makes the map on the `/routes` page behave more smoothly.

Before this change, the map would disappear and reload while deliveries were loading, especially when the page refreshed or the date changed. That made the page feel jumpy.

Now the map stays in place while delivery data loads. A loading message appears on top of the map instead of replacing it. If a search or filter removes all visible deliveries, the old markers are also cleared so the map stays in sync with the table.

What customers should notice:
- The map no longer flashes in and out during loading.
- Changing dates feels smoother.
- Filtering to no matching deliveries no longer leaves old markers behind.
- No route assignment behavior was changed as part of this fix.

Checks run:
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`