### PR TITLE
[codex] Warn when replacing a route driver

### DIFF
--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -103,7 +103,9 @@ import {
 import {
   assignDriverToRoutes,
   assignTimeToRoutes,
+  ClusterDriverReplacementWarning,
   findRouteSlotConflict,
+  getClusterDriverReplacementWarning,
   moveClientToCluster,
   moveClientsToCluster,
   renumberRoutesSequentially,
@@ -399,6 +401,46 @@ const buildRouteSlotConflictMessage = (conflict: RouteSlotConflict): string =>
   `${conflict.driver} already has Route ${conflict.existingRouteId} at ${formatAssignedTime(
     conflict.time
   )}.`;
+
+const formatDriverNameList = (driverNames: string[]): string => {
+  if (driverNames.length === 0) {
+    return "";
+  }
+
+  if (driverNames.length === 1) {
+    return driverNames[0];
+  }
+
+  if (driverNames.length === 2) {
+    return `${driverNames[0]} and ${driverNames[1]}`;
+  }
+
+  const [firstName, secondName, ...remainingNames] = driverNames;
+  return `${firstName}, ${secondName}, and ${remainingNames.length} others`;
+};
+
+const formatClusterDriverReplacementWarning = (
+  routeIds: string[],
+  incomingDriverName: string,
+  warning: ClusterDriverReplacementWarning
+): string => {
+  const normalizedIncomingDriver = normalizeAssignmentValue(incomingDriverName) ?? "";
+  const replacedDriverLabel = formatDriverNameList(warning.replacedDriverNames);
+  const noRemainingDriverLabel = formatDriverNameList(warning.noRemainingRouteDriverNames);
+  const replacedVerb = warning.replacedDriverNames.length === 1 ? "was" : "were";
+  const noRemainingVerb = warning.noRemainingRouteDriverNames.length === 1 ? "has" : "have";
+
+  let message =
+    warning.routeCount === 1
+      ? `Route ${normalizeClusterIdValue(routeIds[0])} now uses ${normalizedIncomingDriver}. ${replacedDriverLabel} ${replacedVerb} removed from this route.`
+      : `Assigned ${normalizedIncomingDriver} to ${warning.routeCount} routes. Removed ${replacedDriverLabel} from those routes.`;
+
+  if (warning.noRemainingRouteDriverNames.length > 0) {
+    message += ` ${noRemainingDriverLabel} now ${noRemainingVerb} no remaining routes.`;
+  }
+
+  return message;
+};
 
 const dedupeClientsById = (clients: DeliveryRowData[]): DeliveryRowData[] => {
   const uniqueClients = new Map<string, DeliveryRowData>();
@@ -1285,6 +1327,12 @@ const DeliverySpreadsheet: React.FC = () => {
       return false;
     }
 
+    const driverReplacementWarning = getClusterDriverReplacementWarning(
+      { clusters, clientOverrides },
+      selectedRouteIds,
+      driver.name
+    );
+
     try {
       const didSave = await commitRouteAssignmentMutation((currentState) =>
         assignDriverToRoutes(currentState, selectedRouteIds, driver.name)
@@ -1292,6 +1340,15 @@ const DeliverySpreadsheet: React.FC = () => {
 
       if (didSave) {
         resetSelections();
+        if (driverReplacementWarning) {
+          showWarning(
+            formatClusterDriverReplacementWarning(
+              selectedRouteIds,
+              driver.name,
+              driverReplacementWarning
+            )
+          );
+        }
       }
 
       return didSave;
@@ -1328,6 +1385,18 @@ const DeliverySpreadsheet: React.FC = () => {
         ? rows.filter((candidateRow) => selectedRows.has(candidateRow.id))
         : [currentClient];
       const selectedClientIds = selectedClientRows.map((candidateRow) => candidateRow.id);
+      const warningRouteId =
+        newClusterId === "__add__" || newClusterId === "__add_new_cluster__"
+          ? getNextClusterId(clusters)
+          : resolvedClusterId;
+      const driverReplacementWarning =
+        driverUpdateRequested && warningRouteId
+          ? getClusterDriverReplacementWarning(
+              { clusters, clientOverrides },
+              [warningRouteId],
+              newDriver ?? ""
+            )
+          : null;
       let actualResolvedClusterId = resolvedClusterId;
       let didChangeClusters = false;
 
@@ -1453,6 +1522,16 @@ const DeliverySpreadsheet: React.FC = () => {
           setSelectedRows(newSelectedRows);
           setSelectedClusters(newSelectedClusters);
         }
+      }
+
+      if (driverReplacementWarning) {
+        showWarning(
+          formatClusterDriverReplacementWarning(
+            [actualResolvedClusterId || warningRouteId],
+            newDriver ?? "",
+            driverReplacementWarning
+          )
+        );
       }
 
       return true;

--- a/my-app/src/pages/Delivery/utils/routeAssignmentState.test.ts
+++ b/my-app/src/pages/Delivery/utils/routeAssignmentState.test.ts
@@ -3,6 +3,7 @@ import {
   assignDriverToRoutes,
   assignTimeToRoutes,
   findRouteSlotConflict,
+  getClusterDriverReplacementWarning,
   moveClientToCluster,
   moveClientsToCluster,
   renumberRoutesSequentially,
@@ -62,6 +63,116 @@ describe("routeAssignmentState helpers", () => {
       { clientId: "c3", driver: "Bob", time: "10:00" },
     ]);
     expect(result.touchedRouteIds).toEqual(["1"]);
+  });
+
+  // App coverage:
+  // - post-save warning toast when a route driver is replaced with a different driver
+  // Behavior contract: route-level warnings list the replaced drivers and report when they have no remaining routes.
+  it("builds replacement warning metadata for a normal cluster driver replacement", () => {
+    const state: RouteAssignmentState = {
+      clusters: [
+        { id: "10", driver: "Betsy", time: "09:00", deliveries: ["c1"] },
+        { id: "11", driver: "Phil", time: "10:00", deliveries: ["c2"] },
+      ],
+      clientOverrides: [],
+    };
+
+    const warning = getClusterDriverReplacementWarning(state, ["10"], "Matty");
+
+    expect(warning).toEqual({
+      routeCount: 1,
+      replacedDriverNames: ["Betsy"],
+      noRemainingRouteDriverNames: ["Betsy"],
+    });
+  });
+
+  // App coverage:
+  // - route-driver replacement warnings should ignore old drivers that still have other routes after the change
+  // Behavior contract: globally unassigned names are only reported when the removed driver has no remaining routes anywhere.
+  it("keeps removed drivers out of the no-remaining list when they still have another route", () => {
+    const state: RouteAssignmentState = {
+      clusters: [
+        { id: "10", driver: "Betsy", time: "09:00", deliveries: ["c1"] },
+        { id: "11", driver: "Betsy", time: "10:00", deliveries: ["c2"] },
+      ],
+      clientOverrides: [],
+    };
+
+    const warning = getClusterDriverReplacementWarning(state, ["10"], "Matty");
+
+    expect(warning).toEqual({
+      routeCount: 1,
+      replacedDriverNames: ["Betsy"],
+      noRemainingRouteDriverNames: [],
+    });
+  });
+
+  // App coverage:
+  // - suppressing replacement toasts when a route already has the selected driver
+  // Behavior contract: unchanged assignments do not produce warning metadata.
+  it("ignores routes whose driver is unchanged", () => {
+    const state: RouteAssignmentState = {
+      clusters: [{ id: "10", driver: "Matty", time: "09:00", deliveries: ["c1"] }],
+      clientOverrides: [],
+    };
+
+    expect(getClusterDriverReplacementWarning(state, ["10"], "matty")).toBeNull();
+  });
+
+  // App coverage:
+  // - assigning a driver to an unassigned route should not look like a replacement
+  // Behavior contract: blank old drivers are ignored.
+  it("ignores routes without an existing driver", () => {
+    const state: RouteAssignmentState = {
+      clusters: [{ id: "10", driver: "", time: "09:00", deliveries: ["c1"] }],
+      clientOverrides: [],
+    };
+
+    expect(getClusterDriverReplacementWarning(state, ["10"], "Matty")).toBeNull();
+  });
+
+  // App coverage:
+  // - bulk route driver updates where repeated old driver names appear across touched routes
+  // Behavior contract: replaced drivers are deduped case-insensitively.
+  it("dedupes repeated replaced driver names across touched routes", () => {
+    const state: RouteAssignmentState = {
+      clusters: [
+        { id: "10", driver: "Betsy", time: "09:00", deliveries: ["c1"] },
+        { id: "11", driver: "betsy", time: "10:00", deliveries: ["c2"] },
+        { id: "12", driver: "Phil", time: "11:00", deliveries: ["c3"] },
+      ],
+      clientOverrides: [],
+    };
+
+    const warning = getClusterDriverReplacementWarning(state, ["10", "11", "12"], "Matty");
+
+    expect(warning).toEqual({
+      routeCount: 3,
+      replacedDriverNames: ["Betsy", "Phil"],
+      noRemainingRouteDriverNames: ["Betsy", "Phil"],
+    });
+  });
+
+  // App coverage:
+  // - replacement warning when one removed driver is still present on an untouched route
+  // Behavior contract: only the drivers with zero remaining route assignments are flagged as having no remaining routes.
+  it("handles removed drivers who still remain on an untouched route", () => {
+    const state: RouteAssignmentState = {
+      clusters: [
+        { id: "10", driver: "Betsy", time: "09:00", deliveries: ["c1"] },
+        { id: "11", driver: "Phil", time: "10:00", deliveries: ["c2"] },
+        { id: "12", driver: "Phil", time: "11:00", deliveries: ["c3"] },
+      ],
+      clientOverrides: [],
+    };
+
+    const warning = getClusterDriverReplacementWarning(state, ["10", "11"], "Matty");
+
+    expect(warning).toEqual({
+      routeCount: 2,
+      replacedDriverNames: ["Betsy", "Phil"],
+      noRemainingRouteDriverNames: ["Betsy"],
+    });
   });
 
   // App coverage:

--- a/my-app/src/pages/Delivery/utils/routeAssignmentState.ts
+++ b/my-app/src/pages/Delivery/utils/routeAssignmentState.ts
@@ -31,6 +31,12 @@ export interface RouteAssignmentMutationResult<
   touchedRouteIds: string[];
 }
 
+export interface ClusterDriverReplacementWarning {
+  routeCount: number;
+  replacedDriverNames: string[];
+  noRemainingRouteDriverNames: string[];
+}
+
 interface EffectiveRouteSlot {
   routeId: string;
   driver?: string;
@@ -274,6 +280,65 @@ export const findRouteSlotConflict = (
   }
 
   return null;
+};
+
+export const getClusterDriverReplacementWarning = <
+  TCluster extends RouteAssignmentCluster,
+>(
+  state: RouteAssignmentState<TCluster>,
+  routeIds: Iterable<string | number | null | undefined>,
+  incomingDriverName: string
+): ClusterDriverReplacementWarning | null => {
+  const normalizedRouteIds = normalizeRouteIds(routeIds);
+  const normalizedIncomingDriver = normalizeAssignmentValue(incomingDriverName);
+
+  if (!normalizedRouteIds.length || !normalizedIncomingDriver) {
+    return null;
+  }
+
+  const incomingDriverKey = normalizedIncomingDriver.toLowerCase();
+  const targetRouteIds = new Set(normalizedRouteIds);
+  const replacedDriverNames = new Map<string, string>();
+  const remainingRouteDriverCounts = new Map<string, number>();
+
+  state.clusters.forEach((cluster) => {
+    const routeId = normalizeRouteId(cluster.id);
+    const currentDriver = normalizeDriverAssignmentValue(cluster.driver);
+
+    if (!routeId || !currentDriver) {
+      return;
+    }
+
+    const currentDriverKey = currentDriver.toLowerCase();
+    const driverIsChanging =
+      targetRouteIds.has(routeId) && currentDriverKey !== incomingDriverKey;
+
+    if (driverIsChanging) {
+      if (!replacedDriverNames.has(currentDriverKey)) {
+        replacedDriverNames.set(currentDriverKey, currentDriver);
+      }
+      return;
+    }
+
+    remainingRouteDriverCounts.set(
+      currentDriverKey,
+      (remainingRouteDriverCounts.get(currentDriverKey) ?? 0) + 1
+    );
+  });
+
+  if (!replacedDriverNames.size) {
+    return null;
+  }
+
+  const noRemainingRouteDriverNames = Array.from(replacedDriverNames.entries())
+    .filter(([driverKey]) => !remainingRouteDriverCounts.has(driverKey))
+    .map(([, driverName]) => driverName);
+
+  return {
+    routeCount: normalizedRouteIds.length,
+    replacedDriverNames: Array.from(replacedDriverNames.values()),
+    noRemainingRouteDriverNames,
+  };
 };
 
 export const assignDriverToRoutes = <TCluster extends RouteAssignmentCluster>(


### PR DESCRIPTION
## Summary
- warn when a route driver is replaced with a different route driver
- include when the removed driver has no remaining routes after the change
- cover the new warning helper with targeted route-assignment tests

## Why
PR #286 warned on the wrong behavior. The product requirement is route-level driver replacement, not per-client override clearing. This PR implements the correct rule with a narrow helper and a single post-save warning toast.

## Validation
- `./node_modules/.bin/eslint src/pages/Delivery/DeliverySpreadsheet.tsx src/pages/Delivery/utils/routeAssignmentState.ts src/pages/Delivery/utils/routeAssignmentState.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `CI=true npm test -- --watchAll=false --runTestsByPath src/pages/Delivery/utils/routeAssignmentState.test.ts`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warnings displayed after driver assignments that notify users when driver changes remove a driver from other routes, detailing affected routes and replaced drivers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->