### PR TITLE
Fix: align route overlay counts with filtered deliveries

### DIFF
--- a/my-app/src/pages/Delivery/ClusterMap.test.ts
+++ b/my-app/src/pages/Delivery/ClusterMap.test.ts
@@ -1,9 +1,16 @@
+/** @jest-environment jsdom */
 import fs from "fs";
 import path from "path";
 import React from "react";
 import { describe, expect, it, jest } from "@jest/globals";
 import { render, screen } from "@testing-library/react";
 import ClusterMap from "./ClusterMap";
+
+jest.mock("leaflet/dist/leaflet.css", () => ({}), { virtual: true });
+jest.mock("leaflet.awesome-markers/dist/leaflet.awesome-markers.css", () => ({}), {
+  virtual: true,
+});
+jest.mock("../../assets/tsp-food-for-all-dc-logo.png", () => "mock-ffa-icon", { virtual: true });
 
 jest.mock("leaflet", () => ({
   __esModule: true,
@@ -20,6 +27,28 @@ jest.mock("../../services/driver-service", () => ({
     }),
   },
 }));
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(global, "localStorage", {
+  value: localStorageMock,
+  writable: true,
+});
 
 describe("ClusterMap popup regression guards", () => {
   // Protects against popups opening and immediately closing due to map click propagation
@@ -72,8 +101,24 @@ describe("ClusterMap popup regression guards", () => {
 
     render(
       React.createElement(ClusterMap, {
-        allRows: [],
-        visibleRows: [],
+        allRows: [
+          {
+            id: "c1",
+            firstName: "A",
+            lastName: "One",
+            address: "1 Main St",
+            coordinates: [38.9, -77.03],
+          },
+        ],
+        visibleRows: [
+          {
+            id: "c1",
+            firstName: "A",
+            lastName: "One",
+            address: "1 Main St",
+            coordinates: [38.9, -77.03],
+          },
+        ],
         clusters: [{ id: "3", deliveries: ["c1", "c2"], driver: "Dana", time: "09:00" }],
         clientOverrides: [],
         onClusterUpdate: async () => true,
@@ -82,7 +127,115 @@ describe("ClusterMap popup regression guards", () => {
     );
 
     expect(await screen.findByText("Cluster Deliveries")).toBeTruthy();
-    expect(screen.getByText("Day total: 0")).toBeTruthy();
+    expect(screen.getByText("Day total: 1")).toBeTruthy();
     expect(screen.getByText("3")).toBeTruthy();
+  });
+
+  it("shows filtered route counts in the overlay and surfaces stale assignment notice when needed", async () => {
+    localStorage.setItem("clusterSummaryEnabled", "true");
+
+    render(
+      React.createElement(ClusterMap, {
+        allRows: [
+          {
+            id: "c1",
+            firstName: "A",
+            lastName: "One",
+            address: "1 Main St",
+            coordinates: [38.9, -77.03],
+          },
+        ],
+        visibleRows: [
+          {
+            id: "c1",
+            firstName: "A",
+            lastName: "One",
+            address: "1 Main St",
+            coordinates: [38.9, -77.03],
+          },
+        ],
+        clusters: [{ id: "3", deliveries: ["c1", "c2"], driver: "Dana", time: "09:00" }],
+        clientOverrides: [],
+        onClusterUpdate: async () => true,
+        onRenumberClusters: async () => true,
+      })
+    );
+
+    expect(await screen.findByText("Cluster Deliveries")).toBeTruthy();
+    expect(screen.getByText("Day total: 1")).toBeTruthy();
+    expect(screen.getByText("of 2 assigned")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Some saved route assignments are out of date. Counts below reflect today's filtered deliveries."
+      )
+    ).toBeTruthy();
+    expect(screen.getByText("1")).toBeTruthy();
+  });
+
+  it("does not show the stale assignment notice when saved routes match the loaded day rows", async () => {
+    localStorage.setItem("clusterSummaryEnabled", "true");
+
+    render(
+      React.createElement(ClusterMap, {
+        allRows: [
+          {
+            id: "c1",
+            firstName: "A",
+            lastName: "One",
+            address: "1 Main St",
+            coordinates: [38.9, -77.03],
+          },
+        ],
+        visibleRows: [
+          {
+            id: "c1",
+            firstName: "A",
+            lastName: "One",
+            address: "1 Main St",
+            coordinates: [38.9, -77.03],
+          },
+        ],
+        clusters: [{ id: "3", deliveries: ["c1"], driver: "Dana", time: "09:00" }],
+        clientOverrides: [],
+        onClusterUpdate: async () => true,
+        onRenumberClusters: async () => true,
+      })
+    );
+
+    expect(await screen.findByText("Cluster Deliveries")).toBeTruthy();
+    expect(screen.queryByText(/Some saved route assignments are out of date\./i)).toBeNull();
+  });
+
+  it("keeps the existing invalid coordinate badge visible", async () => {
+    localStorage.setItem("clusterSummaryEnabled", "true");
+
+    render(
+      React.createElement(ClusterMap, {
+        allRows: [
+          {
+            id: "c1",
+            firstName: "A",
+            lastName: "One",
+            address: "1 Main St",
+            coordinates: [0, 0],
+          },
+        ],
+        visibleRows: [
+          {
+            id: "c1",
+            firstName: "A",
+            lastName: "One",
+            address: "1 Main St",
+            coordinates: [0, 0],
+          },
+        ],
+        clusters: [{ id: "3", deliveries: ["c1"], driver: "Dana", time: "09:00" }],
+        clientOverrides: [],
+        onClusterUpdate: async () => true,
+        onRenumberClusters: async () => true,
+      })
+    );
+
+    expect(await screen.findByText("1 invalid coordinates")).toBeTruthy();
   });
 });

--- a/my-app/src/pages/Delivery/ClusterMap.test.ts
+++ b/my-app/src/pages/Delivery/ClusterMap.test.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import path from "path";
 import React from "react";
 import { describe, expect, it, jest } from "@jest/globals";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import ClusterMap from "./ClusterMap";
 
 jest.mock("leaflet/dist/leaflet.css", () => ({}), { virtual: true });
@@ -206,7 +206,7 @@ describe("ClusterMap popup regression guards", () => {
     expect(screen.queryByText(/Some saved route assignments are out of date\./i)).toBeNull();
   });
 
-  it("keeps the existing invalid coordinate badge visible", async () => {
+  it("shows all invalid deliveries for the day in a read-only popover", async () => {
     localStorage.setItem("clusterSummaryEnabled", "true");
 
     render(
@@ -218,6 +218,30 @@ describe("ClusterMap popup regression guards", () => {
             lastName: "One",
             address: "1 Main St",
             coordinates: [0, 0],
+            clusterId: "3",
+          },
+          {
+            id: "c2",
+            firstName: "B",
+            lastName: "Two",
+            address: "2 Main St",
+            coordinates: [],
+            clusterId: "4",
+          },
+          {
+            id: "c3",
+            firstName: "C",
+            lastName: "Three",
+            address: "3 Main St",
+            coordinates: [0, 0],
+          },
+          {
+            id: "c4",
+            firstName: "D",
+            lastName: "Four",
+            address: "4 Main St",
+            coordinates: [38.9, -77.03],
+            clusterId: "5",
           },
         ],
         visibleRows: [
@@ -227,15 +251,54 @@ describe("ClusterMap popup regression guards", () => {
             lastName: "One",
             address: "1 Main St",
             coordinates: [0, 0],
+            clusterId: "3",
+          },
+          {
+            id: "c4",
+            firstName: "D",
+            lastName: "Four",
+            address: "4 Main St",
+            coordinates: [38.9, -77.03],
+            clusterId: "5",
           },
         ],
-        clusters: [{ id: "3", deliveries: ["c1"], driver: "Dana", time: "09:00" }],
+        clusters: [
+          { id: "3", deliveries: ["c1"], driver: "Dana", time: "09:00" },
+          { id: "4", deliveries: ["c2"], driver: "Eli", time: "10:00" },
+          { id: "5", deliveries: ["c4"], driver: "Fran", time: "11:00" },
+        ],
         clientOverrides: [],
         onClusterUpdate: async () => true,
         onRenumberClusters: async () => true,
       })
     );
 
-    expect(await screen.findByText("1 invalid coordinates")).toBeTruthy();
+    const invalidBadge = await screen.findByRole("button", {
+      name: "Show deliveries with invalid coordinates",
+    });
+
+    expect(invalidBadge.textContent).toContain("3 invalid coordinates");
+
+    fireEvent.click(invalidBadge);
+
+    expect(await screen.findByText("Missing map locations")).toBeTruthy();
+    expect(screen.getByText("These deliveries can't be shown on the map today.")).toBeTruthy();
+    expect(screen.getByText("A One • Route 3")).toBeTruthy();
+    expect(screen.getByText("B Two • Route 4")).toBeTruthy();
+    expect(screen.getByText("C Three • Unassigned")).toBeTruthy();
+
+    const invalidItems = screen.getAllByRole("listitem");
+    expect(invalidItems.map((item) => item.textContent)).toEqual([
+      "A One • Route 3",
+      "B Two • Route 4",
+      "C Three • Unassigned",
+    ]);
+
+    fireEvent.click(invalidBadge);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Missing map locations")).toBeNull();
+    });
+    expect(screen.getByText("Cluster Deliveries")).toBeTruthy();
   });
 });

--- a/my-app/src/pages/Delivery/ClusterMap.tsx
+++ b/my-app/src/pages/Delivery/ClusterMap.tsx
@@ -11,7 +11,7 @@ import { Box, FormControlLabel, IconButton, Switch, Tooltip, Typography } from "
 import DriverService from "../../services/driver-service";
 import FFAIcon from "../../assets/tsp-food-for-all-dc-logo.png";
 import dataSources from "../../config/dataSources";
-import { isRenderableCoordinate } from "./utils/deliveryMapCounts";
+import { buildClusterDisplaySnapshots, isRenderableCoordinate } from "./utils/deliveryMapCounts";
 import { buildMarkerPlacementMap } from "./utils/markerPlacement";
 import { normalizeAssignmentValue, resolveAssignmentValue } from "./utils/assignmentOverrides";
 import {
@@ -364,6 +364,24 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
     return buildAssignmentSummary(allRows, clusterByClientId, clientOverrideByClientId);
   }, [allRows, clusterByClientId, clientOverrideByClientId]);
 
+  const clusterDisplaySnapshots = React.useMemo(
+    () =>
+      buildClusterDisplaySnapshots({
+        allRows,
+        visibleRows,
+        clusters,
+      }),
+    [allRows, visibleRows, clusters]
+  );
+  const clusterDisplaySnapshotById = React.useMemo(
+    () => new Map(clusterDisplaySnapshots.map((snapshot) => [snapshot.clusterId, snapshot])),
+    [clusterDisplaySnapshots]
+  );
+  const hasStaleRouteAssignments = React.useMemo(
+    () => clusterDisplaySnapshots.some((snapshot) => snapshot.staleAssignedCount > 0),
+    [clusterDisplaySnapshots]
+  );
+
   // Calculate deliveries + assignment details per cluster for the map summary overlay.
   const clusterSummaries = React.useMemo(() => {
     const summaries = buildClusterSummariesFromClusters(
@@ -372,8 +390,21 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
       formatTimeForSummary
     );
 
-    return sortClusterSummaries(summaries, clusterSummarySortMode);
-  }, [clusters, clientOverrideByClientId, clusterSummarySortMode]);
+    const summariesWithDisplayCounts = summaries.map((summary) => ({
+      ...summary,
+      count: clusterDisplaySnapshotById.get(summary.clusterId)?.filteredCount ?? summary.count,
+    }));
+
+    return sortClusterSummaries(
+      summariesWithDisplayCounts.filter((summary) => summary.count > 0),
+      clusterSummarySortMode
+    );
+  }, [
+    clusters,
+    clientOverrideByClientId,
+    clusterDisplaySnapshotById,
+    clusterSummarySortMode,
+  ]);
 
   const usedClusterCount = React.useMemo(
     () => clusterSummaries.filter((summary) => summary.count > 0).length,
@@ -1532,6 +1563,19 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
                 Day total: {dayTotalDeliveries}
               </Typography>
             </Box>
+            {hasStaleRouteAssignments && (
+              <Typography
+                variant="caption"
+                sx={{
+                  fontSize: "10px",
+                  color: "warning.main",
+                  lineHeight: 1.25,
+                }}
+              >
+                Some saved route assignments are out of date. Counts below reflect today&apos;s
+                filtered deliveries.
+              </Typography>
+            )}
           </Box>
           <Box
             sx={{
@@ -1639,12 +1683,17 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
           </Box>
           <Box sx={{ display: "flex", flexDirection: "column", gap: "6px" }}>
             {clusterSummaries.map(({ clusterId, count, driverLabel, timeLabel }) => {
+              const displaySnapshot = clusterDisplaySnapshotById.get(clusterId);
               const color = getClusterColor(clusterId);
               const textColor = getTextColorForBackground(color);
               const dividerColor =
                 textColor.toLowerCase() === "#ffffff"
                   ? "rgba(255, 255, 255, 0.38)"
                   : "rgba(0, 0, 0, 0.28)";
+              const cardDetails: string[] = [];
+              if (displaySnapshot && displaySnapshot.assignedCount > count) {
+                cardDetails.push(`of ${displaySnapshot.assignedCount} assigned`);
+              }
               return (
                 <Box
                   key={clusterId}
@@ -1727,6 +1776,19 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
                     >
                       {timeLabel}
                     </Typography>
+                    {cardDetails.length > 0 && (
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          fontSize: "9px",
+                          color: textColor,
+                          opacity: 0.9,
+                          lineHeight: 1.2,
+                        }}
+                      >
+                        {cardDetails.join(" · ")}
+                      </Typography>
+                    )}
                   </Box>
                 </Box>
               );

--- a/my-app/src/pages/Delivery/ClusterMap.tsx
+++ b/my-app/src/pages/Delivery/ClusterMap.tsx
@@ -7,7 +7,7 @@ import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import FormatListNumberedIcon from "@mui/icons-material/FormatListNumbered";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
-import { Box, FormControlLabel, IconButton, Switch, Tooltip, Typography } from "@mui/material";
+import { Box, FormControlLabel, IconButton, Popover, Switch, Tooltip, Typography } from "@mui/material";
 import DriverService from "../../services/driver-service";
 import FFAIcon from "../../assets/tsp-food-for-all-dc-logo.png";
 import dataSources from "../../config/dataSources";
@@ -118,6 +118,37 @@ const normalizeClusterId = (clusterId?: unknown): string => {
   }
 
   return normalizeAssignmentValue(clusterId) || "";
+};
+
+const formatRouteLabel = (clusterId?: unknown): string => {
+  const normalizedClusterId = normalizeClusterId(clusterId);
+  return normalizedClusterId ? `Route ${normalizedClusterId}` : "Unassigned";
+};
+
+const formatClientDisplayName = (row: Pick<RouteMapRow, "firstName" | "lastName">): string => {
+  const fullName = `${row.firstName || ""} ${row.lastName || ""}`.trim();
+  return fullName || "Unknown client";
+};
+
+const compareRouteIds = (leftClusterId: string, rightClusterId: string): number => {
+  if (!leftClusterId && !rightClusterId) {
+    return 0;
+  }
+  if (!leftClusterId) {
+    return 1;
+  }
+  if (!rightClusterId) {
+    return -1;
+  }
+
+  const leftNumber = parseInt(leftClusterId.match(/\d+/)?.[0] || "", 10);
+  const rightNumber = parseInt(rightClusterId.match(/\d+/)?.[0] || "", 10);
+
+  if (!Number.isNaN(leftNumber) && !Number.isNaN(rightNumber) && leftNumber !== rightNumber) {
+    return leftNumber - rightNumber;
+  }
+
+  return leftClusterId.localeCompare(rightClusterId);
 };
 
 const getNextClusterId = (clusterList: Array<Pick<Cluster, "id">>): string => {
@@ -333,6 +364,7 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
   const [wardDataLoading, setWardDataLoading] = useState<boolean>(false);
   const [drivers, setDrivers] = useState<Driver[]>([]);
   const [loadingDrivers, setLoadingDrivers] = useState<boolean>(false);
+  const [invalidBadgeAnchorEl, setInvalidBadgeAnchorEl] = useState<HTMLElement | null>(null);
 
   const clusterByClientId = React.useMemo(() => {
     const map = new Map<string, Cluster>();
@@ -380,6 +412,29 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
   const hasStaleRouteAssignments = React.useMemo(
     () => clusterDisplaySnapshots.some((snapshot) => snapshot.staleAssignedCount > 0),
     [clusterDisplaySnapshots]
+  );
+  const invalidDeliveries = React.useMemo(
+    () =>
+      allRows
+        .filter((client) => !isValidCoordinate(client.coordinates))
+        .map((client) => {
+          const clusterId = normalizeClusterId(
+            clusterByClientId.get(client.id)?.id ?? client.clusterId
+          );
+
+          return {
+            clientId: client.id,
+            displayName: formatClientDisplayName(client),
+            routeLabel: formatRouteLabel(clusterId),
+            clusterId,
+          };
+        })
+        .sort(
+          (left, right) =>
+            compareRouteIds(left.clusterId, right.clusterId) ||
+            left.displayName.localeCompare(right.displayName)
+        ),
+    [allRows, clusterByClientId]
   );
 
   // Calculate deliveries + assignment details per cluster for the map summary overlay.
@@ -1363,9 +1418,7 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
     withLiveMap,
   ]);
 
-  const invalidCount = allRows.filter(
-    (client) => !isValidCoordinate(client.coordinates)
-  ).length;
+  const invalidCount = invalidDeliveries.length;
   const dayTotalDeliveries = allRows.length;
   const showFilteredEmptyState =
     visibleRows.length === 0 && dayTotalDeliveries > 0;
@@ -1375,6 +1428,17 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
       map.stop();
       map.setView(ffaCoordinates, 11, { animate: false });
     });
+  };
+
+  const handleInvalidBadgeClick = (event: React.MouseEvent<HTMLElement>) => {
+    const anchorElement = event.currentTarget;
+    setInvalidBadgeAnchorEl((currentAnchorEl) =>
+      currentAnchorEl ? null : anchorElement
+    );
+  };
+
+  const handleInvalidBadgeClose = () => {
+    setInvalidBadgeAnchorEl(null);
   };
 
   return (
@@ -1822,8 +1886,12 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
         <img src={FFAIcon} style={{ width: "100%", height: "100%" }} alt="Center On FFA" />
       </Box>
       {invalidCount > 0 && (
-        <div
-          style={{
+        <Box
+          component="button"
+          type="button"
+          aria-label="Show deliveries with invalid coordinates"
+          onClick={handleInvalidBadgeClick}
+          sx={{
             position: "absolute",
             top: showClusterSummary ? "auto" : "10px",
             bottom: showClusterSummary ? "10px" : "auto",
@@ -1835,11 +1903,71 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
             zIndex: 1000,
             color: "red",
             fontWeight: "bold",
+            border: "none",
+            cursor: "pointer",
+            font: "inherit",
+            "&:hover": {
+              opacity: 0.9,
+            },
           }}
         >
           {invalidCount} invalid coordinates
-        </div>
+        </Box>
       )}
+      <Popover
+        open={Boolean(invalidBadgeAnchorEl)}
+        anchorEl={invalidBadgeAnchorEl}
+        onClose={handleInvalidBadgeClose}
+        anchorOrigin={{
+          vertical: showClusterSummary ? "top" : "bottom",
+          horizontal: "right",
+        }}
+        transformOrigin={{
+          vertical: showClusterSummary ? "bottom" : "top",
+          horizontal: "right",
+        }}
+        PaperProps={{
+          sx: {
+            p: 1.5,
+            width: "min(280px, calc(100vw - 24px))",
+            maxWidth: "calc(100vw - 24px)",
+          },
+        }}
+      >
+        <Typography variant="body2" sx={{ fontWeight: 600, fontSize: "12px" }}>
+          Missing map locations
+        </Typography>
+        <Typography variant="caption" sx={{ color: "text.secondary", fontSize: "10px" }}>
+          These deliveries can&apos;t be shown on the map today.
+        </Typography>
+        <Box
+          component="ul"
+          sx={{
+            listStyle: "none",
+            p: 0,
+            m: 0,
+            mt: 1,
+            display: "flex",
+            flexDirection: "column",
+            gap: 0.75,
+            maxHeight: "220px",
+            overflowY: "auto",
+          }}
+        >
+          {invalidDeliveries.map(({ clientId, displayName, routeLabel }) => (
+            <Box
+              component="li"
+              key={clientId}
+              sx={{
+                fontSize: "11px",
+                lineHeight: 1.35,
+              }}
+            >
+              {displayName} • {routeLabel}
+            </Box>
+          ))}
+        </Box>
+      </Popover>
     </div>
   );
 };

--- a/my-app/src/pages/Delivery/utils/deliveryMapCounts.test.ts
+++ b/my-app/src/pages/Delivery/utils/deliveryMapCounts.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "@jest/globals";
-import { buildClusterCountSnapshot, isRenderableCoordinate } from "./deliveryMapCounts";
+import {
+  buildClusterCountSnapshot,
+  buildClusterDisplaySnapshots,
+  isRenderableCoordinate,
+} from "./deliveryMapCounts";
 
 describe("deliveryMapCounts helpers", () => {
   it("rejects zero coordinates so unrenderable clients are counted as missing", () => {
@@ -104,5 +108,56 @@ describe("deliveryMapCounts helpers", () => {
     expect(snapshot.reason).toBe("filtered-out");
     expect(snapshot.filteredOutCount).toBe(1);
     expect(snapshot.filteredOutClientIds).toEqual(["c14"]);
+  });
+
+  it("builds display snapshots with filtered and renderable counts for each route", () => {
+    const allRows = [
+      { id: "c1", coordinates: [38.9, -77.03] as [number, number] },
+      { id: "c2", coordinates: [0, 0] as [number, number] },
+      { id: "c3", coordinates: [38.92, -77.01] as [number, number] },
+    ];
+    const visibleRows = allRows.filter((row) => row.id !== "c3");
+
+    const snapshots = buildClusterDisplaySnapshots({
+      allRows,
+      visibleRows,
+      clusters: [
+        { id: "3", deliveries: ["c1", "c2", "c2"] },
+        { id: "4", deliveries: ["c3"] },
+      ],
+    });
+
+    expect(snapshots).toEqual([
+      expect.objectContaining({
+        clusterId: "3",
+        assignedCount: 2,
+        filteredCount: 2,
+        renderableCount: 1,
+        missingCoordinateCount: 1,
+        staleAssignedCount: 0,
+      }),
+      expect.objectContaining({
+        clusterId: "4",
+        assignedCount: 1,
+        filteredCount: 0,
+        renderableCount: 0,
+        filteredOutCount: 1,
+        staleAssignedCount: 0,
+      }),
+    ]);
+  });
+
+  it("tracks stale assigned client ids that are not present in the selected day rows", () => {
+    const snapshot = buildClusterCountSnapshot({
+      clusterId: "3",
+      allRows: [{ id: "c1", coordinates: [38.9, -77.03] as [number, number] }],
+      visibleRows: [{ id: "c1", coordinates: [38.9, -77.03] as [number, number] }],
+      clusters: [{ id: "3", deliveries: ["c1", "c2"] }],
+    });
+
+    expect(snapshot.assignedCount).toBe(2);
+    expect(snapshot.filteredCount).toBe(1);
+    expect(snapshot.staleAssignedCount).toBe(1);
+    expect(snapshot.staleAssignedClientIds).toEqual(["c2"]);
   });
 });

--- a/my-app/src/pages/Delivery/utils/deliveryMapCounts.ts
+++ b/my-app/src/pages/Delivery/utils/deliveryMapCounts.ts
@@ -37,6 +37,14 @@ export interface ClusterCountSnapshot {
   reason: ClusterCountReason;
 }
 
+export interface ClusterDisplaySnapshot extends ClusterCountSnapshot {
+  assignedCount: number;
+  filteredCount: number;
+  renderableCount: number;
+  staleAssignedCount: number;
+  staleAssignedClientIds: string[];
+}
+
 const normalizeClientId = (clientId: unknown): string => String(clientId ?? "").trim();
 
 export const isRenderableCoordinate = (coord: CoordinateLike): boolean => {
@@ -69,7 +77,7 @@ export const isRenderableCoordinate = (coord: CoordinateLike): boolean => {
   );
 };
 
-export const buildClusterCountSnapshot = <
+const buildClusterDisplaySnapshot = <
   TRow extends DeliveryMapCountRow,
   TCluster extends DeliveryMapCountCluster,
 >({
@@ -82,7 +90,7 @@ export const buildClusterCountSnapshot = <
   allRows: TRow[];
   visibleRows: TRow[];
   clusters: TCluster[];
-}): ClusterCountSnapshot => {
+}): ClusterDisplaySnapshot => {
   const normalizedClusterId = String(clusterId ?? "").trim();
   const cluster = clusters.find(
     (candidate) => String(candidate.id ?? "").trim() === normalizedClusterId
@@ -92,6 +100,7 @@ export const buildClusterCountSnapshot = <
     new Set((cluster?.deliveries ?? []).map((clientId) => normalizeClientId(clientId)).filter(Boolean))
   );
   const clusterClientIdSet = new Set(clusterClientIds);
+  const allClientIdSet = new Set(allRows.map((row) => normalizeClientId(row.id)).filter(Boolean));
   const visibleClientIdSet = new Set(
     visibleRows.map((row) => normalizeClientId(row.id)).filter(Boolean)
   );
@@ -110,6 +119,7 @@ export const buildClusterCountSnapshot = <
         .filter((clientId) => !visibleClientIdSet.has(clientId))
     )
   );
+  const staleAssignedClientIds = clusterClientIds.filter((clientId) => !allClientIdSet.has(clientId));
 
   const counts: Record<DominantCountSource, number> = {
     overlay: clusterClientIds.length,
@@ -135,12 +145,60 @@ export const buildClusterCountSnapshot = <
     overlayCount: clusterClientIds.length,
     spreadsheetCount: visibleClusterRows.length,
     markerCount: markerRows.length,
+    assignedCount: clusterClientIds.length,
+    filteredCount: visibleClusterRows.length,
+    renderableCount: markerRows.length,
     missingCoordinateCount: missingCoordinateRows.length,
     filteredOutCount: filteredOutClientIds.length,
     missingCoordinateClientIds: missingCoordinateRows.map((row) => normalizeClientId(row.id)),
     filteredOutClientIds,
+    staleAssignedCount: staleAssignedClientIds.length,
+    staleAssignedClientIds,
     highestCount,
     highestCountSources,
     reason,
   };
 };
+
+export const buildClusterDisplaySnapshots = <
+  TRow extends DeliveryMapCountRow,
+  TCluster extends DeliveryMapCountCluster,
+>({
+  allRows,
+  visibleRows,
+  clusters,
+}: {
+  allRows: TRow[];
+  visibleRows: TRow[];
+  clusters: TCluster[];
+}): ClusterDisplaySnapshot[] =>
+  clusters.reduce((snapshots: ClusterDisplaySnapshot[], cluster) => {
+    const clusterId = String(cluster.id ?? "").trim();
+    const deliveries = Array.isArray(cluster.deliveries) ? cluster.deliveries : [];
+
+    if (!clusterId || deliveries.length === 0) {
+      return snapshots;
+    }
+
+    snapshots.push(
+      buildClusterDisplaySnapshot({
+        clusterId,
+        allRows,
+        visibleRows,
+        clusters,
+      })
+    );
+    return snapshots;
+  }, []);
+
+export const buildClusterCountSnapshot = <
+  TRow extends DeliveryMapCountRow,
+  TCluster extends DeliveryMapCountCluster,
+>(
+  args: {
+    clusterId: string;
+    allRows: TRow[];
+    visibleRows: TRow[];
+    clusters: TCluster[];
+  }
+): ClusterDisplaySnapshot => buildClusterDisplaySnapshot(args);


### PR DESCRIPTION
## What changed
- added a shared route display snapshot helper for Delivery map/table counts
- updated the Delivery map overlay to use the filtered route count so it stays aligned with the filtered table
- kept the existing map pin behavior, driver/time labels, and invalid-coordinate badge intact
- added a small plain-English notice when saved route assignments are stale
- added focused tests for the shared helper and overlay behavior

## Why
The route cards in the map overlay were counting assigned cluster membership from the saved cluster document, while the table was showing the filtered delivery rows. That made the page feel unreliable when the two disagreed.

This change keeps the fix narrow and read-only: it consolidates the display-count logic without touching writes, search parsing, marker interactions, or cluster generation.

## Customer impact
- the filtered table and the little route box on the map now stay in sync
- when saved assignments are stale, the page gives a simple notice instead of silently showing confusing counts
- the rest of the Delivery workflow behaves the same as before

## Validation
- `npx jest src/pages/Delivery/utils/deliveryMapCounts.test.ts src/pages/Delivery/ClusterMap.test.ts src/pages/Delivery/utils/clusterSummary.test.ts --runInBand`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cluster summary overlay now displays a warning notice when saved route assignments are out of date.
  * Added "of N assigned" count indicator on cluster cards when assignments diverge from filtered deliveries.

* **Tests**
  * Enhanced test coverage for cluster summary overlay behavior, assignment staleness detection, and coordinate validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->