### PR TITLE
Fix: warn when route driver changes clear overrides

### DIFF
--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -103,7 +103,9 @@ import {
 import {
   assignDriverToRoutes,
   assignTimeToRoutes,
+  ClearedDriverOverrideWarning,
   findRouteSlotConflict,
+  getClearedDriverOverrideWarning,
   moveClientToCluster,
   moveClientsToCluster,
   renumberRoutesSequentially,
@@ -399,6 +401,46 @@ const buildRouteSlotConflictMessage = (conflict: RouteSlotConflict): string =>
   `${conflict.driver} already has Route ${conflict.existingRouteId} at ${formatAssignedTime(
     conflict.time
   )}.`;
+
+const formatClearedDriverOverrideWarning = (
+  routeIds: string[],
+  driverName: string,
+  warning: ClearedDriverOverrideWarning
+): string => {
+  const normalizedDriver = normalizeAssignmentValue(driverName) ?? "";
+  const normalizedRouteId = normalizeClusterIdValue(routeIds[0]);
+  const routeLabel = normalizedRouteId ? `Route ${normalizedRouteId}` : "the route";
+  const assignmentLabel =
+    warning.clearedOverrideCount === 1 ? "assignment" : "assignments";
+
+  if (!normalizedDriver) {
+    if (warning.routeCount === 1) {
+      return `Cleared the driver for ${routeLabel}. Cleared ${warning.clearedOverrideCount} prior driver ${assignmentLabel}.`;
+    }
+
+    return `Cleared the driver for ${warning.routeCount} routes. Cleared ${warning.clearedOverrideCount} prior driver ${assignmentLabel}.`;
+  }
+
+  if (
+    warning.routeCount === 1 &&
+    warning.clearedOverrideCount <= 2 &&
+    warning.clearedDriverNames.length === warning.clearedOverrideCount
+  ) {
+    const driverNames =
+      warning.clearedDriverNames.length === 2
+        ? `${warning.clearedDriverNames[0]} and ${warning.clearedDriverNames[1]}`
+        : warning.clearedDriverNames[0];
+    const verb = warning.clearedOverrideCount === 1 ? "was" : "were";
+
+    return `${routeLabel} now uses ${normalizedDriver}. ${driverNames} ${verb} unassigned.`;
+  }
+
+  if (warning.routeCount === 1) {
+    return `${routeLabel} now uses ${normalizedDriver}. Cleared ${warning.clearedOverrideCount} prior driver ${assignmentLabel}.`;
+  }
+
+  return `Assigned ${normalizedDriver} to ${warning.routeCount} routes. Cleared ${warning.clearedOverrideCount} prior driver ${assignmentLabel}.`;
+};
 
 const dedupeClientsById = (clients: DeliveryRowData[]): DeliveryRowData[] => {
   const uniqueClients = new Map<string, DeliveryRowData>();
@@ -1285,6 +1327,12 @@ const DeliverySpreadsheet: React.FC = () => {
       return false;
     }
 
+    const driverOverrideWarning = getClearedDriverOverrideWarning(
+      { clusters, clientOverrides },
+      selectedRouteIds,
+      driver.name
+    );
+
     try {
       const didSave = await commitRouteAssignmentMutation((currentState) =>
         assignDriverToRoutes(currentState, selectedRouteIds, driver.name)
@@ -1292,6 +1340,11 @@ const DeliverySpreadsheet: React.FC = () => {
 
       if (didSave) {
         resetSelections();
+        if (driverOverrideWarning) {
+          showWarning(
+            formatClearedDriverOverrideWarning(selectedRouteIds, driver.name, driverOverrideWarning)
+          );
+        }
       }
 
       return didSave;
@@ -1328,6 +1381,18 @@ const DeliverySpreadsheet: React.FC = () => {
         ? rows.filter((candidateRow) => selectedRows.has(candidateRow.id))
         : [currentClient];
       const selectedClientIds = selectedClientRows.map((candidateRow) => candidateRow.id);
+      const warningRouteId =
+        newClusterId === "__add__" || newClusterId === "__add_new_cluster__"
+          ? getNextClusterId(clusters)
+          : resolvedClusterId;
+      const driverOverrideWarning =
+        driverUpdateRequested && warningRouteId
+          ? getClearedDriverOverrideWarning(
+              { clusters, clientOverrides },
+              [warningRouteId],
+              newDriver ?? ""
+            )
+          : null;
       let actualResolvedClusterId = resolvedClusterId;
       let didChangeClusters = false;
 
@@ -1453,6 +1518,16 @@ const DeliverySpreadsheet: React.FC = () => {
           setSelectedRows(newSelectedRows);
           setSelectedClusters(newSelectedClusters);
         }
+      }
+
+      if (driverOverrideWarning) {
+        showWarning(
+          formatClearedDriverOverrideWarning(
+            [actualResolvedClusterId || warningRouteId],
+            newDriver ?? "",
+            driverOverrideWarning
+          )
+        );
       }
 
       return true;

--- a/my-app/src/pages/Delivery/utils/routeAssignmentState.test.ts
+++ b/my-app/src/pages/Delivery/utils/routeAssignmentState.test.ts
@@ -3,6 +3,7 @@ import {
   assignDriverToRoutes,
   assignTimeToRoutes,
   findRouteSlotConflict,
+  getClearedDriverOverrideWarning,
   moveClientToCluster,
   moveClientsToCluster,
   renumberRoutesSequentially,
@@ -62,6 +63,87 @@ describe("routeAssignmentState helpers", () => {
       { clientId: "c3", driver: "Bob", time: "10:00" },
     ]);
     expect(result.touchedRouteIds).toEqual(["1"]);
+  });
+
+  // App coverage:
+  // - post-save warning toast when a route-level driver change clears explicit per-client drivers
+  // - keeps the toast payload minimal while still identifying the affected prior drivers
+  // Behavior contract: returns route count, cleared override count, and up to two distinct driver names.
+  it("builds warning metadata for cleared explicit driver overrides", () => {
+    const state: RouteAssignmentState = {
+      clusters: [{ id: "10", driver: "Dana", time: "09:00", deliveries: ["c1", "c2", "c3"] }],
+      clientOverrides: [
+        { clientId: "c1", driver: "Betsy" },
+        { clientId: "c2", driver: "Phil" },
+        { clientId: "c3", time: "09:00" },
+      ],
+    };
+
+    const warning = getClearedDriverOverrideWarning(state, ["10"], "Matty");
+
+    expect(warning).toEqual({
+      routeCount: 1,
+      clearedOverrideCount: 2,
+      clearedDriverNames: ["Betsy", "Phil"],
+    });
+  });
+
+  // App coverage:
+  // - route-level driver changes that should not warn because there is nothing to clear
+  // Behavior contract: returns null when touched routes have no explicit driver overrides.
+  it("returns null when no explicit driver overrides would be cleared", () => {
+    const state: RouteAssignmentState = {
+      clusters: [{ id: "10", driver: "Dana", time: "09:00", deliveries: ["c1", "c2"] }],
+      clientOverrides: [{ clientId: "c1", time: "09:00" }],
+    };
+
+    expect(getClearedDriverOverrideWarning(state, ["10"], "Matty")).toBeNull();
+  });
+
+  // App coverage:
+  // - warning toast suppression when an override already matches the incoming route driver
+  // Behavior contract: matching override drivers are ignored so the toast only reflects actual removals.
+  it("ignores overrides that already match the incoming route driver", () => {
+    const state: RouteAssignmentState = {
+      clusters: [{ id: "10", driver: "Dana", time: "09:00", deliveries: ["c1", "c2"] }],
+      clientOverrides: [
+        { clientId: "c1", driver: "Matty" },
+        { clientId: "c2", driver: "Phil" },
+      ],
+    };
+
+    const warning = getClearedDriverOverrideWarning(state, ["10"], "matty");
+
+    expect(warning).toEqual({
+      routeCount: 1,
+      clearedOverrideCount: 1,
+      clearedDriverNames: ["Phil"],
+    });
+  });
+
+  // App coverage:
+  // - bulk driver assignment to multiple routes with repeated prior driver names across clients
+  // Behavior contract: driver names are deduped case-insensitively while the cleared override count still reflects all removals.
+  it("dedupes repeated driver names across touched routes", () => {
+    const state: RouteAssignmentState = {
+      clusters: [
+        { id: "1", driver: "Dana", time: "09:00", deliveries: ["c1", "c2"] },
+        { id: "2", driver: "Dana", time: "10:00", deliveries: ["c3"] },
+      ],
+      clientOverrides: [
+        { clientId: "c1", driver: "Betsy" },
+        { clientId: "c2", driver: "betsy" },
+        { clientId: "c3", driver: "Phil" },
+      ],
+    };
+
+    const warning = getClearedDriverOverrideWarning(state, ["1", "2"], "Matty");
+
+    expect(warning).toEqual({
+      routeCount: 2,
+      clearedOverrideCount: 3,
+      clearedDriverNames: ["Betsy", "Phil"],
+    });
   });
 
   // App coverage:

--- a/my-app/src/pages/Delivery/utils/routeAssignmentState.ts
+++ b/my-app/src/pages/Delivery/utils/routeAssignmentState.ts
@@ -31,6 +31,12 @@ export interface RouteAssignmentMutationResult<
   touchedRouteIds: string[];
 }
 
+export interface ClearedDriverOverrideWarning {
+  routeCount: number;
+  clearedOverrideCount: number;
+  clearedDriverNames: string[];
+}
+
 interface EffectiveRouteSlot {
   routeId: string;
   driver?: string;
@@ -274,6 +280,60 @@ export const findRouteSlotConflict = (
   }
 
   return null;
+};
+
+export const getClearedDriverOverrideWarning = <
+  TCluster extends RouteAssignmentCluster,
+>(
+  state: RouteAssignmentState<TCluster>,
+  routeIds: Iterable<string | number | null | undefined>,
+  driverName: string
+): ClearedDriverOverrideWarning | null => {
+  const normalizedRouteIds = normalizeRouteIds(routeIds);
+  if (!normalizedRouteIds.length) {
+    return null;
+  }
+
+  const normalizedIncomingDriver = normalizeAssignmentValue(driverName) ?? "";
+  const affectedClientIds = collectAffectedClientIds(state.clusters, normalizedRouteIds);
+  if (!affectedClientIds.size) {
+    return null;
+  }
+
+  const clearedDriverNames = new Map<string, string>();
+  let clearedOverrideCount = 0;
+
+  state.clientOverrides.forEach((override) => {
+    const clientId = normalizeAssignmentValue(override.clientId);
+    const overrideDriver = normalizeAssignmentValue(override.driver);
+
+    if (!clientId || !affectedClientIds.has(clientId) || !overrideDriver) {
+      return;
+    }
+
+    if (overrideDriver.toLowerCase() === normalizedIncomingDriver.toLowerCase()) {
+      return;
+    }
+
+    clearedOverrideCount += 1;
+
+    if (clearedDriverNames.size < 2) {
+      const driverKey = overrideDriver.toLowerCase();
+      if (!clearedDriverNames.has(driverKey)) {
+        clearedDriverNames.set(driverKey, overrideDriver);
+      }
+    }
+  });
+
+  if (!clearedOverrideCount) {
+    return null;
+  }
+
+  return {
+    routeCount: normalizedRouteIds.length,
+    clearedOverrideCount,
+    clearedDriverNames: Array.from(clearedDriverNames.values()),
+  };
 };
 
 export const assignDriverToRoutes = <TCluster extends RouteAssignmentCluster>(


### PR DESCRIPTION
## What changed
- added a small helper to detect when a route-level driver update will clear explicit per-client driver overrides
- show a single warning toast after a successful save in the two existing Delivery route-driver update paths
- added focused unit coverage for the new warning helper behavior

## Why
Changing a route driver can silently clear explicit client driver overrides. This surfaces that side effect without adding new UI state or blocking the save flow.

## Impact
Dispatchers now get a minimal warning toast when assigning a route driver would unassign prior explicit driver overrides, while clients remain on the route and inherit the new route driver.

## Validation
- `./node_modules/.bin/eslint src/pages/Delivery/DeliverySpreadsheet.tsx src/pages/Delivery/utils/routeAssignmentState.ts src/pages/Delivery/utils/routeAssignmentState.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `CI=true npm test -- --watchAll=false --runTestsByPath src/pages/Delivery/utils/routeAssignmentState.test.ts`
- `npm run build` (passes; existing third-party sourcemap warnings from `react-datepicker` remain)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Driver assignment now displays warnings when clearing existing client-level driver overrides, showing the count of affected clients and previously assigned drivers.

* **Tests**
  * Added test coverage for driver override warning detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->