### PR TITLE
Improve route page filtering and cluster tools

### DIFF
--- a/my-app/src/components/Spreadsheet/Spreadsheet.searchFilters.test.ts
+++ b/my-app/src/components/Spreadsheet/Spreadsheet.searchFilters.test.ts
@@ -1,0 +1,20 @@
+import fs from "fs";
+import path from "path";
+import { describe, expect, it } from "@jest/globals";
+
+describe("Spreadsheet search filter regression guards", () => {
+  const sourcePath = path.resolve(__dirname, "Spreadsheet.tsx");
+  const source = fs.readFileSync(sourcePath, "utf8");
+
+  it("supports multi-value key:value filters for the Clients page search", () => {
+    expect(source).toContain("splitFilterValues(searchValue)");
+    expect(source).toContain("matchesAnySearchValue");
+    expect(source).toContain("normalizeSearchKeyword(keyword)");
+  });
+
+  it("shows multi-value examples in the Clients page search placeholder", () => {
+    expect(source).toContain(
+      'placeholder=\'Search clients (e.g., smith, name:john,jane, address:"main st", gender:female,male)\''
+    );
+  });
+});

--- a/my-app/src/components/Spreadsheet/Spreadsheet.tsx
+++ b/my-app/src/components/Spreadsheet/Spreadsheet.tsx
@@ -5,8 +5,11 @@ import { TableSortLabel, Icon, Tooltip } from "@mui/material";
 import {
   parseSearchTermsProgressively,
   checkStringContains,
+  checkStringEquals,
   extractKeyValue,
   globalSearchMatch,
+  normalizeSearchKeyword,
+  splitFilterValues,
 } from "../../utils/searchFilter";
 // Custom chevron icons for TableSortLabel with spacing
 const iconStyle = { verticalAlign: "middle", marginLeft: 6 };
@@ -634,19 +637,41 @@ const Spreadsheet: React.FC = () => {
           ...customColumns.map((col) => col.propertyKey).filter((key) => key !== "none"),
         ]);
 
+        const checkValueOrInArray = (
+          value: unknown,
+          query: string,
+          exactMatch = false
+        ): boolean => {
+          if (value === undefined || value === null) {
+            return false;
+          }
+
+          if (Array.isArray(value)) {
+            return value.some((item) =>
+              exactMatch ? checkStringEquals(item, query) : checkStringContains(item, query)
+            );
+          }
+
+          return exactMatch ? checkStringEquals(value, query) : checkStringContains(value, query);
+        };
+
         const isVisibleField = (keyword: string): boolean => {
-          const lowerKeyword = keyword.toLowerCase();
+          const normalizedKeyword = normalizeSearchKeyword(keyword);
 
           const fieldMappings: { [key: string]: string[] } = {
-            fullname: ["name", "firstname", "lastname"],
+            fullname: ["name", "first name", "firstname", "last name", "lastname"],
             address: ["address"],
             phone: ["phone"],
+            email: ["email"],
             "deliveryDetails.dietaryRestrictions": ["dietary restrictions", "dietary"],
             "deliveryDetails.deliveryInstructions": ["delivery instructions", "instructions"],
           };
 
           for (const [fieldKey, aliases] of Object.entries(fieldMappings)) {
-            if (visibleFieldKeys.has(fieldKey) && aliases.some((alias) => alias === lowerKeyword)) {
+            if (
+              visibleFieldKeys.has(fieldKey) &&
+              aliases.some((alias) => normalizeSearchKeyword(alias) === normalizedKeyword)
+            ) {
               return true;
             }
           }
@@ -664,13 +689,12 @@ const Spreadsheet: React.FC = () => {
             tefapCert: ["tefap", "tefap cert"],
             dob: ["dob"],
             lastDeliveryDate: ["last delivery date"],
-            email: ["email"],
           };
 
           for (const [propertyKey, aliases] of Object.entries(customColumnMappings)) {
             if (
               visibleFieldKeys.has(propertyKey) &&
-              aliases.some((alias) => alias === lowerKeyword)
+              aliases.some((alias) => normalizeSearchKeyword(alias) === normalizedKeyword)
             ) {
               return true;
             }
@@ -682,25 +706,46 @@ const Spreadsheet: React.FC = () => {
         result = result.filter((row) => {
           return keyValueTerms.every((term) => {
             const { keyword, searchValue, isKeyValue: isKeyValueSearch } = extractKeyValue(term);
+            const normalizedKeyword = normalizeSearchKeyword(keyword);
 
             if (isKeyValueSearch && searchValue) {
               if (!isVisibleField(keyword)) {
                 return true;
               }
 
-              switch (keyword) {
+              const searchValues = splitFilterValues(searchValue);
+              const matchesAnySearchValue = (matcher: (candidate: string) => boolean): boolean =>
+                searchValues.some((candidate: string) => matcher(candidate));
+
+              switch (normalizedKeyword) {
                 case "name":
+                  return matchesAnySearchValue(
+                    (candidate) =>
+                      checkStringContains(`${row.firstName ?? ""} ${row.lastName ?? ""}`, candidate) ||
+                      checkStringContains(row.firstName, candidate) ||
+                      checkStringContains(row.lastName, candidate)
+                  );
                 case "firstname":
-                  return checkStringContains(row.firstName, searchValue);
+                  return matchesAnySearchValue((candidate) =>
+                    checkStringContains(row.firstName, candidate)
+                  );
                 case "lastname":
-                  return checkStringContains(row.lastName, searchValue);
+                  return matchesAnySearchValue((candidate) =>
+                    checkStringContains(row.lastName, candidate)
+                  );
                 case "address":
-                  return checkStringContains(row.address, searchValue);
+                  return matchesAnySearchValue((candidate) =>
+                    checkStringContains(row.address, candidate)
+                  );
                 case "phone":
-                  return checkStringContains(row.phone, searchValue);
+                  return matchesAnySearchValue((candidate) =>
+                    checkStringContains(row.phone, candidate)
+                  );
                 case "email":
-                  return checkStringContains(row.email, searchValue);
-                case "dietary restrictions":
+                  return matchesAnySearchValue((candidate) =>
+                    checkStringContains(row.email, candidate)
+                  );
+                case "dietaryrestrictions":
                 case "dietary": {
                   const dr = row.deliveryDetails?.dietaryRestrictions;
                   if (!dr) return false;
@@ -719,17 +764,80 @@ const Spreadsheet: React.FC = () => {
                     ...(Array.isArray(dr.other) ? dr.other : []),
                     dr.otherText || "",
                   ].filter(Boolean);
-                  return dietaryTerms.some((term) => checkStringContains(term, searchValue));
+                  return matchesAnySearchValue((candidate) =>
+                    dietaryTerms.some((dietaryTerm) => checkStringContains(dietaryTerm, candidate))
+                  );
                 }
-                case "delivery instructions":
+                case "deliveryinstructions":
                 case "instructions":
-                  return checkStringContains(
-                    row.deliveryDetails?.deliveryInstructions,
-                    searchValue
+                  return matchesAnySearchValue((candidate) =>
+                    checkStringContains(row.deliveryDetails?.deliveryInstructions, candidate)
+                  );
+                case "adults":
+                  return matchesAnySearchValue((candidate) =>
+                    checkValueOrInArray(row.adults, candidate, true)
+                  );
+                case "children":
+                  return matchesAnySearchValue((candidate) =>
+                    checkValueOrInArray(row.children, candidate, true)
+                  );
+                case "deliveryfreq":
+                case "deliveryfrequency":
+                  return matchesAnySearchValue((candidate) =>
+                    checkStringContains(row.deliveryFreq, candidate)
+                  );
+                case "ethnicity":
+                  return matchesAnySearchValue((candidate) =>
+                    checkStringContains(row.ethnicity, candidate)
+                  );
+                case "gender":
+                  return matchesAnySearchValue((candidate) =>
+                    checkStringContains(row.gender, candidate)
+                  );
+                case "language":
+                  return matchesAnySearchValue((candidate) =>
+                    checkStringContains(row.language, candidate)
+                  );
+                case "notes":
+                  return matchesAnySearchValue((candidate) =>
+                    checkStringContains(row.notes, candidate)
+                  );
+                case "referralentity":
+                case "referral": {
+                  const referralEntity = row.referralEntity;
+
+                  if (referralEntity && typeof referralEntity === "object") {
+                    return matchesAnySearchValue(
+                      (candidate) =>
+                        checkStringContains(referralEntity.name, candidate) ||
+                        checkStringContains(referralEntity.organization, candidate)
+                    );
+                  }
+                  return false;
+                }
+                case "tags":
+                case "tag":
+                  return matchesAnySearchValue((candidate) => checkValueOrInArray(row.tags, candidate));
+                case "tefap":
+                case "tefapcert":
+                  return matchesAnySearchValue((candidate) =>
+                    checkStringContains(row.tefapCert, candidate)
+                  );
+                case "dob":
+                  return matchesAnySearchValue((candidate) =>
+                    checkValueOrInArray(row.dob, candidate, true)
+                  );
+                case "lastdeliverydate":
+                  return matchesAnySearchValue((candidate) =>
+                    checkStringContains(row.lastDeliveryDate, candidate)
                   );
                 default: {
                   const matchesCustomColumn = customColumns.some((col) => {
-                    if (col.propertyKey !== "none" && visibleFieldKeys.has(col.propertyKey)) {
+                    if (
+                      col.propertyKey !== "none" &&
+                      visibleFieldKeys.has(col.propertyKey) &&
+                      normalizeSearchKeyword(col.propertyKey).includes(normalizedKeyword)
+                    ) {
                       if (col.propertyKey.includes(".")) {
                         const keys = col.propertyKey.split(".");
                         let value: unknown = row;
@@ -737,12 +845,16 @@ const Spreadsheet: React.FC = () => {
                           value = value && (value as Record<string, unknown>)[k];
                           if (value === undefined) return false;
                         }
-                        return checkStringContains(String(value || ""), searchValue);
-                      } else {
-                        if (col.propertyKey in row) {
-                          const fieldValue = row[col.propertyKey as keyof RowData];
-                          return checkStringContains(fieldValue, searchValue);
-                        }
+                        return matchesAnySearchValue((candidate) =>
+                          checkValueOrInArray(value, candidate)
+                        );
+                      }
+
+                      if (col.propertyKey in row) {
+                        const fieldValue = row[col.propertyKey as keyof RowData];
+                        return matchesAnySearchValue((candidate) =>
+                          checkValueOrInArray(fieldValue, candidate)
+                        );
                       }
                     }
                     return false;
@@ -878,7 +990,7 @@ const Spreadsheet: React.FC = () => {
               type="text"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              placeholder='Search clients (e.g., smith, name:john, address:"main st")'
+              placeholder='Search clients (e.g., smith, name:john,jane, address:"main st", gender:female,male)'
               style={{
                 width: "100%",
                 height: "50px",

--- a/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.searchFilters.test.ts
+++ b/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.searchFilters.test.ts
@@ -1,0 +1,17 @@
+import fs from "fs";
+import path from "path";
+import { describe, expect, it } from "@jest/globals";
+
+describe("UsersSpreadsheet search filter regression guards", () => {
+  const sourcePath = path.resolve(__dirname, "UsersSpreadsheet.tsx");
+  const source = fs.readFileSync(sourcePath, "utf8");
+
+  it("supports multi-value key:value filters for the Clients page search", () => {
+    expect(source).toContain("splitFilterValues(searchValue)");
+    expect(source).toContain("matchesAnySearchValue");
+  });
+
+  it("shows multi-value examples in the Clients page search placeholder", () => {
+    expect(source).toContain('placeholder="Search users (e.g., role:admin,manager, name:jane,john, email:test@example.com)"');
+  });
+});

--- a/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.tsx
+++ b/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.tsx
@@ -33,6 +33,8 @@ import {
   checkStringContains,
   extractKeyValue,
   globalSearchMatch,
+  normalizeSearchKeyword,
+  splitFilterValues,
 } from "../../utils/searchFilter";
 import { useNavigate } from "react-router-dom";
 import { auth } from "../../auth/firebaseConfig";
@@ -272,7 +274,7 @@ const UsersSpreadsheet: React.FC<UsersSpreadsheetProps> = ({ onAuthStateChangedO
       const visibleFieldKeys = new Set(fields.map((f) => f.key));
 
       const isVisibleField = (keyword: string): boolean => {
-        const lowerKeyword = keyword.toLowerCase();
+        const normalizedKeyword = normalizeSearchKeyword(keyword);
 
         const fieldMappings: { [key: string]: string[] } = {
           name: ["name"],
@@ -284,7 +286,7 @@ const UsersSpreadsheet: React.FC<UsersSpreadsheetProps> = ({ onAuthStateChangedO
         for (const [fieldKey, aliases] of Object.entries(fieldMappings)) {
           if (
             visibleFieldKeys.has(fieldKey as keyof AuthUserRow) &&
-            aliases.some((alias) => alias === lowerKeyword)
+            aliases.some((alias) => normalizeSearchKeyword(alias) === normalizedKeyword)
           ) {
             return true;
           }
@@ -295,21 +297,28 @@ const UsersSpreadsheet: React.FC<UsersSpreadsheetProps> = ({ onAuthStateChangedO
 
       matches = keyValueTerms.every((term) => {
         const { keyword, searchValue, isKeyValue: isKeyValueSearch } = extractKeyValue(term);
+        const normalizedKeyword = normalizeSearchKeyword(keyword);
 
         if (isKeyValueSearch && searchValue) {
           if (!isVisibleField(keyword)) {
             return true;
           }
 
-          switch (keyword) {
+          const searchValues = splitFilterValues(searchValue);
+          const matchesAnySearchValue = (matcher: (candidate: string) => boolean): boolean =>
+            searchValues.some((candidate: string) => matcher(candidate));
+
+          switch (normalizedKeyword) {
             case "name":
-              return checkStringContains(row.name, searchValue);
+              return matchesAnySearchValue((candidate) => checkStringContains(row.name, candidate));
             case "role":
-              return checkStringContains(getRoleDisplayName(row.role), searchValue);
+              return matchesAnySearchValue((candidate) =>
+                checkStringContains(getRoleDisplayName(row.role), candidate)
+              );
             case "phone":
-              return checkStringContains(row.phone, searchValue);
+              return matchesAnySearchValue((candidate) => checkStringContains(row.phone, candidate));
             case "email":
-              return checkStringContains(row.email, searchValue);
+              return matchesAnySearchValue((candidate) => checkStringContains(row.email, candidate));
             default:
               return false;
           }
@@ -404,7 +413,7 @@ const UsersSpreadsheet: React.FC<UsersSpreadsheetProps> = ({ onAuthStateChangedO
                 type="text"
                 value={searchQuery}
                 onChange={handleSearchChange}
-                placeholder="Search users (e.g., admin, name:jane, email:test@example.com)"
+                placeholder="Search users (e.g., role:admin,manager, name:jane,john, email:test@example.com)"
                 style={{
                   width: "100%",
                   height: "50px",

--- a/my-app/src/pages/Delivery/ClusterMap.test.ts
+++ b/my-app/src/pages/Delivery/ClusterMap.test.ts
@@ -23,4 +23,19 @@ describe("ClusterMap popup regression guards", () => {
     expect(source).toMatch(/\.on\("click",\s*\(\)\s*=>\s*\{[\s\S]*?marker\.openPopup\(\)/m);
     expect(source).toMatch(/openMapPopup\s*=\s*\(clientId:\s*string\)\s*=>\s*\{[\s\S]*?marker\.openPopup\(\)/m);
   });
+
+  it("lets the cluster summary overlay toggle sorting by number of deliveries", () => {
+    const sourcePath = path.resolve(__dirname, "ClusterMap.tsx");
+    const source = fs.readFileSync(sourcePath, "utf8");
+
+    expect(source).toContain("clusterSummarySortMode");
+    expect(source).toContain("sortClusterSummaries(");
+    expect(source).toContain("ArrowDownwardIcon");
+    expect(source).toContain("ArrowUpwardIcon");
+    expect(source).toContain("FormatListNumberedIcon");
+    expect(source).toContain("handleClusterSummarySortToggle");
+    expect(source).toContain("Sorting by delivery count (highest first)");
+    expect(source).toContain("Sorting by delivery count (lowest first)");
+    expect(source).toMatch(/<Typography[^>]*>[\s\S]*Sort[\s\S]*<\/Typography>/);
+  });
 });

--- a/my-app/src/pages/Delivery/ClusterMap.test.ts
+++ b/my-app/src/pages/Delivery/ClusterMap.test.ts
@@ -1,6 +1,25 @@
 import fs from "fs";
 import path from "path";
-import { describe, expect, it } from "@jest/globals";
+import React from "react";
+import { describe, expect, it, jest } from "@jest/globals";
+import { render, screen } from "@testing-library/react";
+import ClusterMap from "./ClusterMap";
+
+jest.mock("leaflet", () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock("leaflet.awesome-markers", () => ({}));
+
+jest.mock("../../services/driver-service", () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => ({
+      getAllDrivers: async () => [],
+    }),
+  },
+}));
 
 describe("ClusterMap popup regression guards", () => {
   // Protects against popups opening and immediately closing due to map click propagation
@@ -46,5 +65,24 @@ describe("ClusterMap popup regression guards", () => {
     expect(source).toContain("Sorting by cluster number");
     expect(source).toContain("Renumber clusters to 1-");
     expect(source).toMatch(/<Typography[^>]*>[\s\S]*Sort[\s\S]*<\/Typography>/);
+  });
+
+  it("renders the cluster summary overlay without invalid element errors", async () => {
+    localStorage.setItem("clusterSummaryEnabled", "true");
+
+    render(
+      React.createElement(ClusterMap, {
+        allRows: [],
+        visibleRows: [],
+        clusters: [{ id: "3", deliveries: ["c1", "c2"], driver: "Dana", time: "09:00" }],
+        clientOverrides: [],
+        onClusterUpdate: async () => true,
+        onRenumberClusters: async () => true,
+      })
+    );
+
+    expect(await screen.findByText("Cluster Deliveries")).toBeTruthy();
+    expect(screen.getByText("Day total: 0")).toBeTruthy();
+    expect(screen.getByText("3")).toBeTruthy();
   });
 });

--- a/my-app/src/pages/Delivery/ClusterMap.test.ts
+++ b/my-app/src/pages/Delivery/ClusterMap.test.ts
@@ -36,6 +36,7 @@ describe("ClusterMap popup regression guards", () => {
     expect(source).toContain("handleClusterSummarySortToggle");
     expect(source).toContain("Sorting by delivery count (highest first)");
     expect(source).toContain("Sorting by delivery count (lowest first)");
+    expect(source).toContain("Sorting by cluster number");
     expect(source).toMatch(/<Typography[^>]*>[\s\S]*Sort[\s\S]*<\/Typography>/);
   });
 });

--- a/my-app/src/pages/Delivery/ClusterMap.test.ts
+++ b/my-app/src/pages/Delivery/ClusterMap.test.ts
@@ -36,7 +36,10 @@ describe("ClusterMap popup regression guards", () => {
     expect(source).toContain("handleClusterSummarySortToggle");
     expect(source).toContain("handleClusterReorder");
     expect(source).toContain("usedClusterCount");
-    expect(source).toContain("assignmentSummary.done && canRenumberClusters");
+    expect(source).toContain("hasUnassignedClusterSlots");
+    expect(source).toContain(
+      "assignmentSummary.done && hasUnassignedClusterSlots && canRenumberClusters"
+    );
     expect(source).toContain("Renumber");
     expect(source).toContain("Sorting by delivery count (highest first)");
     expect(source).toContain("Sorting by delivery count (lowest first)");

--- a/my-app/src/pages/Delivery/ClusterMap.test.ts
+++ b/my-app/src/pages/Delivery/ClusterMap.test.ts
@@ -34,9 +34,14 @@ describe("ClusterMap popup regression guards", () => {
     expect(source).toContain("ArrowUpwardIcon");
     expect(source).toContain("FormatListNumberedIcon");
     expect(source).toContain("handleClusterSummarySortToggle");
+    expect(source).toContain("handleClusterReorder");
+    expect(source).toContain("usedClusterCount");
+    expect(source).toContain("assignmentSummary.done && canRenumberClusters");
+    expect(source).toContain("Renumber");
     expect(source).toContain("Sorting by delivery count (highest first)");
     expect(source).toContain("Sorting by delivery count (lowest first)");
     expect(source).toContain("Sorting by cluster number");
+    expect(source).toContain("Renumber clusters to 1-");
     expect(source).toMatch(/<Typography[^>]*>[\s\S]*Sort[\s\S]*<\/Typography>/);
   });
 });

--- a/my-app/src/pages/Delivery/ClusterMap.tsx
+++ b/my-app/src/pages/Delivery/ClusterMap.tsx
@@ -6,6 +6,7 @@ import "leaflet.awesome-markers/dist/leaflet.awesome-markers.css";
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import FormatListNumberedIcon from "@mui/icons-material/FormatListNumbered";
+import RestartAltIcon from "@mui/icons-material/RestartAlt";
 import { Box, FormControlLabel, IconButton, Switch, Tooltip, Typography } from "@mui/material";
 import DriverService from "../../services/driver-service";
 import FFAIcon from "../../assets/tsp-food-for-all-dc-logo.png";
@@ -79,6 +80,7 @@ interface ClusterMapProps {
     newDriver?: string,
     newTime?: string
   ) => Promise<boolean>;
+  onRenumberClusters?: () => Promise<boolean>;
   onOpenPopup?: (clientId: string) => void; // Prop to handle table row clicks
   onMarkerClick?: (clientId: string) => void; // Prop to handle marker clicks
   onClearHighlight?: () => void; // Prop to clear row highlighting
@@ -203,6 +205,7 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
   clusters,
   clientOverrides = [],
   onClusterUpdate,
+  onRenumberClusters,
   onOpenPopup,
   onMarkerClick,
   onClearHighlight,
@@ -342,6 +345,7 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
       return "cluster";
     }
   );
+  const [isReorderingClusters, setIsReorderingClusters] = useState<boolean>(false);
 
   const [wardData, setWardData] = useState<any>(null);
   const [wardDataLoading, setWardDataLoading] = useState<boolean>(false);
@@ -389,6 +393,13 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
     return sortClusterSummaries(summaries, clusterSummarySortMode);
   }, [clusters, clientOverrideByClientId, clusterSummarySortMode]);
 
+  const usedClusterCount = React.useMemo(
+    () => clusterSummaries.filter((summary) => summary.count > 0).length,
+    [clusterSummaries]
+  );
+  const canRenumberClusters =
+    Boolean(onRenumberClusters) && !isReorderingClusters && (usedClusterCount > 1 || usedClusterCount < clusterSummaries.length);
+
   // Toggle cluster summary visibility
   const handleClusterSummaryToggle = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { checked } = event.target;
@@ -407,6 +418,19 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
       localStorage.setItem("clusterSummarySortMode", nextMode);
       return nextMode;
     });
+  };
+
+  const handleClusterReorder = async () => {
+    if (!canRenumberClusters || !onRenumberClusters) {
+      return;
+    }
+
+    try {
+      setIsReorderingClusters(true);
+      await onRenumberClusters();
+    } finally {
+      setIsReorderingClusters(false);
+    }
   };
 
   const getClusterColor = useCallback((clusterIdToCheck: string): string => {
@@ -1540,17 +1564,51 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
                 </Tooltip>
               </Box>
             </Box>
-            <Typography
-              variant="caption"
+            <Box
               sx={{
-                fontSize: "11px",
-                fontWeight: "bold",
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                gap: 0.5,
                 mt: 0.25,
-                color: assignmentSummary.done ? "success.main" : "warning.main",
               }}
             >
-              {assignmentSummary.done ? "Done" : `${assignmentSummary.remaining} remaining`}
-            </Typography>
+              <Typography
+                variant="caption"
+                sx={{
+                  fontSize: "11px",
+                  fontWeight: "bold",
+                  color: assignmentSummary.done ? "success.main" : "warning.main",
+                }}
+              >
+                {assignmentSummary.done ? "Done" : `${assignmentSummary.remaining} remaining`}
+              </Typography>
+              {assignmentSummary.done && canRenumberClusters && (
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                  <Typography variant="caption" sx={{ fontSize: "10px", color: "text.secondary" }}>
+                    Renumber
+                  </Typography>
+                  <Tooltip title={`Renumber clusters to 1-${Math.max(usedClusterCount, 1)}`}>
+                    <span>
+                      <IconButton
+                        size="small"
+                        onClick={handleClusterReorder}
+                        disabled={!canRenumberClusters}
+                        sx={{
+                          p: 0.25,
+                          color: "text.secondary",
+                          border: "1px solid",
+                          borderColor: "divider",
+                          borderRadius: "6px",
+                        }}
+                      >
+                        <RestartAltIcon sx={{ fontSize: "14px" }} />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                </Box>
+              )}
+            </Box>
           </Box>
           <Box sx={{ display: "flex", flexDirection: "column", gap: "6px" }}>
             {clusterSummaries.map(({ clusterId, count, driverLabel, timeLabel }) => {

--- a/my-app/src/pages/Delivery/ClusterMap.tsx
+++ b/my-app/src/pages/Delivery/ClusterMap.tsx
@@ -3,7 +3,10 @@ import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import "leaflet.awesome-markers";
 import "leaflet.awesome-markers/dist/leaflet.awesome-markers.css";
-import { Box, Button, FormControlLabel, Switch, Typography } from "@mui/material";
+import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
+import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
+import FormatListNumberedIcon from "@mui/icons-material/FormatListNumbered";
+import { Box, FormControlLabel, IconButton, Switch, Tooltip, Typography } from "@mui/material";
 import DriverService from "../../services/driver-service";
 import FFAIcon from "../../assets/tsp-food-for-all-dc-logo.png";
 import dataSources from "../../config/dataSources";
@@ -11,6 +14,8 @@ import { normalizeAssignmentValue, resolveAssignmentValue } from "./utils/assign
 import {
   buildAssignmentSummary,
   buildClusterSummariesFromClusters,
+  sortClusterSummaries,
+  type ClusterSummarySortMode,
 } from "./utils/clusterSummary";
 import { TIME_SLOT_LABELS } from "./utils/timeSlots";
 import { getClientStatusPresentation } from "../../utils/clientStatus";
@@ -325,6 +330,18 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
     const saved = localStorage.getItem("clusterSummaryEnabled");
     return saved ? JSON.parse(saved) : true; // Default to true
   });
+  const [clusterSummarySortMode, setClusterSummarySortMode] = useState<ClusterSummarySortMode>(
+    () => {
+      const saved = localStorage.getItem("clusterSummarySortMode");
+      if (saved === "count-asc") {
+        return "count-asc";
+      }
+      if (saved === "count-desc" || saved === "count") {
+        return "count-desc";
+      }
+      return "cluster";
+    }
+  );
 
   const [wardData, setWardData] = useState<any>(null);
   const [wardDataLoading, setWardDataLoading] = useState<boolean>(false);
@@ -363,18 +380,33 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
 
   // Calculate deliveries + assignment details per cluster for the map summary overlay.
   const clusterSummaries = React.useMemo(() => {
-    return buildClusterSummariesFromClusters(
+    const summaries = buildClusterSummariesFromClusters(
       clusters,
       clientOverrideByClientId,
       formatTimeForSummary
     );
-  }, [clusters, clientOverrideByClientId]);
+
+    return sortClusterSummaries(summaries, clusterSummarySortMode);
+  }, [clusters, clientOverrideByClientId, clusterSummarySortMode]);
 
   // Toggle cluster summary visibility
   const handleClusterSummaryToggle = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { checked } = event.target;
     setShowClusterSummary(checked);
     localStorage.setItem("clusterSummaryEnabled", JSON.stringify(checked));
+  };
+
+  const handleClusterSummarySortToggle = () => {
+    setClusterSummarySortMode((previousMode) => {
+      const nextMode =
+        previousMode === "cluster"
+          ? "count-desc"
+          : previousMode === "count-desc"
+            ? "count-asc"
+            : "cluster";
+      localStorage.setItem("clusterSummarySortMode", nextMode);
+      return nextMode;
+    });
   };
 
   const getClusterColor = useCallback((clusterIdToCheck: string): string => {
@@ -1454,16 +1486,60 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
             sx={{
               display: "flex",
               flexDirection: "column",
-              alignItems: "flex-start",
+              alignItems: "stretch",
               mb: 1,
               pb: 1,
               borderBottom: "1px solid",
               borderColor: "divider",
+              gap: 0.25,
             }}
           >
-            <Typography variant="caption" sx={{ fontSize: "11px", color: "text.secondary" }}>
-              Assigned: {assignmentSummary.assigned}/{assignmentSummary.total}
-            </Typography>
+            <Box
+              sx={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                gap: 0.5,
+              }}
+            >
+              <Typography variant="caption" sx={{ fontSize: "11px", color: "text.secondary" }}>
+                Assigned: {assignmentSummary.assigned}/{assignmentSummary.total}
+              </Typography>
+              <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                <Typography variant="caption" sx={{ fontSize: "10px", color: "text.secondary" }}>
+                  Sort
+                </Typography>
+                <Tooltip
+                  title={
+                    clusterSummarySortMode === "count-desc"
+                      ? "Sorting by delivery count (highest first)"
+                      : clusterSummarySortMode === "count-asc"
+                        ? "Sorting by delivery count (lowest first)"
+                        : "Sorting by route order"
+                  }
+                >
+                  <IconButton
+                    size="small"
+                    onClick={handleClusterSummarySortToggle}
+                    sx={{
+                      p: 0.25,
+                      color: "text.secondary",
+                      border: "1px solid",
+                      borderColor: "divider",
+                      borderRadius: "6px",
+                    }}
+                  >
+                    {clusterSummarySortMode === "count-desc" ? (
+                      <ArrowDownwardIcon sx={{ fontSize: "14px" }} />
+                    ) : clusterSummarySortMode === "count-asc" ? (
+                      <ArrowUpwardIcon sx={{ fontSize: "14px" }} />
+                    ) : (
+                      <FormatListNumberedIcon sx={{ fontSize: "14px" }} />
+                    )}
+                  </IconButton>
+                </Tooltip>
+              </Box>
+            </Box>
             <Typography
               variant="caption"
               sx={{

--- a/my-app/src/pages/Delivery/ClusterMap.tsx
+++ b/my-app/src/pages/Delivery/ClusterMap.tsx
@@ -1515,7 +1515,7 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
                       ? "Sorting by delivery count (highest first)"
                       : clusterSummarySortMode === "count-asc"
                         ? "Sorting by delivery count (lowest first)"
-                        : "Sorting by route order"
+                        : "Sorting by cluster number"
                   }
                 >
                   <IconButton

--- a/my-app/src/pages/Delivery/ClusterMap.tsx
+++ b/my-app/src/pages/Delivery/ClusterMap.tsx
@@ -397,8 +397,51 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
     () => clusterSummaries.filter((summary) => summary.count > 0).length,
     [clusterSummaries]
   );
-  const canRenumberClusters =
-    Boolean(onRenumberClusters) && !isReorderingClusters && (usedClusterCount > 1 || usedClusterCount < clusterSummaries.length);
+  const hasUnassignedClusterSlots = React.useMemo(() => {
+    const normalizedClusters = clusters
+      .map((cluster) => {
+        const clusterId = String(cluster.id ?? "").trim();
+        const deliveryCount = Array.from(
+          new Set(
+            (cluster.deliveries ?? [])
+              .map((deliveryId) => normalizeAssignmentValue(deliveryId))
+              .filter((deliveryId): deliveryId is string => Boolean(deliveryId))
+          )
+        ).length;
+
+        return { clusterId, deliveryCount };
+      })
+      .filter((cluster) => Boolean(cluster.clusterId));
+
+    if (!normalizedClusters.length) {
+      return false;
+    }
+
+    if (normalizedClusters.some((cluster) => cluster.deliveryCount === 0)) {
+      return true;
+    }
+
+    const usedClusterNumbers = normalizedClusters
+      .filter((cluster) => cluster.deliveryCount > 0)
+      .map((cluster) => {
+        const match = cluster.clusterId.match(/\d+/);
+        return match ? Number(match[0]) : Number.NaN;
+      });
+
+    if (
+      !usedClusterNumbers.length ||
+      usedClusterNumbers.some((clusterNumber) => !Number.isFinite(clusterNumber))
+    ) {
+      return false;
+    }
+
+    const sortedUsedClusterNumbers = [...usedClusterNumbers].sort((left, right) => left - right);
+
+    return sortedUsedClusterNumbers.some(
+      (clusterNumber, index) => clusterNumber !== index + 1
+    );
+  }, [clusters]);
+  const canRenumberClusters = Boolean(onRenumberClusters) && !isReorderingClusters;
 
   // Toggle cluster summary visibility
   const handleClusterSummaryToggle = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -1583,7 +1626,7 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
               >
                 {assignmentSummary.done ? "Done" : `${assignmentSummary.remaining} remaining`}
               </Typography>
-              {assignmentSummary.done && canRenumberClusters && (
+              {assignmentSummary.done && hasUnassignedClusterSlots && canRenumberClusters && (
                 <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
                   <Typography variant="caption" sx={{ fontSize: "10px", color: "text.secondary" }}>
                     Renumber

--- a/my-app/src/pages/Delivery/ClusterMap.tsx
+++ b/my-app/src/pages/Delivery/ClusterMap.tsx
@@ -11,6 +11,8 @@ import { Box, FormControlLabel, IconButton, Switch, Tooltip, Typography } from "
 import DriverService from "../../services/driver-service";
 import FFAIcon from "../../assets/tsp-food-for-all-dc-logo.png";
 import dataSources from "../../config/dataSources";
+import { isRenderableCoordinate } from "./utils/deliveryMapCounts";
+import { buildMarkerPlacementMap } from "./utils/markerPlacement";
 import { normalizeAssignmentValue, resolveAssignmentValue } from "./utils/assignmentOverrides";
 import {
   buildAssignmentSummary,
@@ -101,27 +103,7 @@ const wardColors: { [key: string]: string } = {
 
 const ffaCoordinates: L.LatLngExpression = [38.91433, -77.036942];
 
-const isValidCoordinate = (coord: any): boolean => {
-  if (!coord) return false;
-
-  if (Array.isArray(coord)) {
-    return (
-      coord.length === 2 &&
-      !isNaN(coord[0]) &&
-      !isNaN(coord[1]) &&
-      Math.abs(coord[0]) <= 90 &&
-      Math.abs(coord[1]) <= 180
-    );
-  }
-
-  return (
-    typeof coord === "object" &&
-    !isNaN(coord.lat) &&
-    !isNaN(coord.lng) &&
-    Math.abs(coord.lat) <= 90 &&
-    Math.abs(coord.lng) <= 180
-  );
-};
+const isValidCoordinate = isRenderableCoordinate;
 
 const normalizeCoordinate = (coord: any): Coordinate => {
   if (Array.isArray(coord)) {
@@ -839,10 +821,12 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
       });
     });
 
+    const markerPlacements = buildMarkerPlacementMap(visibleRows);
+
     visibleRows.forEach((client) => {
       if (!client.coordinates || !isValidCoordinate(client.coordinates)) return;
 
-      const coord = normalizeCoordinate(client.coordinates);
+      const coord = markerPlacements.get(client.id) ?? normalizeCoordinate(client.coordinates);
       const clientName = `${client.firstName} ${client.lastName}` || "Client: None";
       const statusPresentation = getClientStatusPresentation(
         client.activeStatus === false ? false : true,

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.searchAliases.test.ts
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.searchAliases.test.ts
@@ -31,6 +31,14 @@ describe("DeliverySpreadsheet search alias regression guards", () => {
     expect(source).toContain("moveClientsToCluster(");
   });
 
+  it("lets the map popup use the same selected-row bulk reassignment behavior", () => {
+    expect(source).toContain("const selectedClientRows = selectedRows.has(clientId)");
+    expect(source).toContain("rows.filter((candidateRow) => selectedRows.has(candidateRow.id))");
+    expect(source).toContain(
+      "rows.filter((candidateRow) => normalizeClusterIdValue(candidateRow.clusterId) === oldClusterId)"
+    );
+  });
+
   it("preserves empty source clusters after moving all deliveries to a new route", () => {
     expect(source).not.toContain("if (!normalizedClusterId || normalizedDeliveries.length === 0)");
     expect(source).toContain("if (!normalizedClusterId) {");

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.searchAliases.test.ts
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.searchAliases.test.ts
@@ -25,4 +25,15 @@ describe("DeliverySpreadsheet search alias regression guards", () => {
       /customColumnMappings[\s\S]*aliases\.some\(\(alias\) => normalizeSearchKeyword\(alias\) === normalizedKeyword\)/
     );
   });
+
+  it("bulk reassigns all checked rows when changing the route dropdown for a selected cluster", () => {
+    expect(source).toContain("selectedRows.has(row.id)");
+    expect(source).toContain("moveClientsToCluster(");
+  });
+
+  it("preserves empty source clusters after moving all deliveries to a new route", () => {
+    expect(source).not.toContain("if (!normalizedClusterId || normalizedDeliveries.length === 0)");
+    expect(source).toContain("if (!normalizedClusterId) {");
+    expect(source).toContain("deliveries: normalizedDeliveries");
+  });
 });

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.searchAliases.test.ts
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.searchAliases.test.ts
@@ -31,11 +31,29 @@ describe("DeliverySpreadsheet search alias regression guards", () => {
     expect(source).toContain("moveClientsToCluster(");
   });
 
+  it("derives route reassignment ids from transaction state instead of render state", () => {
+    expect(source).toContain("getClusterIdForClient(currentState.clusters, clientId)");
+    expect(source).toContain("getNextClusterId(currentState.clusters)");
+  });
+
   it("lets the map popup use the same selected-row bulk reassignment behavior", () => {
     expect(source).toContain("const selectedClientRows = selectedRows.has(clientId)");
     expect(source).toContain("rows.filter((candidateRow) => selectedRows.has(candidateRow.id))");
-    expect(source).toContain(
-      "rows.filter((candidateRow) => normalizeClusterIdValue(candidateRow.clusterId) === oldClusterId)"
+    expect(source).toContain(": [currentClient];");
+  });
+
+  it("keeps driver and time filters aligned with rendered override values", () => {
+    expect(source).toContain(".compute?.(row, clusters, clientOverrides)");
+    expect(source).toContain("[rows, searchQuery, customColumns, clusters, clientOverrides]");
+  });
+
+  it("resolves nested custom-column values for key:value filters", () => {
+    expect(source).toContain("const fieldValue = getNestedPropertyValue(row, col.propertyKey);");
+  });
+
+  it("clears stale route selections after renumbering clusters", () => {
+    expect(source).toMatch(
+      /handleRenumberClusters[\s\S]*setSelectedRows\(new Set\(\)\)[\s\S]*setSelectedClusters\(new Set\(\)\)/
     );
   });
 
@@ -47,7 +65,7 @@ describe("DeliverySpreadsheet search alias regression guards", () => {
 
   it("shows a filtered total count when a route search is active", () => {
     expect(source).toContain("hasActiveRouteFilter && (");
-    expect(source).toContain('Showing {sortedRows.length} filtered ');
-    expect(source).toContain('of {rows.length}');
+    expect(source).toContain("Showing {sortedRows.length} filtered ");
+    expect(source).toContain("of {rows.length}");
   });
 });

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.searchAliases.test.ts
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.searchAliases.test.ts
@@ -36,4 +36,10 @@ describe("DeliverySpreadsheet search alias regression guards", () => {
     expect(source).toContain("if (!normalizedClusterId) {");
     expect(source).toContain("deliveries: normalizedDeliveries");
   });
+
+  it("shows a filtered total count when a route search is active", () => {
+    expect(source).toContain("hasActiveRouteFilter && (");
+    expect(source).toContain('Showing {sortedRows.length} filtered ');
+    expect(source).toContain('of {rows.length}');
+  });
 });

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -17,6 +17,7 @@ import { db } from "../../auth/firebaseConfig";
 import dataSources from "../../config/dataSources";
 import { useClientData } from "../../context/ClientDataContext";
 import { ClientProfile } from "../../types/client-types";
+import { isRenderableCoordinate } from "./utils/deliveryMapCounts";
 
 import {
   parseSearchTermsProgressively,
@@ -1434,22 +1435,7 @@ const DeliverySpreadsheet: React.FC = () => {
   const isValidCoordinate = (
     coord: LatLngTuple | { lat: number; lng: number } | undefined | null
   ): coord is LatLngTuple | { lat: number; lng: number } => {
-    if (!coord) return false;
-    if (Array.isArray(coord)) {
-      // Check for LatLngTuple [number, number]
-      return (
-        coord.length === 2 &&
-        typeof coord[0] === "number" &&
-        typeof coord[1] === "number" &&
-        (coord[0] !== 0 || coord[1] !== 0)
-      );
-    }
-    // Check for { lat: number, lng: number }
-    return (
-      typeof coord.lat === "number" &&
-      typeof coord.lng === "number" &&
-      (coord.lat !== 0 || coord.lng !== 0)
-    );
+    return isRenderableCoordinate(coord);
   };
 
   const generateClusters = async (

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -21,9 +21,11 @@ import { ClientProfile } from "../../types/client-types";
 import {
   parseSearchTermsProgressively,
   checkStringContains as utilCheckStringContains,
+  checkStringEquals as utilCheckStringEquals,
   extractKeyValue,
   globalSearchMatch,
   normalizeSearchKeyword,
+  splitFilterValues,
 } from "../../utils/searchFilter";
 import { query, Timestamp, updateDoc, where, orderBy, runTransaction } from "firebase/firestore";
 import { TimeUtils } from "../../utils/timeUtils";
@@ -102,6 +104,7 @@ import {
   assignTimeToRoutes,
   findRouteSlotConflict,
   moveClientToCluster,
+  moveClientsToCluster,
   RouteAssignmentMutationResult,
   RouteAssignmentState,
   RouteSlotConflict,
@@ -559,7 +562,7 @@ const DeliverySpreadsheet: React.FC = () => {
         )
       );
 
-      if (!normalizedClusterId || normalizedDeliveries.length === 0) {
+      if (!normalizedClusterId) {
         return;
       }
 
@@ -1130,14 +1133,56 @@ const DeliverySpreadsheet: React.FC = () => {
         ? getNextClusterId(clusters)
         : normalizeClusterIdValue(newClusterIdStr);
 
-    if (!row || !row.id || newClusterId === oldClusterId) {
+    if (!row || !row.id) {
+      return false;
+    }
+
+    const selectedClientRows = selectedRows.has(row.id)
+      ? rows.filter((candidateRow) => selectedRows.has(candidateRow.id))
+      : [row];
+
+    const rowsToMove = selectedClientRows.filter(
+      (candidateRow) => normalizeClusterIdValue(candidateRow.clusterId) !== newClusterId
+    );
+
+    if (!rowsToMove.length) {
       return false;
     }
 
     try {
-      return await commitRouteAssignmentMutation((currentState) =>
-        moveClientToCluster(currentState, row.id, oldClusterId, newClusterId)
+      const didSave = await commitRouteAssignmentMutation((currentState) =>
+        rowsToMove.length > 1
+          ? moveClientsToCluster(
+              currentState,
+              rowsToMove.map((candidateRow) => ({
+                clientId: candidateRow.id,
+                oldClusterId: normalizeClusterIdValue(candidateRow.clusterId),
+              })),
+              newClusterId
+            )
+          : moveClientToCluster(currentState, row.id, oldClusterId, newClusterId)
       );
+
+      if (didSave && selectedRows.has(row.id)) {
+        if (newClusterId) {
+          setSelectedRows(new Set(selectedClientRows.map((candidateRow) => candidateRow.id)));
+          setSelectedClusters(
+            new Set([
+              {
+                id: newClusterId,
+                deliveries: selectedClientRows.map((candidateRow) => candidateRow.id),
+                driver: "",
+                time: "",
+              } as Cluster,
+            ])
+          );
+        } else {
+          setSelectedRows(new Set());
+          setSelectedClusters(new Set());
+        }
+      }
+
+      return didSave;
     } catch (error) {
       handleAssignmentSaveError(error, "Unable to update the route assignment. Please try again.");
       return false;
@@ -1715,16 +1760,24 @@ const DeliverySpreadsheet: React.FC = () => {
 
     if (keyValueTerms.length > 0) {
       const checkStringContains = utilCheckStringContains;
+      const checkStringEquals = utilCheckStringEquals;
 
-      const checkValueOrInArray = (value: unknown, query: string): boolean => {
+      const checkValueOrInArray = (
+        value: unknown,
+        query: string,
+        exactMatch = false
+      ): boolean => {
         if (value === undefined || value === null) {
           return false;
         }
-        const lowerQuery = query.toLowerCase();
+
         if (Array.isArray(value)) {
-          return value.some((item) => String(item).toLowerCase().includes(lowerQuery));
+          return value.some((item) =>
+            exactMatch ? checkStringEquals(item, query) : checkStringContains(item, query)
+          );
         }
-        return String(value).toLowerCase().includes(lowerQuery);
+
+        return exactMatch ? checkStringEquals(value, query) : checkStringContains(value, query);
       };
 
       const visibleFieldKeys = new Set([
@@ -1795,39 +1848,45 @@ const DeliverySpreadsheet: React.FC = () => {
           if (!isVisibleField(keyword)) {
             return true;
           }
+
+          const searchValues = splitFilterValues(searchValue);
+          const matchesAnySearchValue = (matcher: (candidate: string) => boolean): boolean =>
+            searchValues.some((candidate: string) => matcher(candidate));
+
           switch (normalizedKeyword) {
             case "name":
             case "client":
-              return (
-                checkStringContains(`${row.firstName} ${row.lastName}`, searchValue) ||
-                checkStringContains(row.firstName, searchValue) ||
-                checkStringContains(row.lastName, searchValue)
+              return matchesAnySearchValue(
+                (candidate) =>
+                  checkStringContains(`${row.firstName} ${row.lastName}`, candidate) ||
+                  checkStringContains(row.firstName, candidate) ||
+                  checkStringContains(row.lastName, candidate)
               );
             case "address":
-              return checkStringContains(row.address, searchValue);
+              return matchesAnySearchValue((candidate) => checkStringContains(row.address, candidate));
             case "ward":
-              return checkStringContains(row.ward, searchValue);
+              return matchesAnySearchValue((candidate) => checkStringEquals(row.ward, candidate));
             case "zip":
             case "zipcode":
-              return checkStringContains(row.zipCode, searchValue);
+              return matchesAnySearchValue((candidate) => checkStringEquals(row.zipCode, candidate));
             case "cluster":
             case "clusterid":
             case "route":
             case "routeid":
-              return checkStringContains(row.clusterId, searchValue);
+              return matchesAnySearchValue((candidate) => checkStringEquals(row.clusterId, candidate));
             case "driver":
             case "assigneddriver": {
               const driverName = fields
                 .find((f) => f.key === "assignedDriver")
                 ?.compute?.(row, clusters);
-              return checkStringContains(driverName, searchValue);
+              return matchesAnySearchValue((candidate) => checkStringContains(driverName, candidate));
             }
             case "time":
             case "assignedtime": {
               const assignedTime = fields
                 .find((f) => f.key === "assignedTime")
                 ?.compute?.(row, clusters);
-              return checkStringContains(assignedTime, searchValue);
+              return matchesAnySearchValue((candidate) => checkStringContains(assignedTime, candidate));
             }
             case "deliveryinstructions":
             case "instructions": {
@@ -1837,39 +1896,44 @@ const DeliverySpreadsheet: React.FC = () => {
                   { key: "deliveryDetails.deliveryInstructions" }
                 >
               ).compute?.(row);
-              return checkStringContains(instructions, searchValue);
+              return matchesAnySearchValue((candidate) => checkStringContains(instructions, candidate));
             }
             case "tags":
             case "tag":
-              return checkValueOrInArray(row.tags, searchValue);
+              return matchesAnySearchValue((candidate) => checkValueOrInArray(row.tags, candidate));
             case "phone":
-              return checkStringContains(row.phone, searchValue);
+              return matchesAnySearchValue((candidate) => checkStringContains(row.phone, candidate));
             case "ethnicity":
-              return checkStringContains(row.ethnicity, searchValue);
+              return matchesAnySearchValue((candidate) => checkStringContains(row.ethnicity, candidate));
             case "adults":
-              return checkValueOrInArray(row.adults, searchValue);
+              return matchesAnySearchValue((candidate) =>
+                checkValueOrInArray(row.adults, candidate, true)
+              );
             case "children":
-              return checkValueOrInArray(row.children, searchValue);
+              return matchesAnySearchValue((candidate) =>
+                checkValueOrInArray(row.children, candidate, true)
+              );
             case "deliveryfreq":
             case "deliveryfrequency":
-              return checkStringContains(row.deliveryFreq, searchValue);
+              return matchesAnySearchValue((candidate) => checkStringContains(row.deliveryFreq, candidate));
             case "gender":
-              return checkStringContains(row.gender, searchValue);
+              return matchesAnySearchValue((candidate) => checkStringContains(row.gender, candidate));
             case "language":
-              return checkStringContains(row.language, searchValue);
+              return matchesAnySearchValue((candidate) => checkStringContains(row.language, candidate));
             case "notes":
-              return checkStringContains(row.notes, searchValue);
+              return matchesAnySearchValue((candidate) => checkStringContains(row.notes, candidate));
             case "tefap":
             case "tefapcert":
-              return checkStringContains(row.tefapCert, searchValue);
+              return matchesAnySearchValue((candidate) => checkStringContains(row.tefapCert, candidate));
             case "dob":
-              return checkValueOrInArray(row.dob, searchValue);
+              return matchesAnySearchValue((candidate) => checkValueOrInArray(row.dob, candidate, true));
             case "referralentity":
             case "referral": {
               if (row.referralEntity && typeof row.referralEntity === "object") {
-                return (
-                  checkStringContains(row.referralEntity.name, searchValue) ||
-                  checkStringContains(row.referralEntity.organization, searchValue)
+                return matchesAnySearchValue(
+                  (candidate) =>
+                    checkStringContains(row.referralEntity.name, candidate) ||
+                    checkStringContains(row.referralEntity.organization, candidate)
                 );
               }
               return false;
@@ -1882,7 +1946,9 @@ const DeliverySpreadsheet: React.FC = () => {
                 ) {
                   if (col.propertyKey in row) {
                     const fieldValue = row[col.propertyKey as keyof DeliveryRowData];
-                    return checkStringContains(fieldValue, searchValue);
+                    return matchesAnySearchValue((candidate) =>
+                      checkStringContains(fieldValue, candidate)
+                    );
                   }
                 }
                 return false;
@@ -2614,7 +2680,7 @@ const DeliverySpreadsheet: React.FC = () => {
               type="text"
               value={searchQuery}
               onChange={handleSearchChange}
-              placeholder='Search deliveries (e.g., cluster:12, ward:7, driver:maria, name:"john smith")'
+              placeholder='Search deliveries (e.g., cluster:1,2, ward:7, driver:maria, name:"john smith")'
               style={{
                 width: "100%",
                 height: "60px",

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -105,6 +105,7 @@ import {
   findRouteSlotConflict,
   moveClientToCluster,
   moveClientsToCluster,
+  renumberRoutesSequentially,
   RouteAssignmentMutationResult,
   RouteAssignmentState,
   RouteSlotConflict,
@@ -722,6 +723,17 @@ const DeliverySpreadsheet: React.FC = () => {
     [selectedClusters]
   );
 
+  const handleRenumberClusters = React.useCallback(async (): Promise<boolean> => {
+    try {
+      return await commitRouteAssignmentMutation((currentState) =>
+        renumberRoutesSequentially(currentState)
+      );
+    } catch (error) {
+      handleAssignmentSaveError(error, "Unable to renumber clusters. Please try again.");
+      return false;
+    }
+  }, [commitRouteAssignmentMutation, handleAssignmentSaveError]);
+
   // Sorting state - default to sorting by fullname (Client) in ascending order
   // Always default to sorting by name (fullname) ascending on first load or reload
   const [sortedColumn, setSortedColumn] = useState<string>(() => {
@@ -1258,15 +1270,57 @@ const DeliverySpreadsheet: React.FC = () => {
       const timeUpdateRequested = newTime !== undefined;
 
       const currentClient = rows.find((row) => row.id === clientId);
-      const oldClusterId = normalizeClusterIdValue(currentClient?.clusterId);
+      if (!currentClient) {
+        return false;
+      }
+
+      const oldClusterId = normalizeClusterIdValue(currentClient.clusterId);
       const clusterChanged = oldClusterId !== resolvedClusterId;
+      const currentClusterRows = oldClusterId
+        ? rows.filter((candidateRow) => normalizeClusterIdValue(candidateRow.clusterId) === oldClusterId)
+        : [currentClient];
+      const selectedClientRows = selectedRows.has(clientId)
+        ? rows.filter((candidateRow) => selectedRows.has(candidateRow.id))
+        : clusterChanged && currentClusterRows.length > 0
+          ? currentClusterRows
+          : [currentClient];
+      const rowsToMove = clusterChanged
+        ? selectedClientRows.filter(
+            (candidateRow) => normalizeClusterIdValue(candidateRow.clusterId) !== resolvedClusterId
+          )
+        : [];
 
       if (!clusterChanged && !driverUpdateRequested && !timeUpdateRequested) {
         return false;
       }
 
-      const didSave = await commitRouteAssignmentMutation((currentState) =>
-        updateClientRouteAssignment(currentState, {
+      const didSave = await commitRouteAssignmentMutation((currentState) => {
+        if (clusterChanged && rowsToMove.length > 1) {
+          const movedState = moveClientsToCluster(
+            currentState,
+            rowsToMove.map((candidateRow) => ({
+              clientId: candidateRow.id,
+              oldClusterId: normalizeClusterIdValue(candidateRow.clusterId),
+            })),
+            resolvedClusterId
+          );
+
+          if (!resolvedClusterId || (!driverUpdateRequested && !timeUpdateRequested)) {
+            return movedState;
+          }
+
+          return updateClientRouteAssignment(movedState, {
+            clientId,
+            oldClusterId: resolvedClusterId,
+            newClusterId: resolvedClusterId,
+            driverUpdateRequested,
+            timeUpdateRequested,
+            driverValue: newDriver,
+            timeValue: newTime,
+          });
+        }
+
+        return updateClientRouteAssignment(currentState, {
           clientId,
           oldClusterId,
           newClusterId: resolvedClusterId,
@@ -1274,42 +1328,58 @@ const DeliverySpreadsheet: React.FC = () => {
           timeUpdateRequested,
           driverValue: newDriver,
           timeValue: newTime,
-        })
-      );
+        });
+      });
 
       if (!didSave) {
         return false;
       }
 
-      // Remove the client from selected rows since their cluster assignment changed
+      // Keep the same bulk-selection behavior in the map popup as the spreadsheet route dropdown.
       if (clusterChanged) {
-        const newSelectedRows = new Set(selectedRows);
-        const newSelectedClusters = new Set(selectedClusters);
-
-        // Remove the client from selected rows
-        newSelectedRows.delete(clientId);
-
-        // If the old cluster no longer has any selected clients, remove it from selected clusters
-        if (oldClusterId) {
-          const oldCluster = clusters.find((c) => normalizeClusterIdValue(c.id) === oldClusterId);
-          if (oldCluster) {
-            const hasSelectedClientsInOldCluster = oldCluster.deliveries.some(
-              (id) => id !== clientId && newSelectedRows.has(id)
+        if (selectedRows.has(clientId)) {
+          if (resolvedClusterId) {
+            setSelectedRows(new Set(selectedClientRows.map((candidateRow) => candidateRow.id)));
+            setSelectedClusters(
+              new Set([
+                {
+                  id: resolvedClusterId,
+                  deliveries: selectedClientRows.map((candidateRow) => candidateRow.id),
+                  driver: "",
+                  time: "",
+                } as Cluster,
+              ])
             );
-            if (!hasSelectedClientsInOldCluster) {
-              // Remove the old cluster from selected clusters
-              const clusterToRemove = Array.from(newSelectedClusters).find(
-                (c) => normalizeClusterIdValue(c.id) === oldClusterId
+          } else {
+            setSelectedRows(new Set());
+            setSelectedClusters(new Set());
+          }
+        } else {
+          const newSelectedRows = new Set(selectedRows);
+          const newSelectedClusters = new Set(selectedClusters);
+
+          newSelectedRows.delete(clientId);
+
+          if (oldClusterId) {
+            const oldCluster = clusters.find((c) => normalizeClusterIdValue(c.id) === oldClusterId);
+            if (oldCluster) {
+              const hasSelectedClientsInOldCluster = oldCluster.deliveries.some(
+                (id) => id !== clientId && newSelectedRows.has(id)
               );
-              if (clusterToRemove) {
-                newSelectedClusters.delete(clusterToRemove);
+              if (!hasSelectedClientsInOldCluster) {
+                const clusterToRemove = Array.from(newSelectedClusters).find(
+                  (c) => normalizeClusterIdValue(c.id) === oldClusterId
+                );
+                if (clusterToRemove) {
+                  newSelectedClusters.delete(clusterToRemove);
+                }
               }
             }
           }
-        }
 
-        setSelectedRows(newSelectedRows);
-        setSelectedClusters(newSelectedClusters);
+          setSelectedRows(newSelectedRows);
+          setSelectedClusters(newSelectedClusters);
+        }
       }
 
       return true;
@@ -2620,6 +2690,7 @@ const DeliverySpreadsheet: React.FC = () => {
             visibleRows={visibleRows}
             clientOverrides={clientOverrides}
             onClusterUpdate={handleIndividualClientUpdate}
+            onRenumberClusters={handleRenumberClusters}
             onOpenPopup={handleRowClick}
             onMarkerClick={handleMarkerClick}
             onClearHighlight={clearRowHighlight}

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -2694,6 +2694,11 @@ const DeliverySpreadsheet: React.FC = () => {
               }}
             />
           </Box>
+          {hasActiveRouteFilter && (
+            <Typography variant="body2" sx={{ color: "text.secondary", px: 1 }}>
+              Showing {sortedRows.length} filtered {sortedRows.length === 1 ? "delivery" : "deliveries"} of {rows.length}
+            </Typography>
+          )}
           <Box sx={{ display: "flex", justifyContent: "space-between", marginTop: "16px" }}>
             {/* Left group: Assign Driver and Assign Time */}
             <Box sx={{ display: "flex", width: "100%", gap: "8px", flexWrap: "wrap" }}>

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -332,6 +332,48 @@ const normalizeClusterIdValue = (clusterId?: unknown): string => {
   return normalizeAssignmentValue(clusterId) || "";
 };
 
+const getNextClusterId = (clusterList: Array<Pick<Cluster, "id">>): string => {
+  const numericIds = clusterList
+    .map((cluster) => parseInt(normalizeClusterIdValue(cluster.id), 10))
+    .filter((clusterId) => !Number.isNaN(clusterId));
+
+  const maxId = numericIds.length > 0 ? Math.max(...numericIds) : 0;
+  return String(maxId + 1);
+};
+
+const getClusterIdForClient = (
+  clusterList: Array<Pick<Cluster, "id" | "deliveries">>,
+  clientId: string
+): string => {
+  const normalizedClientId = normalizeAssignmentValue(clientId);
+  if (!normalizedClientId) {
+    return "";
+  }
+
+  let matchedClusterId = "";
+
+  clusterList.forEach((cluster) => {
+    const hasClient = (cluster.deliveries ?? []).some(
+      (deliveryId) => normalizeAssignmentValue(deliveryId) === normalizedClientId
+    );
+
+    if (hasClient) {
+      matchedClusterId = normalizeClusterIdValue(cluster.id);
+    }
+  });
+
+  return matchedClusterId;
+};
+
+const getNestedPropertyValue = (source: unknown, path: string): unknown =>
+  path.split(".").reduce<unknown>((currentValue, key) => {
+    if (currentValue && typeof currentValue === "object" && key in currentValue) {
+      return (currentValue as Record<string, unknown>)[key];
+    }
+
+    return undefined;
+  }, source);
+
 const compareClusterIds = (left: string, right: string) => {
   const leftNumber = parseInt(left, 10);
   const rightNumber = parseInt(right, 10);
@@ -341,15 +383,6 @@ const compareClusterIds = (left: string, right: string) => {
   }
 
   return left.localeCompare(right, undefined, { numeric: true, sensitivity: "base" });
-};
-
-const getNextClusterId = (clusterList: Array<Pick<Cluster, "id">>): string => {
-  const numericIds = clusterList
-    .map((cluster) => parseInt(normalizeClusterIdValue(cluster.id), 10))
-    .filter((clusterId) => !Number.isNaN(clusterId));
-
-  const maxId = numericIds.length > 0 ? Math.max(...numericIds) : 0;
-  return String(maxId + 1);
 };
 
 class RouteSlotConflictError extends Error {
@@ -726,9 +759,16 @@ const DeliverySpreadsheet: React.FC = () => {
 
   const handleRenumberClusters = React.useCallback(async (): Promise<boolean> => {
     try {
-      return await commitRouteAssignmentMutation((currentState) =>
+      const didSave = await commitRouteAssignmentMutation((currentState) =>
         renumberRoutesSequentially(currentState)
       );
+
+      if (didSave) {
+        setSelectedRows(new Set());
+        setSelectedClusters(new Set());
+      }
+
+      return didSave;
     } catch (error) {
       handleAssignmentSaveError(error, "Unable to renumber clusters. Please try again.");
       return false;
@@ -1140,50 +1180,59 @@ const DeliverySpreadsheet: React.FC = () => {
     row: DeliveryRowData,
     newClusterIdStr: string
   ): Promise<boolean> => {
-    const oldClusterId = normalizeClusterIdValue(row.clusterId);
-    const newClusterId =
-      newClusterIdStr === "__add__"
-        ? getNextClusterId(clusters)
-        : normalizeClusterIdValue(newClusterIdStr);
-
     if (!row || !row.id) {
       return false;
     }
 
-    const selectedClientRows = selectedRows.has(row.id)
-      ? rows.filter((candidateRow) => selectedRows.has(candidateRow.id))
-      : [row];
-
-    const rowsToMove = selectedClientRows.filter(
-      (candidateRow) => normalizeClusterIdValue(candidateRow.clusterId) !== newClusterId
-    );
-
-    if (!rowsToMove.length) {
-      return false;
-    }
+    const selectedClientIds = selectedRows.has(row.id)
+      ? rows
+          .filter((candidateRow) => selectedRows.has(candidateRow.id))
+          .map((candidateRow) => candidateRow.id)
+      : [row.id];
+    let resolvedNewClusterId = "";
+    let didMoveClients = false;
 
     try {
-      const didSave = await commitRouteAssignmentMutation((currentState) =>
-        rowsToMove.length > 1
-          ? moveClientsToCluster(
-              currentState,
-              rowsToMove.map((candidateRow) => ({
-                clientId: candidateRow.id,
-                oldClusterId: normalizeClusterIdValue(candidateRow.clusterId),
-              })),
-              newClusterId
-            )
-          : moveClientToCluster(currentState, row.id, oldClusterId, newClusterId)
-      );
+      const didSave = await commitRouteAssignmentMutation((currentState) => {
+        resolvedNewClusterId =
+          newClusterIdStr === "__add__"
+            ? getNextClusterId(currentState.clusters)
+            : normalizeClusterIdValue(newClusterIdStr);
+        const clientMoves = selectedClientIds
+          .map((clientId) => ({
+            clientId,
+            oldClusterId: getClusterIdForClient(currentState.clusters, clientId),
+          }))
+          .filter((clientMove) => clientMove.oldClusterId !== resolvedNewClusterId);
 
-      if (didSave && selectedRows.has(row.id)) {
-        if (newClusterId) {
-          setSelectedRows(new Set(selectedClientRows.map((candidateRow) => candidateRow.id)));
+        didMoveClients = clientMoves.length > 0;
+
+        if (!didMoveClients) {
+          return {
+            clusters: currentState.clusters,
+            clientOverrides: currentState.clientOverrides,
+            touchedRouteIds: [],
+          };
+        }
+
+        return clientMoves.length > 1
+          ? moveClientsToCluster(currentState, clientMoves, resolvedNewClusterId)
+          : moveClientToCluster(
+              currentState,
+              clientMoves[0].clientId,
+              clientMoves[0].oldClusterId,
+              resolvedNewClusterId
+            );
+      });
+
+      if (didSave && didMoveClients && selectedRows.has(row.id)) {
+        if (resolvedNewClusterId) {
+          setSelectedRows(new Set(selectedClientIds));
           setSelectedClusters(
             new Set([
               {
-                id: newClusterId,
-                deliveries: selectedClientRows.map((candidateRow) => candidateRow.id),
+                id: resolvedNewClusterId,
+                deliveries: selectedClientIds,
                 driver: "",
                 time: "",
               } as Cluster,
@@ -1265,7 +1314,7 @@ const DeliverySpreadsheet: React.FC = () => {
     try {
       const resolvedClusterId =
         newClusterId === "__add__" || newClusterId === "__add_new_cluster__"
-          ? getNextClusterId(clusters)
+          ? ""
           : normalizeClusterIdValue(newClusterId);
       const driverUpdateRequested = newDriver !== undefined;
       const timeUpdateRequested = newTime !== undefined;
@@ -1275,45 +1324,65 @@ const DeliverySpreadsheet: React.FC = () => {
         return false;
       }
 
-      const oldClusterId = normalizeClusterIdValue(currentClient.clusterId);
-      const clusterChanged = oldClusterId !== resolvedClusterId;
-      const currentClusterRows = oldClusterId
-        ? rows.filter((candidateRow) => normalizeClusterIdValue(candidateRow.clusterId) === oldClusterId)
-        : [currentClient];
       const selectedClientRows = selectedRows.has(clientId)
         ? rows.filter((candidateRow) => selectedRows.has(candidateRow.id))
-        : clusterChanged && currentClusterRows.length > 0
-          ? currentClusterRows
-          : [currentClient];
-      const rowsToMove = clusterChanged
-        ? selectedClientRows.filter(
-            (candidateRow) => normalizeClusterIdValue(candidateRow.clusterId) !== resolvedClusterId
-          )
-        : [];
-
-      if (!clusterChanged && !driverUpdateRequested && !timeUpdateRequested) {
-        return false;
-      }
+        : [currentClient];
+      const selectedClientIds = selectedClientRows.map((candidateRow) => candidateRow.id);
+      let actualResolvedClusterId = resolvedClusterId;
+      let didChangeClusters = false;
 
       const didSave = await commitRouteAssignmentMutation((currentState) => {
-        if (clusterChanged && rowsToMove.length > 1) {
+        const currentOldClusterId = getClusterIdForClient(currentState.clusters, clientId);
+        actualResolvedClusterId =
+          newClusterId === "__add__" || newClusterId === "__add_new_cluster__"
+            ? getNextClusterId(currentState.clusters)
+            : normalizeClusterIdValue(newClusterId);
+        const clusterChanged = currentOldClusterId !== actualResolvedClusterId;
+
+        if (!clusterChanged && !driverUpdateRequested && !timeUpdateRequested) {
+          return {
+            clusters: currentState.clusters,
+            clientOverrides: currentState.clientOverrides,
+            touchedRouteIds: [],
+          };
+        }
+
+        if (clusterChanged && selectedClientIds.length > 1) {
+          const clientMoves = selectedClientIds
+            .map((selectedClientId) => ({
+              clientId: selectedClientId,
+              oldClusterId: getClusterIdForClient(currentState.clusters, selectedClientId),
+            }))
+            .filter((clientMove) => clientMove.oldClusterId !== actualResolvedClusterId);
+
+          didChangeClusters = clientMoves.length > 0;
+
+          if (!didChangeClusters) {
+            return updateClientRouteAssignment(currentState, {
+              clientId,
+              oldClusterId: currentOldClusterId,
+              newClusterId: actualResolvedClusterId,
+              driverUpdateRequested,
+              timeUpdateRequested,
+              driverValue: newDriver,
+              timeValue: newTime,
+            });
+          }
+
           const movedState = moveClientsToCluster(
             currentState,
-            rowsToMove.map((candidateRow) => ({
-              clientId: candidateRow.id,
-              oldClusterId: normalizeClusterIdValue(candidateRow.clusterId),
-            })),
-            resolvedClusterId
+            clientMoves,
+            actualResolvedClusterId
           );
 
-          if (!resolvedClusterId || (!driverUpdateRequested && !timeUpdateRequested)) {
+          if (!actualResolvedClusterId || (!driverUpdateRequested && !timeUpdateRequested)) {
             return movedState;
           }
 
           return updateClientRouteAssignment(movedState, {
             clientId,
-            oldClusterId: resolvedClusterId,
-            newClusterId: resolvedClusterId,
+            oldClusterId: actualResolvedClusterId,
+            newClusterId: actualResolvedClusterId,
             driverUpdateRequested,
             timeUpdateRequested,
             driverValue: newDriver,
@@ -1321,10 +1390,12 @@ const DeliverySpreadsheet: React.FC = () => {
           });
         }
 
+        didChangeClusters = clusterChanged;
+
         return updateClientRouteAssignment(currentState, {
           clientId,
-          oldClusterId,
-          newClusterId: resolvedClusterId,
+          oldClusterId: currentOldClusterId,
+          newClusterId: actualResolvedClusterId,
           driverUpdateRequested,
           timeUpdateRequested,
           driverValue: newDriver,
@@ -1337,15 +1408,15 @@ const DeliverySpreadsheet: React.FC = () => {
       }
 
       // Keep the same bulk-selection behavior in the map popup as the spreadsheet route dropdown.
-      if (clusterChanged) {
+      if (didChangeClusters) {
         if (selectedRows.has(clientId)) {
-          if (resolvedClusterId) {
-            setSelectedRows(new Set(selectedClientRows.map((candidateRow) => candidateRow.id)));
+          if (actualResolvedClusterId) {
+            setSelectedRows(new Set(selectedClientIds));
             setSelectedClusters(
               new Set([
                 {
-                  id: resolvedClusterId,
-                  deliveries: selectedClientRows.map((candidateRow) => candidateRow.id),
+                  id: actualResolvedClusterId,
+                  deliveries: selectedClientIds,
                   driver: "",
                   time: "",
                 } as Cluster,
@@ -1358,6 +1429,7 @@ const DeliverySpreadsheet: React.FC = () => {
         } else {
           const newSelectedRows = new Set(selectedRows);
           const newSelectedClusters = new Set(selectedClusters);
+          const oldClusterId = normalizeClusterIdValue(currentClient.clusterId);
 
           newSelectedRows.delete(clientId);
 
@@ -1807,236 +1879,266 @@ const DeliverySpreadsheet: React.FC = () => {
         return true;
       }
 
-    const validSearchTerms = parseSearchTermsProgressively(trimmedSearchQuery);
+      const validSearchTerms = parseSearchTermsProgressively(trimmedSearchQuery);
 
-    const keyValueTerms = validSearchTerms.filter((term) => term.includes(":"));
-    const nonKeyValueTerms = validSearchTerms.filter((term) => !term.includes(":"));
+      const keyValueTerms = validSearchTerms.filter((term) => term.includes(":"));
+      const nonKeyValueTerms = validSearchTerms.filter((term) => !term.includes(":"));
 
-    let matches = true;
+      let matches = true;
 
-    if (keyValueTerms.length > 0) {
-      const checkStringContains = utilCheckStringContains;
-      const checkStringEquals = utilCheckStringEquals;
+      if (keyValueTerms.length > 0) {
+        const checkStringContains = utilCheckStringContains;
+        const checkStringEquals = utilCheckStringEquals;
 
-      const checkValueOrInArray = (
-        value: unknown,
-        query: string,
-        exactMatch = false
-      ): boolean => {
-        if (value === undefined || value === null) {
+        const checkValueOrInArray = (
+          value: unknown,
+          query: string,
+          exactMatch = false
+        ): boolean => {
+          if (value === undefined || value === null) {
+            return false;
+          }
+
+          if (Array.isArray(value)) {
+            return value.some((item) =>
+              exactMatch ? checkStringEquals(item, query) : checkStringContains(item, query)
+            );
+          }
+
+          return exactMatch ? checkStringEquals(value, query) : checkStringContains(value, query);
+        };
+
+        const visibleFieldKeys = new Set([
+          ...fields.map((f) => f.key).filter((key) => key !== "checkbox"),
+          ...customColumns.map((col) => col.propertyKey).filter((key) => key !== "none"),
+        ]);
+
+        const isVisibleField = (keyword: string): boolean => {
+          const lowerKeyword = keyword.toLowerCase();
+
+          const fieldMappings: { [key: string]: string[] } = {
+            fullname: ["name", "client"],
+            clusterIdChange: ["cluster", "cluster id", "clusterid", "route", "route id", "routeid"],
+            tags: ["tags", "tag"],
+            zipCode: ["zip", "zipcode", "zip code"],
+            ward: ["ward"],
+            assignedDriver: ["driver", "assigned driver"],
+            assignedTime: ["time", "assigned time"],
+            "deliveryDetails.deliveryInstructions": ["delivery instructions", "instructions"],
+          };
+
+          const normalizedKeyword = normalizeSearchKeyword(lowerKeyword);
+
+          for (const [fieldKey, aliases] of Object.entries(fieldMappings)) {
+            if (
+              visibleFieldKeys.has(fieldKey) &&
+              aliases.some((alias) => normalizeSearchKeyword(alias) === normalizedKeyword)
+            ) {
+              return true;
+            }
+          }
+
+          const customColumnMappings: { [key: string]: string[] } = {
+            address: ["address"],
+            adults: ["adults"],
+            children: ["children"],
+            deliveryFreq: ["delivery freq", "delivery frequency"],
+            "deliveryDetails.dietaryRestrictions": ["dietary restrictions"],
+            ethnicity: ["ethnicity"],
+            gender: ["gender"],
+            language: ["language"],
+            notes: ["notes"],
+            phone: ["phone"],
+            referralEntity: ["referral entity", "referral"],
+            tags: ["tags", "tag"],
+            tefapCert: ["tefap", "tefap cert"],
+            dob: ["dob"],
+            lastDeliveryDate: ["last delivery date"],
+          };
+
+          for (const [propertyKey, aliases] of Object.entries(customColumnMappings)) {
+            if (
+              visibleFieldKeys.has(propertyKey) &&
+              aliases.some((alias) => normalizeSearchKeyword(alias) === normalizedKeyword)
+            ) {
+              return true;
+            }
+          }
+
           return false;
-        }
-
-        if (Array.isArray(value)) {
-          return value.some((item) =>
-            exactMatch ? checkStringEquals(item, query) : checkStringContains(item, query)
-          );
-        }
-
-        return exactMatch ? checkStringEquals(value, query) : checkStringContains(value, query);
-      };
-
-      const visibleFieldKeys = new Set([
-        ...fields.map((f) => f.key).filter((key) => key !== "checkbox"),
-        ...customColumns.map((col) => col.propertyKey).filter((key) => key !== "none"),
-      ]);
-
-      const isVisibleField = (keyword: string): boolean => {
-        const lowerKeyword = keyword.toLowerCase();
-
-        const fieldMappings: { [key: string]: string[] } = {
-          fullname: ["name", "client"],
-          clusterIdChange: ["cluster", "cluster id", "clusterid", "route", "route id", "routeid"],
-          tags: ["tags", "tag"],
-          zipCode: ["zip", "zipcode", "zip code"],
-          ward: ["ward"],
-          assignedDriver: ["driver", "assigned driver"],
-          assignedTime: ["time", "assigned time"],
-          "deliveryDetails.deliveryInstructions": ["delivery instructions", "instructions"],
         };
 
-        const normalizedKeyword = normalizeSearchKeyword(lowerKeyword);
+        matches = keyValueTerms.every((term) => {
+          const { keyword, searchValue, isKeyValue: isKeyValueSearch } = extractKeyValue(term);
+          const normalizedKeyword = normalizeSearchKeyword(keyword);
 
-        for (const [fieldKey, aliases] of Object.entries(fieldMappings)) {
-          if (
-            visibleFieldKeys.has(fieldKey) &&
-            aliases.some((alias) => normalizeSearchKeyword(alias) === normalizedKeyword)
-          ) {
-            return true;
-          }
-        }
-
-        const customColumnMappings: { [key: string]: string[] } = {
-          address: ["address"],
-          adults: ["adults"],
-          children: ["children"],
-          deliveryFreq: ["delivery freq", "delivery frequency"],
-          "deliveryDetails.dietaryRestrictions": ["dietary restrictions"],
-          ethnicity: ["ethnicity"],
-          gender: ["gender"],
-          language: ["language"],
-          notes: ["notes"],
-          phone: ["phone"],
-          referralEntity: ["referral entity", "referral"],
-          tags: ["tags", "tag"],
-          tefapCert: ["tefap", "tefap cert"],
-          dob: ["dob"],
-          lastDeliveryDate: ["last delivery date"],
-        };
-
-        for (const [propertyKey, aliases] of Object.entries(customColumnMappings)) {
-          if (
-            visibleFieldKeys.has(propertyKey) &&
-            aliases.some((alias) => normalizeSearchKeyword(alias) === normalizedKeyword)
-          ) {
-            return true;
-          }
-        }
-
-        return false;
-      };
-
-      matches = keyValueTerms.every((term) => {
-        const { keyword, searchValue, isKeyValue: isKeyValueSearch } = extractKeyValue(term);
-        const normalizedKeyword = normalizeSearchKeyword(keyword);
-
-        if (isKeyValueSearch && searchValue) {
-          if (!isVisibleField(keyword)) {
-            return true;
-          }
-
-          const searchValues = splitFilterValues(searchValue);
-          const matchesAnySearchValue = (matcher: (candidate: string) => boolean): boolean =>
-            searchValues.some((candidate: string) => matcher(candidate));
-
-          switch (normalizedKeyword) {
-            case "name":
-            case "client":
-              return matchesAnySearchValue(
-                (candidate) =>
-                  checkStringContains(`${row.firstName} ${row.lastName}`, candidate) ||
-                  checkStringContains(row.firstName, candidate) ||
-                  checkStringContains(row.lastName, candidate)
-              );
-            case "address":
-              return matchesAnySearchValue((candidate) => checkStringContains(row.address, candidate));
-            case "ward":
-              return matchesAnySearchValue((candidate) => checkStringEquals(row.ward, candidate));
-            case "zip":
-            case "zipcode":
-              return matchesAnySearchValue((candidate) => checkStringEquals(row.zipCode, candidate));
-            case "cluster":
-            case "clusterid":
-            case "route":
-            case "routeid":
-              return matchesAnySearchValue((candidate) => checkStringEquals(row.clusterId, candidate));
-            case "driver":
-            case "assigneddriver": {
-              const driverName = fields
-                .find((f) => f.key === "assignedDriver")
-                ?.compute?.(row, clusters);
-              return matchesAnySearchValue((candidate) => checkStringContains(driverName, candidate));
+          if (isKeyValueSearch && searchValue) {
+            if (!isVisibleField(keyword)) {
+              return true;
             }
-            case "time":
-            case "assignedtime": {
-              const assignedTime = fields
-                .find((f) => f.key === "assignedTime")
-                ?.compute?.(row, clusters);
-              return matchesAnySearchValue((candidate) => checkStringContains(assignedTime, candidate));
-            }
-            case "deliveryinstructions":
-            case "instructions": {
-              const instructions = (
-                fields.find((f) => f.key === "deliveryDetails.deliveryInstructions") as Extract<
-                  Field,
-                  { key: "deliveryDetails.deliveryInstructions" }
-                >
-              ).compute?.(row);
-              return matchesAnySearchValue((candidate) => checkStringContains(instructions, candidate));
-            }
-            case "tags":
-            case "tag":
-              return matchesAnySearchValue((candidate) => checkValueOrInArray(row.tags, candidate));
-            case "phone":
-              return matchesAnySearchValue((candidate) => checkStringContains(row.phone, candidate));
-            case "ethnicity":
-              return matchesAnySearchValue((candidate) => checkStringContains(row.ethnicity, candidate));
-            case "adults":
-              return matchesAnySearchValue((candidate) =>
-                checkValueOrInArray(row.adults, candidate, true)
-              );
-            case "children":
-              return matchesAnySearchValue((candidate) =>
-                checkValueOrInArray(row.children, candidate, true)
-              );
-            case "deliveryfreq":
-            case "deliveryfrequency":
-              return matchesAnySearchValue((candidate) => checkStringContains(row.deliveryFreq, candidate));
-            case "gender":
-              return matchesAnySearchValue((candidate) => checkStringContains(row.gender, candidate));
-            case "language":
-              return matchesAnySearchValue((candidate) => checkStringContains(row.language, candidate));
-            case "notes":
-              return matchesAnySearchValue((candidate) => checkStringContains(row.notes, candidate));
-            case "tefap":
-            case "tefapcert":
-              return matchesAnySearchValue((candidate) => checkStringContains(row.tefapCert, candidate));
-            case "dob":
-              return matchesAnySearchValue((candidate) => checkValueOrInArray(row.dob, candidate, true));
-            case "referralentity":
-            case "referral": {
-              if (row.referralEntity && typeof row.referralEntity === "object") {
+
+            const searchValues = splitFilterValues(searchValue);
+            const matchesAnySearchValue = (matcher: (candidate: string) => boolean): boolean =>
+              searchValues.some((candidate: string) => matcher(candidate));
+
+            switch (normalizedKeyword) {
+              case "name":
+              case "client":
                 return matchesAnySearchValue(
                   (candidate) =>
-                    checkStringContains(row.referralEntity.name, candidate) ||
-                    checkStringContains(row.referralEntity.organization, candidate)
+                    checkStringContains(`${row.firstName} ${row.lastName}`, candidate) ||
+                    checkStringContains(row.firstName, candidate) ||
+                    checkStringContains(row.lastName, candidate)
+                );
+              case "address":
+                return matchesAnySearchValue((candidate) =>
+                  checkStringContains(row.address, candidate)
+                );
+              case "ward":
+                return matchesAnySearchValue((candidate) => checkStringEquals(row.ward, candidate));
+              case "zip":
+              case "zipcode":
+                return matchesAnySearchValue((candidate) =>
+                  checkStringEquals(row.zipCode, candidate)
+                );
+              case "cluster":
+              case "clusterid":
+              case "route":
+              case "routeid":
+                return matchesAnySearchValue((candidate) =>
+                  checkStringEquals(row.clusterId, candidate)
+                );
+              case "driver":
+              case "assigneddriver": {
+                const driverName = fields
+                  .find((f) => f.key === "assignedDriver")
+                  ?.compute?.(row, clusters, clientOverrides);
+                return matchesAnySearchValue((candidate) =>
+                  checkStringContains(driverName, candidate)
                 );
               }
-              return false;
-            }
-            default: {
-              const matchesCustomColumn = customColumns.some((col) => {
-                if (
-                  col.propertyKey !== "none" &&
-                  normalizeSearchKeyword(col.propertyKey).includes(normalizedKeyword)
-                ) {
-                  if (col.propertyKey in row) {
-                    const fieldValue = row[col.propertyKey as keyof DeliveryRowData];
-                    return matchesAnySearchValue((candidate) =>
-                      checkStringContains(fieldValue, candidate)
-                    );
-                  }
+              case "time":
+              case "assignedtime": {
+                const assignedTime = fields
+                  .find((f) => f.key === "assignedTime")
+                  ?.compute?.(row, clusters, clientOverrides);
+                return matchesAnySearchValue((candidate) =>
+                  checkStringContains(assignedTime, candidate)
+                );
+              }
+              case "deliveryinstructions":
+              case "instructions": {
+                const instructions = (
+                  fields.find((f) => f.key === "deliveryDetails.deliveryInstructions") as Extract<
+                    Field,
+                    { key: "deliveryDetails.deliveryInstructions" }
+                  >
+                ).compute?.(row);
+                return matchesAnySearchValue((candidate) =>
+                  checkStringContains(instructions, candidate)
+                );
+              }
+              case "tags":
+              case "tag":
+                return matchesAnySearchValue((candidate) =>
+                  checkValueOrInArray(row.tags, candidate)
+                );
+              case "phone":
+                return matchesAnySearchValue((candidate) =>
+                  checkStringContains(row.phone, candidate)
+                );
+              case "ethnicity":
+                return matchesAnySearchValue((candidate) =>
+                  checkStringContains(row.ethnicity, candidate)
+                );
+              case "adults":
+                return matchesAnySearchValue((candidate) =>
+                  checkValueOrInArray(row.adults, candidate, true)
+                );
+              case "children":
+                return matchesAnySearchValue((candidate) =>
+                  checkValueOrInArray(row.children, candidate, true)
+                );
+              case "deliveryfreq":
+              case "deliveryfrequency":
+                return matchesAnySearchValue((candidate) =>
+                  checkStringContains(row.deliveryFreq, candidate)
+                );
+              case "gender":
+                return matchesAnySearchValue((candidate) =>
+                  checkStringContains(row.gender, candidate)
+                );
+              case "language":
+                return matchesAnySearchValue((candidate) =>
+                  checkStringContains(row.language, candidate)
+                );
+              case "notes":
+                return matchesAnySearchValue((candidate) =>
+                  checkStringContains(row.notes, candidate)
+                );
+              case "tefap":
+              case "tefapcert":
+                return matchesAnySearchValue((candidate) =>
+                  checkStringContains(row.tefapCert, candidate)
+                );
+              case "dob":
+                return matchesAnySearchValue((candidate) =>
+                  checkValueOrInArray(row.dob, candidate, true)
+                );
+              case "referralentity":
+              case "referral": {
+                if (row.referralEntity && typeof row.referralEntity === "object") {
+                  return matchesAnySearchValue(
+                    (candidate) =>
+                      checkStringContains(row.referralEntity.name, candidate) ||
+                      checkStringContains(row.referralEntity.organization, candidate)
+                  );
                 }
                 return false;
-              });
-              return matchesCustomColumn;
+              }
+              default: {
+                const matchesCustomColumn = customColumns.some((col) => {
+                  if (
+                    col.propertyKey !== "none" &&
+                    normalizeSearchKeyword(col.propertyKey).includes(normalizedKeyword)
+                  ) {
+                    const fieldValue = getNestedPropertyValue(row, col.propertyKey);
+                    if (fieldValue !== undefined) {
+                      return matchesAnySearchValue((candidate) =>
+                        checkStringContains(fieldValue, candidate)
+                      );
+                    }
+                  }
+                  return false;
+                });
+                return matchesCustomColumn;
+              }
             }
           }
-        }
 
-        return true;
-      });
-    }
+          return true;
+        });
+      }
 
-    if (matches && nonKeyValueTerms.length > 0) {
-      const searchableFields = [
-        "firstName",
-        "lastName",
-        "address",
-        "phone",
-        "ward",
-        "zipCode",
-        "clusterId",
-        "tags",
-        "deliveryDetails.deliveryInstructions",
-        ...customColumns.map((col) => col.propertyKey).filter((key) => key !== "none"),
-      ];
-      matches = nonKeyValueTerms.every((term) => globalSearchMatch(row, term, searchableFields));
-    }
+      if (matches && nonKeyValueTerms.length > 0) {
+        const searchableFields = [
+          "firstName",
+          "lastName",
+          "address",
+          "phone",
+          "ward",
+          "zipCode",
+          "clusterId",
+          "tags",
+          "deliveryDetails.deliveryInstructions",
+          ...customColumns.map((col) => col.propertyKey).filter((key) => key !== "none"),
+        ];
+        matches = nonKeyValueTerms.every((term) => globalSearchMatch(row, term, searchableFields));
+      }
 
       return matches;
     });
-  }, [rows, searchQuery, customColumns, clusters]);
+  }, [rows, searchQuery, customColumns, clusters, clientOverrides]);
 
   const unassignedRouteCount = useMemo(() => rows.filter((row) => !row.clusterId).length, [rows]);
 

--- a/my-app/src/pages/Delivery/utils/clusterSummary.test.ts
+++ b/my-app/src/pages/Delivery/utils/clusterSummary.test.ts
@@ -33,19 +33,21 @@ describe("clusterSummary helpers", () => {
   });
 
   // App coverage:
-  // - cluster summary overlay on the map can be switched to sort by number of deliveries
-  // - dispatchers can cycle between highest-first and lowest-first ordering
-  // Behavior contract: delivery-count sorting orders by count in the requested direction, then cluster id ascending.
-  it("sorts cluster summaries by delivery count in both directions when requested", () => {
+  // - cluster deliveries overlay defaults to showing routes in cluster-number order
+  // - dispatchers can cycle between cluster order, highest-first, and lowest-first delivery counts
+  // Behavior contract: default cluster sorting is ascending by cluster id; count sorting orders by count in the requested direction, then cluster id ascending.
+  it("sorts cluster summaries by cluster number by default and by delivery count in both directions", () => {
     const summaries = [
       { clusterId: "10", count: 2, driverLabel: "Alice", timeLabel: "09:00" },
       { clusterId: "2", count: 4, driverLabel: "Bob", timeLabel: "10:00" },
       { clusterId: "1", count: 4, driverLabel: "Dana", timeLabel: "11:00" },
     ];
 
+    const defaultClusterOrder = sortClusterSummaries(summaries, "cluster");
     const descending = sortClusterSummaries(summaries, "count-desc");
     const ascending = sortClusterSummaries(summaries, "count-asc");
 
+    expect(defaultClusterOrder.map((summary) => summary.clusterId)).toEqual(["1", "2", "10"]);
     expect(descending.map((summary) => summary.clusterId)).toEqual(["1", "2", "10"]);
     expect(ascending.map((summary) => summary.clusterId)).toEqual(["10", "1", "2"]);
   });

--- a/my-app/src/pages/Delivery/utils/clusterSummary.test.ts
+++ b/my-app/src/pages/Delivery/utils/clusterSummary.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@jest/globals";
-import { buildClusterSummariesFromClusters } from "./clusterSummary";
+import { buildClusterSummariesFromClusters, sortClusterSummaries } from "./clusterSummary";
 
 describe("clusterSummary helpers", () => {
   // App coverage:
@@ -30,6 +30,24 @@ describe("clusterSummary helpers", () => {
         timeLabel: "10:00",
       },
     ]);
+  });
+
+  // App coverage:
+  // - cluster summary overlay on the map can be switched to sort by number of deliveries
+  // - dispatchers can cycle between highest-first and lowest-first ordering
+  // Behavior contract: delivery-count sorting orders by count in the requested direction, then cluster id ascending.
+  it("sorts cluster summaries by delivery count in both directions when requested", () => {
+    const summaries = [
+      { clusterId: "10", count: 2, driverLabel: "Alice", timeLabel: "09:00" },
+      { clusterId: "2", count: 4, driverLabel: "Bob", timeLabel: "10:00" },
+      { clusterId: "1", count: 4, driverLabel: "Dana", timeLabel: "11:00" },
+    ];
+
+    const descending = sortClusterSummaries(summaries, "count-desc");
+    const ascending = sortClusterSummaries(summaries, "count-asc");
+
+    expect(descending.map((summary) => summary.clusterId)).toEqual(["1", "2", "10"]);
+    expect(ascending.map((summary) => summary.clusterId)).toEqual(["10", "1", "2"]);
   });
 
   // App coverage:

--- a/my-app/src/pages/Delivery/utils/clusterSummary.ts
+++ b/my-app/src/pages/Delivery/utils/clusterSummary.ts
@@ -30,11 +30,40 @@ export interface ClusterSummary {
   timeLabel: string;
 }
 
+export type ClusterSummarySortMode = "cluster" | "count-desc" | "count-asc";
+export type ClusterSummarySortDirection = "asc" | "desc";
+
 const sortClusterIds = (left: string, right: string): number => {
   const leftNumber = parseInt(left.match(/\d+/)?.[0] || "0", 10);
   const rightNumber = parseInt(right.match(/\d+/)?.[0] || "0", 10);
 
   return leftNumber - rightNumber || left.localeCompare(right);
+};
+
+export const sortClusterSummaries = (
+  summaries: ClusterSummary[],
+  sortMode: ClusterSummarySortMode = "cluster",
+  sortDirection?: ClusterSummarySortDirection
+): ClusterSummary[] => {
+  const isCountSort = sortMode === "count-desc" || sortMode === "count-asc";
+  const resolvedSortDirection = sortDirection ?? (sortMode === "count-asc" ? "asc" : "desc");
+  const directionMultiplier = resolvedSortDirection === "asc" ? 1 : -1;
+
+  return [...summaries].sort((left, right) => {
+    if (isCountSort) {
+      const countDiff = (left.count - right.count) * directionMultiplier;
+      if (countDiff !== 0) {
+        return countDiff;
+      }
+    } else {
+      const clusterDiff = sortClusterIds(left.clusterId, right.clusterId) * directionMultiplier;
+      if (clusterDiff !== 0) {
+        return clusterDiff;
+      }
+    }
+
+    return sortClusterIds(left.clusterId, right.clusterId);
+  });
 };
 
 export const buildAssignmentSummary = <
@@ -113,9 +142,8 @@ export const buildClusterSummaries = <
     summaryMap.set(clusterId, current);
   });
 
-  return Array.from(summaryMap.entries())
-    .sort(([left], [right]) => sortClusterIds(left, right))
-    .map(([clusterId, values]) => ({
+  return sortClusterSummaries(
+    Array.from(summaryMap.entries()).map(([clusterId, values]) => ({
       clusterId,
       count: values.count,
       driverLabel:
@@ -130,7 +158,10 @@ export const buildClusterSummaries = <
           : values.times.size === 1
             ? formatTimeLabel(Array.from(values.times)[0])
             : "Mixed times",
-    }));
+    })),
+    "cluster",
+    "asc"
+  );
 };
 
 export const buildClusterSummariesFromClusters = <
@@ -141,55 +172,58 @@ export const buildClusterSummariesFromClusters = <
   clientOverrideByClientId: Map<string, TOverride>,
   formatTimeLabel: (time: string) => string
 ): ClusterSummary[] => {
-  return clusters
-    .map((cluster) => {
-      const clusterId = String(cluster.id ?? "").trim();
-      const clientIds = Array.from(
-        new Set(
-          (cluster.deliveries ?? [])
-            .map((clientId) => String(clientId ?? "").trim())
-            .filter(Boolean)
-        )
-      );
+  return sortClusterSummaries(
+    clusters
+      .map((cluster) => {
+        const clusterId = String(cluster.id ?? "").trim();
+        const clientIds = Array.from(
+          new Set(
+            (cluster.deliveries ?? [])
+              .map((clientId) => String(clientId ?? "").trim())
+              .filter(Boolean)
+          )
+        );
 
-      if (!clusterId || clientIds.length === 0) {
-        return null;
-      }
-
-      const drivers = new Set<string>();
-      const times = new Set<string>();
-
-      clientIds.forEach((clientId) => {
-        const override = clientOverrideByClientId.get(clientId);
-        const effectiveDriver = resolveAssignmentValue(override?.driver, cluster.driver);
-        const effectiveTime = resolveAssignmentValue(override?.time, cluster.time);
-
-        if (hasAssignmentValue(effectiveDriver)) {
-          drivers.add(effectiveDriver!);
+        if (!clusterId || clientIds.length === 0) {
+          return null;
         }
 
-        if (hasAssignmentValue(effectiveTime)) {
-          times.add(effectiveTime!);
-        }
-      });
+        const drivers = new Set<string>();
+        const times = new Set<string>();
 
-      return {
-        clusterId,
-        count: clientIds.length,
-        driverLabel:
-          drivers.size === 0
-            ? "No driver"
-            : drivers.size === 1
-              ? Array.from(drivers)[0]
-              : "Mixed drivers",
-        timeLabel:
-          times.size === 0
-            ? "No time"
-            : times.size === 1
-              ? formatTimeLabel(Array.from(times)[0])
-              : "Mixed times",
-      };
-    })
-    .filter((summary): summary is ClusterSummary => summary !== null)
-    .sort((left, right) => sortClusterIds(left.clusterId, right.clusterId));
+        clientIds.forEach((clientId) => {
+          const override = clientOverrideByClientId.get(clientId);
+          const effectiveDriver = resolveAssignmentValue(override?.driver, cluster.driver);
+          const effectiveTime = resolveAssignmentValue(override?.time, cluster.time);
+
+          if (hasAssignmentValue(effectiveDriver)) {
+            drivers.add(effectiveDriver!);
+          }
+
+          if (hasAssignmentValue(effectiveTime)) {
+            times.add(effectiveTime!);
+          }
+        });
+
+        return {
+          clusterId,
+          count: clientIds.length,
+          driverLabel:
+            drivers.size === 0
+              ? "No driver"
+              : drivers.size === 1
+                ? Array.from(drivers)[0]
+                : "Mixed drivers",
+          timeLabel:
+            times.size === 0
+              ? "No time"
+              : times.size === 1
+                ? formatTimeLabel(Array.from(times)[0])
+                : "Mixed times",
+        };
+      })
+      .filter((summary): summary is ClusterSummary => summary !== null),
+    "cluster",
+    "asc"
+  );
 };

--- a/my-app/src/pages/Delivery/utils/clusterSummary.ts
+++ b/my-app/src/pages/Delivery/utils/clusterSummary.ts
@@ -46,7 +46,9 @@ export const sortClusterSummaries = (
   sortDirection?: ClusterSummarySortDirection
 ): ClusterSummary[] => {
   const isCountSort = sortMode === "count-desc" || sortMode === "count-asc";
-  const resolvedSortDirection = sortDirection ?? (sortMode === "count-asc" ? "asc" : "desc");
+  const resolvedSortDirection =
+    sortDirection ??
+    (sortMode === "count-asc" ? "asc" : sortMode === "count-desc" ? "desc" : "asc");
   const directionMultiplier = resolvedSortDirection === "asc" ? 1 : -1;
 
   return [...summaries].sort((left, right) => {

--- a/my-app/src/pages/Delivery/utils/deliveryMapCounts.test.ts
+++ b/my-app/src/pages/Delivery/utils/deliveryMapCounts.test.ts
@@ -6,6 +6,7 @@ describe("deliveryMapCounts helpers", () => {
     expect(isRenderableCoordinate([0, 0])).toBe(false);
     expect(isRenderableCoordinate({ lat: 0, lng: 0 })).toBe(false);
     expect(isRenderableCoordinate([38.9, -77.03])).toBe(true);
+    expect(isRenderableCoordinate([38.9, -77.03, 15])).toBe(true);
   });
 
   it("matches overlay, spreadsheet, and markers when no rows are filtered and all coordinates render", () => {

--- a/my-app/src/pages/Delivery/utils/deliveryMapCounts.test.ts
+++ b/my-app/src/pages/Delivery/utils/deliveryMapCounts.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "@jest/globals";
+import { buildClusterCountSnapshot, isRenderableCoordinate } from "./deliveryMapCounts";
+
+describe("deliveryMapCounts helpers", () => {
+  it("rejects zero coordinates so unrenderable clients are counted as missing", () => {
+    expect(isRenderableCoordinate([0, 0])).toBe(false);
+    expect(isRenderableCoordinate({ lat: 0, lng: 0 })).toBe(false);
+    expect(isRenderableCoordinate([38.9, -77.03])).toBe(true);
+  });
+
+  it("matches overlay, spreadsheet, and markers when no rows are filtered and all coordinates render", () => {
+    const rows = [
+      { id: "c1", coordinates: [38.90, -77.03] as [number, number] },
+      { id: "c2", coordinates: [38.91, -77.02] as [number, number] },
+      { id: "c3", coordinates: [38.92, -77.01] as [number, number] },
+    ];
+
+    const snapshot = buildClusterCountSnapshot({
+      clusterId: "3",
+      allRows: rows,
+      visibleRows: rows,
+      clusters: [{ id: "3", deliveries: ["c1", "c2", "c3"] }],
+    });
+
+    expect(snapshot).toMatchObject({
+      overlayCount: 3,
+      spreadsheetCount: 3,
+      markerCount: 3,
+      missingCoordinateCount: 0,
+      filteredOutCount: 0,
+      highestCount: 3,
+      highestCountSources: ["overlay", "spreadsheet", "markers"],
+      reason: "match",
+    });
+  });
+
+  it("still matches all three counts when the spreadsheet is filtered down to one full cluster", () => {
+    const allRows = [
+      { id: "c1", coordinates: [38.90, -77.03] as [number, number] },
+      { id: "c2", coordinates: [38.91, -77.02] as [number, number] },
+      { id: "c3", coordinates: [38.92, -77.01] as [number, number] },
+      { id: "other", coordinates: [38.93, -77.00] as [number, number] },
+    ];
+    const visibleRows = allRows.filter((row) => row.id !== "other");
+
+    const snapshot = buildClusterCountSnapshot({
+      clusterId: "3",
+      allRows,
+      visibleRows,
+      clusters: [
+        { id: "3", deliveries: ["c1", "c2", "c3"] },
+        { id: "4", deliveries: ["other"] },
+      ],
+    });
+
+    expect(snapshot.overlayCount).toBe(3);
+    expect(snapshot.spreadsheetCount).toBe(3);
+    expect(snapshot.markerCount).toBe(3);
+    expect(snapshot.reason).toBe("match");
+  });
+
+  it("biases toward overlay and spreadsheet counts when a visible client is missing coordinates", () => {
+    const clusterRows = Array.from({ length: 14 }, (_, index) => ({
+      id: `c${index + 1}`,
+      coordinates:
+        index === 13 ? ([0, 0] as [number, number]) : ([38.9 + index * 0.001, -77.03] as [number, number]),
+    }));
+
+    const snapshot = buildClusterCountSnapshot({
+      clusterId: "3",
+      allRows: clusterRows,
+      visibleRows: clusterRows,
+      clusters: [{ id: "3", deliveries: clusterRows.map((row) => row.id) }],
+    });
+
+    expect(snapshot.overlayCount).toBe(14);
+    expect(snapshot.spreadsheetCount).toBe(14);
+    expect(snapshot.markerCount).toBe(13);
+    expect(snapshot.highestCountSources).toEqual(["overlay", "spreadsheet"]);
+    expect(snapshot.reason).toBe("missing-coordinates");
+    expect(snapshot.missingCoordinateCount).toBe(1);
+    expect(snapshot.missingCoordinateClientIds).toEqual(["c14"]);
+  });
+
+  it("biases toward overlay counts and reports filtered-out clients when the spreadsheet filter hides one route member", () => {
+    const allRows = Array.from({ length: 14 }, (_, index) => ({
+      id: `c${index + 1}`,
+      coordinates: [38.9 + index * 0.001, -77.03] as [number, number],
+    }));
+    const visibleRows = allRows.filter((row) => row.id !== "c14");
+
+    const snapshot = buildClusterCountSnapshot({
+      clusterId: "3",
+      allRows,
+      visibleRows,
+      clusters: [{ id: "3", deliveries: allRows.map((row) => row.id) }],
+    });
+
+    expect(snapshot.overlayCount).toBe(14);
+    expect(snapshot.spreadsheetCount).toBe(13);
+    expect(snapshot.markerCount).toBe(13);
+    expect(snapshot.highestCountSources).toEqual(["overlay"]);
+    expect(snapshot.reason).toBe("filtered-out");
+    expect(snapshot.filteredOutCount).toBe(1);
+    expect(snapshot.filteredOutClientIds).toEqual(["c14"]);
+  });
+});

--- a/my-app/src/pages/Delivery/utils/deliveryMapCounts.ts
+++ b/my-app/src/pages/Delivery/utils/deliveryMapCounts.ts
@@ -1,0 +1,146 @@
+export type CoordinateLike =
+  | [number, number]
+  | [number, number, number?]
+  | []
+  | { lat: number; lng: number }
+  | null
+  | undefined;
+
+export interface DeliveryMapCountRow {
+  id: string;
+  coordinates?: CoordinateLike;
+}
+
+export interface DeliveryMapCountCluster {
+  id: string;
+  deliveries?: string[];
+}
+
+export type DominantCountSource = "overlay" | "spreadsheet" | "markers";
+export type ClusterCountReason =
+  | "match"
+  | "missing-coordinates"
+  | "filtered-out"
+  | "missing-coordinates-and-filtered-out";
+
+export interface ClusterCountSnapshot {
+  clusterId: string;
+  overlayCount: number;
+  spreadsheetCount: number;
+  markerCount: number;
+  missingCoordinateCount: number;
+  filteredOutCount: number;
+  missingCoordinateClientIds: string[];
+  filteredOutClientIds: string[];
+  highestCount: number;
+  highestCountSources: DominantCountSource[];
+  reason: ClusterCountReason;
+}
+
+const normalizeClientId = (clientId: unknown): string => String(clientId ?? "").trim();
+
+export const isRenderableCoordinate = (coord: CoordinateLike): boolean => {
+  if (!coord) {
+    return false;
+  }
+
+  if (Array.isArray(coord)) {
+    return (
+      coord.length === 2 &&
+      typeof coord[0] === "number" &&
+      typeof coord[1] === "number" &&
+      Number.isFinite(coord[0]) &&
+      Number.isFinite(coord[1]) &&
+      Math.abs(coord[0]) <= 90 &&
+      Math.abs(coord[1]) <= 180 &&
+      (coord[0] !== 0 || coord[1] !== 0)
+    );
+  }
+
+  return (
+    typeof coord === "object" &&
+    typeof coord.lat === "number" &&
+    typeof coord.lng === "number" &&
+    Number.isFinite(coord.lat) &&
+    Number.isFinite(coord.lng) &&
+    Math.abs(coord.lat) <= 90 &&
+    Math.abs(coord.lng) <= 180 &&
+    (coord.lat !== 0 || coord.lng !== 0)
+  );
+};
+
+export const buildClusterCountSnapshot = <
+  TRow extends DeliveryMapCountRow,
+  TCluster extends DeliveryMapCountCluster,
+>({
+  clusterId,
+  allRows,
+  visibleRows,
+  clusters,
+}: {
+  clusterId: string;
+  allRows: TRow[];
+  visibleRows: TRow[];
+  clusters: TCluster[];
+}): ClusterCountSnapshot => {
+  const normalizedClusterId = String(clusterId ?? "").trim();
+  const cluster = clusters.find(
+    (candidate) => String(candidate.id ?? "").trim() === normalizedClusterId
+  );
+
+  const clusterClientIds = Array.from(
+    new Set((cluster?.deliveries ?? []).map((clientId) => normalizeClientId(clientId)).filter(Boolean))
+  );
+  const clusterClientIdSet = new Set(clusterClientIds);
+  const visibleClientIdSet = new Set(
+    visibleRows.map((row) => normalizeClientId(row.id)).filter(Boolean)
+  );
+  const allClusterRows = allRows.filter((row) => clusterClientIdSet.has(normalizeClientId(row.id)));
+  const visibleClusterRows = visibleRows.filter((row) =>
+    clusterClientIdSet.has(normalizeClientId(row.id))
+  );
+  const missingCoordinateRows = visibleClusterRows.filter(
+    (row) => !isRenderableCoordinate(row.coordinates)
+  );
+  const markerRows = visibleClusterRows.filter((row) => isRenderableCoordinate(row.coordinates));
+  const filteredOutClientIds = Array.from(
+    new Set(
+      allClusterRows
+        .map((row) => normalizeClientId(row.id))
+        .filter((clientId) => !visibleClientIdSet.has(clientId))
+    )
+  );
+
+  const counts: Record<DominantCountSource, number> = {
+    overlay: clusterClientIds.length,
+    spreadsheet: visibleClusterRows.length,
+    markers: markerRows.length,
+  };
+  const highestCount = Math.max(...Object.values(counts));
+  const highestCountSources = (Object.entries(counts) as Array<[DominantCountSource, number]>)
+    .filter(([, count]) => count === highestCount)
+    .map(([source]) => source);
+
+  let reason: ClusterCountReason = "match";
+  if (missingCoordinateRows.length > 0 && filteredOutClientIds.length > 0) {
+    reason = "missing-coordinates-and-filtered-out";
+  } else if (missingCoordinateRows.length > 0) {
+    reason = "missing-coordinates";
+  } else if (filteredOutClientIds.length > 0) {
+    reason = "filtered-out";
+  }
+
+  return {
+    clusterId: normalizedClusterId,
+    overlayCount: clusterClientIds.length,
+    spreadsheetCount: visibleClusterRows.length,
+    markerCount: markerRows.length,
+    missingCoordinateCount: missingCoordinateRows.length,
+    filteredOutCount: filteredOutClientIds.length,
+    missingCoordinateClientIds: missingCoordinateRows.map((row) => normalizeClientId(row.id)),
+    filteredOutClientIds,
+    highestCount,
+    highestCountSources,
+    reason,
+  };
+};

--- a/my-app/src/pages/Delivery/utils/deliveryMapCounts.ts
+++ b/my-app/src/pages/Delivery/utils/deliveryMapCounts.ts
@@ -46,7 +46,7 @@ export const isRenderableCoordinate = (coord: CoordinateLike): boolean => {
 
   if (Array.isArray(coord)) {
     return (
-      coord.length === 2 &&
+      (coord.length === 2 || coord.length === 3) &&
       typeof coord[0] === "number" &&
       typeof coord[1] === "number" &&
       Number.isFinite(coord[0]) &&

--- a/my-app/src/pages/Delivery/utils/markerPlacement.test.ts
+++ b/my-app/src/pages/Delivery/utils/markerPlacement.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "@jest/globals";
+import { buildMarkerPlacementMap, normalizeMarkerPoint } from "./markerPlacement";
+
+describe("markerPlacement helpers", () => {
+  it("keeps single markers at their original coordinates", () => {
+    const placements = buildMarkerPlacementMap([
+      { id: "c1", coordinates: [38.9, -77.03] as [number, number] },
+    ]);
+
+    expect(placements.get("c1")).toEqual({ lat: 38.9, lng: -77.03 });
+  });
+
+  it("spreads clients with identical coordinates into distinct marker positions", () => {
+    const placements = buildMarkerPlacementMap([
+      { id: "c1", coordinates: [38.9, -77.03] as [number, number] },
+      { id: "c2", coordinates: [38.9, -77.03] as [number, number] },
+      { id: "c3", coordinates: [38.9, -77.03] as [number, number] },
+    ]);
+
+    const placedPoints = [placements.get("c1"), placements.get("c2"), placements.get("c3")];
+    const uniquePoints = new Set(placedPoints.map((point) => JSON.stringify(point)));
+
+    expect(uniquePoints.size).toBe(3);
+    expect(placedPoints.every((point) => point !== undefined)).toBe(true);
+  });
+
+  it("skips non-renderable coordinates when building placements", () => {
+    const placements = buildMarkerPlacementMap([
+      { id: "c1", coordinates: [0, 0] as [number, number] },
+      { id: "c2", coordinates: [] as [] },
+      { id: "c3", coordinates: [38.9, -77.03] as [number, number] },
+    ]);
+
+    expect(placements.has("c1")).toBe(false);
+    expect(placements.has("c2")).toBe(false);
+    expect(placements.get("c3")).toEqual({ lat: 38.9, lng: -77.03 });
+  });
+
+  it("normalizes array and object coordinates into marker points", () => {
+    expect(normalizeMarkerPoint([38.9, -77.03] as [number, number])).toEqual({
+      lat: 38.9,
+      lng: -77.03,
+    });
+    expect(normalizeMarkerPoint({ lat: 38.9, lng: -77.03 })).toEqual({
+      lat: 38.9,
+      lng: -77.03,
+    });
+  });
+});

--- a/my-app/src/pages/Delivery/utils/markerPlacement.test.ts
+++ b/my-app/src/pages/Delivery/utils/markerPlacement.test.ts
@@ -41,6 +41,10 @@ describe("markerPlacement helpers", () => {
       lat: 38.9,
       lng: -77.03,
     });
+    expect(normalizeMarkerPoint([38.9, -77.03, 15] as [number, number, number])).toEqual({
+      lat: 38.9,
+      lng: -77.03,
+    });
     expect(normalizeMarkerPoint({ lat: 38.9, lng: -77.03 })).toEqual({
       lat: 38.9,
       lng: -77.03,

--- a/my-app/src/pages/Delivery/utils/markerPlacement.ts
+++ b/my-app/src/pages/Delivery/utils/markerPlacement.ts
@@ -1,0 +1,78 @@
+import { isRenderableCoordinate, type CoordinateLike } from "./deliveryMapCounts";
+
+export interface MarkerPlacementRow {
+  id: string;
+  coordinates?: CoordinateLike;
+}
+
+export interface MarkerPoint {
+  lat: number;
+  lng: number;
+}
+
+const OVERLAP_RADIUS_DEGREES = 0.00018;
+const COORDINATE_PRECISION = 6;
+
+export const normalizeMarkerPoint = (coord: CoordinateLike): MarkerPoint | null => {
+  if (!isRenderableCoordinate(coord)) {
+    return null;
+  }
+
+  if (Array.isArray(coord)) {
+    return { lat: coord[0] as number, lng: coord[1] as number };
+  }
+
+  return { lat: (coord as { lat: number; lng: number }).lat, lng: (coord as { lat: number; lng: number }).lng };
+};
+
+const getCoordinateKey = (point: MarkerPoint): string =>
+  `${point.lat.toFixed(COORDINATE_PRECISION)},${point.lng.toFixed(COORDINATE_PRECISION)}`;
+
+const getOffsetMarkerPoint = (
+  point: MarkerPoint,
+  occurrenceIndex: number,
+  occurrenceCount: number
+): MarkerPoint => {
+  if (occurrenceCount <= 1) {
+    return point;
+  }
+
+  const angle = (2 * Math.PI * occurrenceIndex) / occurrenceCount;
+  const radius = OVERLAP_RADIUS_DEGREES;
+
+  return {
+    lat: point.lat + Math.sin(angle) * radius,
+    lng: point.lng + Math.cos(angle) * radius,
+  };
+};
+
+export const buildMarkerPlacementMap = <TRow extends MarkerPlacementRow>(
+  rows: TRow[]
+): Map<string, MarkerPoint> => {
+  const validPoints = rows
+    .map((row) => {
+      const point = normalizeMarkerPoint(row.coordinates);
+      return point ? { id: row.id, point } : null;
+    })
+    .filter((entry): entry is { id: string; point: MarkerPoint } => entry !== null);
+
+  const coordinateCounts = new Map<string, number>();
+  validPoints.forEach(({ point }) => {
+    const key = getCoordinateKey(point);
+    coordinateCounts.set(key, (coordinateCounts.get(key) ?? 0) + 1);
+  });
+
+  const coordinateOccurrences = new Map<string, number>();
+  const placements = new Map<string, MarkerPoint>();
+
+  validPoints.forEach(({ id, point }) => {
+    const key = getCoordinateKey(point);
+    const occurrenceIndex = coordinateOccurrences.get(key) ?? 0;
+    const occurrenceCount = coordinateCounts.get(key) ?? 1;
+
+    placements.set(id, getOffsetMarkerPoint(point, occurrenceIndex, occurrenceCount));
+    coordinateOccurrences.set(key, occurrenceIndex + 1);
+  });
+
+  return placements;
+};

--- a/my-app/src/pages/Delivery/utils/routeAssignmentState.test.ts
+++ b/my-app/src/pages/Delivery/utils/routeAssignmentState.test.ts
@@ -5,6 +5,7 @@ import {
   findRouteSlotConflict,
   moveClientToCluster,
   moveClientsToCluster,
+  renumberRoutesSequentially,
   updateClientRouteAssignment,
   type RouteAssignmentState,
 } from "./routeAssignmentState";
@@ -139,6 +140,27 @@ describe("routeAssignmentState helpers", () => {
     ]);
     expect(result.clientOverrides).toEqual([{ clientId: "c3", driver: "Bob", time: "10:00" }]);
     expect(result.touchedRouteIds).toEqual(["1", "3"]);
+  });
+
+  // App coverage:
+  // - cluster deliveries overlay action for reordering route ids after assignment is complete
+  // - keeps route contents and overrides intact while renumbering route ids back to a clean 1..X sequence
+  // Behavior contract: out-of-order route ids are compacted to ascending sequential ids and unused empty routes are removed.
+  it("renumbers out-of-order clusters back to a sequential 1..X order and removes unused clusters", () => {
+    const state: RouteAssignmentState = {
+      clusters: [
+        { id: "2", driver: "Alice", time: "09:00", deliveries: ["c1"] },
+        { id: "4", driver: "Bob", time: "10:00", deliveries: ["c2"] },
+        { id: "7", driver: "Dana", time: "11:00", deliveries: [] },
+      ],
+      clientOverrides: [{ clientId: "c1", driver: "Alice", time: "09:00" }],
+    };
+
+    const result = renumberRoutesSequentially(state);
+
+    expect(result.clusters.map((cluster) => cluster.id)).toEqual(["1", "2"]);
+    expect(result.clusters.map((cluster) => cluster.deliveries)).toEqual([["c1"], ["c2"]]);
+    expect(result.clientOverrides).toEqual([{ clientId: "c1", driver: "Alice", time: "09:00" }]);
   });
 
   // App coverage:

--- a/my-app/src/pages/Delivery/utils/routeAssignmentState.test.ts
+++ b/my-app/src/pages/Delivery/utils/routeAssignmentState.test.ts
@@ -4,6 +4,7 @@ import {
   assignTimeToRoutes,
   findRouteSlotConflict,
   moveClientToCluster,
+  moveClientsToCluster,
   updateClientRouteAssignment,
   type RouteAssignmentState,
 } from "./routeAssignmentState";
@@ -105,10 +106,46 @@ describe("routeAssignmentState helpers", () => {
   });
 
   // App coverage:
+  // - bulk checkbox selection on the Routes spreadsheet followed by changing the cluster dropdown
+  // - ensures all checked deliveries move together instead of only the clicked row moving
+  // Behavior contract: bulk cluster reassignment moves every selected client, removes their overrides,
+  // and reports both the old and new touched route IDs.
+  it("moves multiple selected clients to a new cluster in one mutation", () => {
+    const state: RouteAssignmentState = {
+      clusters: [
+        { id: "1", driver: "Alice", time: "09:00", deliveries: ["c1", "c2"] },
+        { id: "2", driver: "Bob", time: "10:00", deliveries: ["c3"] },
+      ],
+      clientOverrides: [
+        { clientId: "c1", driver: "Alice", time: "09:00" },
+        { clientId: "c2", driver: "Alice", time: "09:00" },
+        { clientId: "c3", driver: "Bob", time: "10:00" },
+      ],
+    };
+
+    const result = moveClientsToCluster(
+      state,
+      [
+        { clientId: "c1", oldClusterId: "1" },
+        { clientId: "c2", oldClusterId: "1" },
+      ],
+      "3"
+    );
+
+    expect(result.clusters.find((cluster) => cluster.id === "1")?.deliveries).toEqual([]);
+    expect(result.clusters.find((cluster) => cluster.id === "3")?.deliveries).toEqual([
+      "c1",
+      "c2",
+    ]);
+    expect(result.clientOverrides).toEqual([{ clientId: "c3", driver: "Bob", time: "10:00" }]);
+    expect(result.touchedRouteIds).toEqual(["1", "3"]);
+  });
+
+  // App coverage:
   // - per-client route assignment updates when editing cluster/driver/time from popup or table controls
   // - clears route-wide override fields (driver/time) when route-level values are explicitly updated
   // Behavior contract: updating route-level driver/time for a target cluster preserves cluster membership and
-  // removes corresponding override fields for all clients in that target route.
+  // removes corresponding override fields for all clients in target route.
   it("updates route-level driver/time and clears matching overrides for clients in target route", () => {
     const state: RouteAssignmentState = {
       clusters: [

--- a/my-app/src/pages/Delivery/utils/routeAssignmentState.ts
+++ b/my-app/src/pages/Delivery/utils/routeAssignmentState.ts
@@ -454,6 +454,35 @@ export const moveClientsToCluster = <TCluster extends RouteAssignmentCluster>(
   };
 };
 
+export const renumberRoutesSequentially = <TCluster extends RouteAssignmentCluster>(
+  state: RouteAssignmentState<TCluster>
+): RouteAssignmentMutationResult<TCluster> => {
+  const usedClusters = state.clusters.filter((cluster) => {
+    const normalizedDeliveries = (cluster.deliveries ?? [])
+      .map((deliveryId) => normalizeAssignmentValue(deliveryId))
+      .filter((deliveryId): deliveryId is string => Boolean(deliveryId));
+
+    return normalizedDeliveries.length > 0;
+  });
+
+  const sortedUsedClusters = [...usedClusters].sort((left, right) =>
+    compareRouteIds(normalizeRouteId(left.id) || "", normalizeRouteId(right.id) || "")
+  );
+
+  return {
+    clusters: sortedUsedClusters.map((cluster, index) => {
+      const nextRouteId = String(index + 1);
+
+      return {
+        ...cluster,
+        id: typeof cluster.id === "number" ? Number(nextRouteId) : nextRouteId,
+      } as TCluster;
+    }),
+    clientOverrides: sanitizeClientOverrides(state.clientOverrides),
+    touchedRouteIds: Array.from({ length: sortedUsedClusters.length }, (_, index) => String(index + 1)),
+  };
+};
+
 export const updateClientRouteAssignment = <TCluster extends RouteAssignmentCluster>(
   state: RouteAssignmentState<TCluster>,
   params: ClientRouteUpdateParams

--- a/my-app/src/pages/Delivery/utils/routeAssignmentState.ts
+++ b/my-app/src/pages/Delivery/utils/routeAssignmentState.ts
@@ -54,6 +54,11 @@ interface ClientRouteUpdateParams {
   timeValue?: string;
 }
 
+interface BulkClientClusterMoveParams {
+  clientId: string;
+  oldClusterId?: string;
+}
+
 const normalizeRouteId = (routeId?: unknown): string | undefined => {
   if (typeof routeId === "number" && Number.isFinite(routeId)) {
     return String(routeId);
@@ -401,6 +406,51 @@ export const moveClientToCluster = <TCluster extends RouteAssignmentCluster>(
       normalizedOldClusterId || "",
       normalizedNewClusterId || "",
     ]),
+  };
+};
+
+export const moveClientsToCluster = <TCluster extends RouteAssignmentCluster>(
+  state: RouteAssignmentState<TCluster>,
+  clientMoves: BulkClientClusterMoveParams[],
+  newClusterId?: string
+): RouteAssignmentMutationResult<TCluster> => {
+  const normalizedNewClusterId = normalizeRouteId(newClusterId);
+  const movedClientIds = new Set<string>();
+  const touchedRouteIds = new Set<string>();
+
+  let nextState: RouteAssignmentState<TCluster> = {
+    clusters: [...state.clusters],
+    clientOverrides: sanitizeClientOverrides(state.clientOverrides),
+  };
+
+  clientMoves.forEach(({ clientId, oldClusterId }) => {
+    const normalizedClientId = normalizeAssignmentValue(clientId);
+
+    if (!normalizedClientId || movedClientIds.has(normalizedClientId)) {
+      return;
+    }
+
+    movedClientIds.add(normalizedClientId);
+
+    const result = moveClientToCluster(
+      nextState,
+      normalizedClientId,
+      oldClusterId,
+      normalizedNewClusterId
+    );
+
+    nextState = {
+      clusters: result.clusters,
+      clientOverrides: result.clientOverrides,
+    };
+
+    result.touchedRouteIds.forEach((routeId) => touchedRouteIds.add(routeId));
+  });
+
+  return {
+    clusters: nextState.clusters,
+    clientOverrides: nextState.clientOverrides,
+    touchedRouteIds: Array.from(touchedRouteIds).sort(compareRouteIds),
   };
 };
 

--- a/my-app/src/utils/searchFilter.test.ts
+++ b/my-app/src/utils/searchFilter.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "@jest/globals";
-import { extractKeyValue, parseSearchTermsProgressively } from "./searchFilter";
+import {
+  checkStringEquals,
+  extractKeyValue,
+  parseSearchTermsProgressively,
+  splitFilterValues,
+} from "./searchFilter";
 
 describe("searchFilter parsing", () => {
   // App coverage:
@@ -42,6 +47,37 @@ describe("searchFilter parsing", () => {
 
     expect(compactTerms).toEqual(["cluster:12", "driver:maria"]);
     expect(spacedTerms).toEqual(["cluster: 12", "driver:maria"]);
+  });
+
+  // App coverage:
+  // - Routes page key:value parsing for comma-separated values in a single column filter
+  // - supports input like `cluster: 1, 2 ward:7` without splitting `2` into a stray term
+  // Behavior contract: comma-separated values remain attached to the same key:value filter term.
+  it("preserves multi-value key:value filters as a single search term", () => {
+    const terms = parseSearchTermsProgressively("cluster: 1, 2 ward:7");
+
+    expect(terms).toEqual(["cluster: 1, 2", "ward:7"]);
+  });
+
+  // App coverage:
+  // - multi-value Routes page filtering across columns like cluster, ward, driver, and tags
+  // - each comma-separated entry should be treated as an OR value for the same key
+  // Behavior contract: splitFilterValues trims entries and preserves quoted comma text as one value.
+  it("splits comma-separated filter values while preserving quoted entries", () => {
+    const values = splitFilterValues('1, 2, "north east"');
+
+    expect(values).toEqual(["1", "2", "north east"]);
+  });
+
+  // App coverage:
+  // - exact-match route filters like cluster, ward, and zip should not over-match partial numeric strings
+  // - prevents `cluster:1,2` from including route ids like `10`, `11`, or `12`
+  // Behavior contract: exact comparison is case-insensitive but does not allow substring matches.
+  it("matches exact discrete filter values without partial numeric matches", () => {
+    expect(checkStringEquals("1", "1")).toBe(true);
+    expect(checkStringEquals(" 2 ", "2")).toBe(true);
+    expect(checkStringEquals("10", "1")).toBe(false);
+    expect(checkStringEquals("12", "2")).toBe(false);
   });
 
   // App coverage:

--- a/my-app/src/utils/searchFilter.test.ts
+++ b/my-app/src/utils/searchFilter.test.ts
@@ -60,6 +60,18 @@ describe("searchFilter parsing", () => {
   });
 
   // App coverage:
+  // - Routes page filtering should allow AND across columns while still allowing OR within one column
+  // - supports user input like `cluster: 1, 2, ward: 2` in a single search box
+  // Behavior contract: the parser must split the cluster filter from the ward filter even when a comma is used between them.
+  it("preserves multiple column filters when a multi-value filter is followed by another key:value term", () => {
+    const spacedTerms = parseSearchTermsProgressively("cluster: 1, 2, ward: 2");
+    const compactTerms = parseSearchTermsProgressively("cluster:1,2,ward:2");
+
+    expect(spacedTerms).toEqual(["cluster: 1, 2", "ward: 2"]);
+    expect(compactTerms).toEqual(["cluster:1,2", "ward:2"]);
+  });
+
+  // App coverage:
   // - multi-value Routes page filtering across columns like cluster, ward, driver, and tags
   // - each comma-separated entry should be treated as an OR value for the same key
   // Behavior contract: splitFilterValues trims entries and preserves quoted comma text as one value.
@@ -76,8 +88,10 @@ describe("searchFilter parsing", () => {
   it("matches exact discrete filter values without partial numeric matches", () => {
     expect(checkStringEquals("1", "1")).toBe(true);
     expect(checkStringEquals(" 2 ", "2")).toBe(true);
+    expect(checkStringEquals("Ward 2", "2")).toBe(true);
     expect(checkStringEquals("10", "1")).toBe(false);
     expect(checkStringEquals("12", "2")).toBe(false);
+    expect(checkStringEquals("Ward 12", "2")).toBe(false);
   });
 
   // App coverage:

--- a/my-app/src/utils/searchFilter.test.ts
+++ b/my-app/src/utils/searchFilter.test.ts
@@ -71,6 +71,13 @@ describe("searchFilter parsing", () => {
     expect(compactTerms).toEqual(["cluster:1,2", "ward:2"]);
   });
 
+  it("preserves supported multi-word aliases as a single key:value term", () => {
+    expect(parseSearchTermsProgressively("dietary restrictions:vegan")).toEqual([
+      "dietary restrictions:vegan",
+    ]);
+    expect(parseSearchTermsProgressively("first name:john")).toEqual(["first name:john"]);
+  });
+
   // App coverage:
   // - multi-value Routes page filtering across columns like cluster, ward, driver, and tags
   // - each comma-separated entry should be treated as an OR value for the same key

--- a/my-app/src/utils/searchFilter.ts
+++ b/my-app/src/utils/searchFilter.ts
@@ -20,6 +20,20 @@ export const parseSearchTermsProgressively = (trimmedSearchQuery: string): strin
     "zip",
   ]);
 
+  const pushCurrentTerm = (stripTrailingComma = false): void => {
+    let normalizedTerm = currentTerm.trim();
+
+    if (stripTrailingComma) {
+      normalizedTerm = normalizedTerm.replace(/,\s*$/, "");
+    }
+
+    if (normalizedTerm) {
+      searchTerms.push(normalizedTerm);
+    }
+
+    currentTerm = "";
+  };
+
   const upcomingTokenContainsColon = (startIndex: number): boolean => {
     let index = startIndex;
 
@@ -27,7 +41,11 @@ export const parseSearchTermsProgressively = (trimmedSearchQuery: string): strin
       index += 1;
     }
 
-    while (index < trimmedSearchQuery.length && trimmedSearchQuery[index] !== " ") {
+    while (
+      index < trimmedSearchQuery.length &&
+      trimmedSearchQuery[index] !== " " &&
+      trimmedSearchQuery[index] !== ","
+    ) {
       if (trimmedSearchQuery[index] === ":") {
         return true;
       }
@@ -49,6 +67,18 @@ export const parseSearchTermsProgressively = (trimmedSearchQuery: string): strin
       currentTerm += char;
       inQuote = false;
       quoteChar = "";
+    } else if (!inQuote && char === ",") {
+      const trimmedCurrentTerm = currentTerm.trim();
+      const colonIndex = trimmedCurrentTerm.indexOf(":");
+      const valueAfterColon =
+        colonIndex === -1 ? "" : trimmedCurrentTerm.substring(colonIndex + 1).trim();
+      const nextTokenHasColon = upcomingTokenContainsColon(i + 1);
+
+      if (colonIndex !== -1 && valueAfterColon !== "" && nextTokenHasColon) {
+        pushCurrentTerm(false);
+      } else {
+        currentTerm += char;
+      }
     } else if (!inQuote && char === " ") {
       const trimmedCurrentTerm = currentTerm.trim();
       const colonIndex = trimmedCurrentTerm.indexOf(":");
@@ -66,11 +96,13 @@ export const parseSearchTermsProgressively = (trimmedSearchQuery: string): strin
         multiWordFilterPrefixes.has(normalizedTerm)
       ) {
         currentTerm += char;
-      } else if (colonIndex !== -1 && (valueAfterColon === "" || endsWithComma || nextChar === '"' || nextChar === "'")) {
+      } else if (
+        colonIndex !== -1 &&
+        (valueAfterColon === "" || (endsWithComma && !nextTokenHasColon) || nextChar === '"' || nextChar === "'")
+      ) {
         currentTerm += char;
       } else if (trimmedCurrentTerm) {
-        searchTerms.push(trimmedCurrentTerm);
-        currentTerm = "";
+        pushCurrentTerm(endsWithComma && nextTokenHasColon);
       }
     } else {
       currentTerm += char;
@@ -97,7 +129,22 @@ export const checkStringEquals = (value: any, query: string): boolean => {
   if (value === undefined || value === null) {
     return false;
   }
-  return normalizeSearchValue(value) === normalizeSearchValue(query);
+
+  const normalizedValue = normalizeSearchValue(value);
+  const normalizedQuery = normalizeSearchValue(query);
+
+  if (normalizedValue === normalizedQuery) {
+    return true;
+  }
+
+  const valueNumberTokens: string[] = normalizedValue.match(/\d+/g) ?? [];
+  const queryNumberTokens: string[] = normalizedQuery.match(/\d+/g) ?? [];
+
+  if (queryNumberTokens.length === 1 && valueNumberTokens.length > 0) {
+    return valueNumberTokens.includes(queryNumberTokens[0]);
+  }
+
+  return false;
 };
 
 const stripWrappingQuotes = (value: string): string => {

--- a/my-app/src/utils/searchFilter.ts
+++ b/my-app/src/utils/searchFilter.ts
@@ -9,8 +9,37 @@ export const parseSearchTermsProgressively = (trimmedSearchQuery: string): strin
   let quoteChar = "";
   let currentTerm = "";
 
+  const multiWordFilterPrefixes = new Set([
+    "assigned",
+    "cluster",
+    "delivery",
+    "last",
+    "referral",
+    "route",
+    "tefap",
+    "zip",
+  ]);
+
+  const upcomingTokenContainsColon = (startIndex: number): boolean => {
+    let index = startIndex;
+
+    while (index < trimmedSearchQuery.length && trimmedSearchQuery[index] === " ") {
+      index += 1;
+    }
+
+    while (index < trimmedSearchQuery.length && trimmedSearchQuery[index] !== " ") {
+      if (trimmedSearchQuery[index] === ":") {
+        return true;
+      }
+      index += 1;
+    }
+
+    return false;
+  };
+
   for (let i = 0; i < trimmedSearchQuery.length; i++) {
     const char = trimmedSearchQuery[i];
+    const nextChar = i + 1 < trimmedSearchQuery.length ? trimmedSearchQuery[i + 1] : "";
 
     if (!inQuote && (char === '"' || char === "'")) {
       inQuote = true;
@@ -25,8 +54,19 @@ export const parseSearchTermsProgressively = (trimmedSearchQuery: string): strin
       const colonIndex = trimmedCurrentTerm.indexOf(":");
       const valueAfterColon =
         colonIndex === -1 ? "" : trimmedCurrentTerm.substring(colonIndex + 1).trim();
+      const nextTokenHasColon = upcomingTokenContainsColon(i + 1);
+      const endsWithComma = trimmedCurrentTerm.endsWith(",");
+      const endsWithQuote = trimmedCurrentTerm.endsWith('"') || trimmedCurrentTerm.endsWith("'");
+      const normalizedTerm = normalizeSearchKeyword(trimmedCurrentTerm);
 
-      if (colonIndex !== -1 && valueAfterColon === "") {
+      if (
+        colonIndex === -1 &&
+        !endsWithQuote &&
+        nextTokenHasColon &&
+        multiWordFilterPrefixes.has(normalizedTerm)
+      ) {
+        currentTerm += char;
+      } else if (colonIndex !== -1 && (valueAfterColon === "" || endsWithComma || nextChar === '"' || nextChar === "'")) {
         currentTerm += char;
       } else if (trimmedCurrentTerm) {
         searchTerms.push(trimmedCurrentTerm);
@@ -44,11 +84,69 @@ export const parseSearchTermsProgressively = (trimmedSearchQuery: string): strin
   return searchTerms.filter((term) => term.length > 0 && term !== '"' && term !== "'");
 };
 
+const normalizeSearchValue = (value: any): string => String(value).trim().toLowerCase();
+
 export const checkStringContains = (value: any, query: string): boolean => {
   if (value === undefined || value === null) {
     return false;
   }
-  return String(value).toLowerCase().includes(query.toLowerCase());
+  return normalizeSearchValue(value).includes(normalizeSearchValue(query));
+};
+
+export const checkStringEquals = (value: any, query: string): boolean => {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  return normalizeSearchValue(value) === normalizeSearchValue(query);
+};
+
+const stripWrappingQuotes = (value: string): string => {
+  const trimmedValue = value.trim();
+
+  if (
+    (trimmedValue.startsWith('"') && trimmedValue.endsWith('"')) ||
+    (trimmedValue.startsWith("'") && trimmedValue.endsWith("'"))
+  ) {
+    return trimmedValue.slice(1, -1).trim();
+  }
+
+  return trimmedValue;
+};
+
+export const splitFilterValues = (searchValue: string): string[] => {
+  const values: string[] = [];
+  let currentValue = "";
+  let inQuote = false;
+  let quoteChar = "";
+
+  for (let i = 0; i < searchValue.length; i++) {
+    const char = searchValue[i];
+
+    if (!inQuote && (char === '"' || char === "'")) {
+      inQuote = true;
+      quoteChar = char;
+      currentValue += char;
+    } else if (inQuote && char === quoteChar) {
+      currentValue += char;
+      inQuote = false;
+      quoteChar = "";
+    } else if (!inQuote && char === ",") {
+      const normalizedValue = stripWrappingQuotes(currentValue);
+      if (normalizedValue) {
+        values.push(normalizedValue);
+      }
+      currentValue = "";
+    } else {
+      currentValue += char;
+    }
+  }
+
+  const normalizedValue = stripWrappingQuotes(currentValue);
+  if (normalizedValue) {
+    values.push(normalizedValue);
+  }
+
+  return values;
 };
 
 export const normalizeSearchKeyword = (value: string): string =>
@@ -71,11 +169,8 @@ export const extractKeyValue = (
   if (colonIndex !== -1) {
     let searchValue = term.substring(colonIndex + 1).trim();
 
-    if (
-      (searchValue.startsWith('"') && searchValue.endsWith('"')) ||
-      (searchValue.startsWith("'") && searchValue.endsWith("'"))
-    ) {
-      searchValue = searchValue.slice(1, -1);
+    if (!searchValue.includes(",")) {
+      searchValue = stripWrappingQuotes(searchValue);
     }
 
     return {

--- a/my-app/src/utils/searchFilter.ts
+++ b/my-app/src/utils/searchFilter.ts
@@ -13,6 +13,8 @@ export const parseSearchTermsProgressively = (trimmedSearchQuery: string): strin
     "assigned",
     "cluster",
     "delivery",
+    "dietary",
+    "first",
     "last",
     "referral",
     "route",
@@ -98,7 +100,10 @@ export const parseSearchTermsProgressively = (trimmedSearchQuery: string): strin
         currentTerm += char;
       } else if (
         colonIndex !== -1 &&
-        (valueAfterColon === "" || (endsWithComma && !nextTokenHasColon) || nextChar === '"' || nextChar === "'")
+        (valueAfterColon === "" ||
+          (endsWithComma && !nextTokenHasColon) ||
+          nextChar === '"' ||
+          nextChar === "'")
       ) {
         currentTerm += char;
       } else if (trimmedCurrentTerm) {


### PR DESCRIPTION
PR does fix route search filtering for cluster and other key:value fields, including optional spaces after the colon and comma-separated multi-value filters. Test this by going to the Routes page and trying searches like \cluster:12\, \cluster: 12\, and \cluster:1,2\.

PR does fix exact matching for discrete route fields so filters like \cluster:1,2\ no longer incorrectly match clusters such as 10, 11, or 12. Test this by searching for \cluster:1,2\ and confirming only clusters 1 and 2 appear.

PR does add the same multi-value key:value filtering behavior to the Clients and Users pages. Test this by using filters like \ ame:john,jane\ or \
ole:admin,dispatcher\ on those tables.

PR does fix bulk cluster reassignment from the Routes page when multiple rows are selected with checkboxes. Test this by selecting several deliveries, changing the cluster once, and confirming all selected rows move together.

PR does fix the issue where moving all deliveries out of a cluster caused that cluster to disappear. Test this by moving every delivery out of a cluster and confirming the empty cluster still remains available.

PR does improve the cluster summary overlay on the map with compact sorting controls and delivery-count sorting in both directions. Test this by opening the Routes map summary and clicking the Sort control to cycle through route order, highest-to-lowest, and lowest-to-highest.

PR creates a button when all of the clusters have a driver and time but have unassigned clusters that lets you reorder clusters. Test this by creating a empty cluster but assign all clients a driver and time.

PR shows a count when filtering of how many items are showing out of the total test this by doing a filter.

PR should show markers from the same apartment complex with a slight difference instead of on top of each other so you can see the counts, zoom in to verify there are two (or more) from the same complex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent cluster-summary sort with UI controls and icons
  * Renumber clusters action with progress state (sequential renumbering)
  * Search placeholders updated with multi-value key:value examples
  * Multi-value key:value search supported across spreadsheets (comma-separated)
  * Bulk client reassignment supports moving multiple selected clients at once

* **Bug Fixes**
  * Preserve empty source clusters when moving all clients
  * Improved search normalization with exact/array-aware matching
  * Route filter shows "Showing X filtered … of Y" counts

* **Tests**
  * Added regression/unit tests for search filters, cluster sorting, and bulk moves
<!-- end of auto-generated comment: release notes by coderabbit.ai -->