### PR TITLE
Fix: restore static route overview counts

### DIFF
--- a/my-app/src/pages/Delivery/ClusterMap.test.ts
+++ b/my-app/src/pages/Delivery/ClusterMap.test.ts
@@ -166,9 +166,7 @@ describe("ClusterMap popup regression guards", () => {
     expect(screen.getByText("2")).toBeTruthy();
     expect(screen.queryByText("of 2 assigned")).toBeNull();
     expect(
-      screen.getByText(
-        "Some saved route assignments are out of date. Counts below reflect today's filtered deliveries."
-      )
+      screen.getByText("Some saved route assignments are out of date.")
     ).toBeTruthy();
   });
 

--- a/my-app/src/pages/Delivery/ClusterMap.test.ts
+++ b/my-app/src/pages/Delivery/ClusterMap.test.ts
@@ -131,7 +131,7 @@ describe("ClusterMap popup regression guards", () => {
     expect(screen.getByText("3")).toBeTruthy();
   });
 
-  it("shows filtered route counts in the overlay and surfaces stale assignment notice when needed", async () => {
+  it("keeps static route totals in the overlay even when the table is filtered down", async () => {
     localStorage.setItem("clusterSummaryEnabled", "true");
 
     render(
@@ -163,13 +163,41 @@ describe("ClusterMap popup regression guards", () => {
 
     expect(await screen.findByText("Cluster Deliveries")).toBeTruthy();
     expect(screen.getByText("Day total: 1")).toBeTruthy();
-    expect(screen.getByText("of 2 assigned")).toBeTruthy();
+    expect(screen.getByText("2")).toBeTruthy();
+    expect(screen.queryByText("of 2 assigned")).toBeNull();
     expect(
       screen.getByText(
         "Some saved route assignments are out of date. Counts below reflect today's filtered deliveries."
       )
     ).toBeTruthy();
-    expect(screen.getByText("1")).toBeTruthy();
+  });
+
+  it("keeps routes visible in the overlay even when the current filter hides all of their rows", async () => {
+    localStorage.setItem("clusterSummaryEnabled", "true");
+
+    render(
+      React.createElement(ClusterMap, {
+        allRows: [
+          {
+            id: "c1",
+            firstName: "A",
+            lastName: "One",
+            address: "1 Main St",
+            coordinates: [38.9, -77.03],
+          },
+        ],
+        visibleRows: [],
+        clusters: [{ id: "3", deliveries: ["c1"], driver: "Dana", time: "09:00" }],
+        clientOverrides: [],
+        onClusterUpdate: async () => true,
+        onRenumberClusters: async () => true,
+      })
+    );
+
+    expect(await screen.findByText("Cluster Deliveries")).toBeTruthy();
+    expect(screen.getByText("No deliveries match current filter")).toBeTruthy();
+    expect(screen.getByText("3")).toBeTruthy();
+    expect(screen.getByText("Dana")).toBeTruthy();
   });
 
   it("does not show the stale assignment notice when saved routes match the loaded day rows", async () => {

--- a/my-app/src/pages/Delivery/ClusterMap.tsx
+++ b/my-app/src/pages/Delivery/ClusterMap.tsx
@@ -1620,8 +1620,7 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
                   lineHeight: 1.25,
                 }}
               >
-                Some saved route assignments are out of date. Counts below reflect today&apos;s
-                filtered deliveries.
+                Some saved route assignments are out of date.
               </Typography>
             )}
           </Box>

--- a/my-app/src/pages/Delivery/ClusterMap.tsx
+++ b/my-app/src/pages/Delivery/ClusterMap.tsx
@@ -405,10 +405,6 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
       }),
     [allRows, visibleRows, clusters]
   );
-  const clusterDisplaySnapshotById = React.useMemo(
-    () => new Map(clusterDisplaySnapshots.map((snapshot) => [snapshot.clusterId, snapshot])),
-    [clusterDisplaySnapshots]
-  );
   const hasStaleRouteAssignments = React.useMemo(
     () => clusterDisplaySnapshots.some((snapshot) => snapshot.staleAssignedCount > 0),
     [clusterDisplaySnapshots]
@@ -439,27 +435,15 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
 
   // Calculate deliveries + assignment details per cluster for the map summary overlay.
   const clusterSummaries = React.useMemo(() => {
-    const summaries = buildClusterSummariesFromClusters(
-      clusters,
-      clientOverrideByClientId,
-      formatTimeForSummary
-    );
-
-    const summariesWithDisplayCounts = summaries.map((summary) => ({
-      ...summary,
-      count: clusterDisplaySnapshotById.get(summary.clusterId)?.filteredCount ?? summary.count,
-    }));
-
     return sortClusterSummaries(
-      summariesWithDisplayCounts.filter((summary) => summary.count > 0),
+      buildClusterSummariesFromClusters(
+        clusters,
+        clientOverrideByClientId,
+        formatTimeForSummary
+      ),
       clusterSummarySortMode
     );
-  }, [
-    clusters,
-    clientOverrideByClientId,
-    clusterDisplaySnapshotById,
-    clusterSummarySortMode,
-  ]);
+  }, [clusters, clientOverrideByClientId, clusterSummarySortMode]);
 
   const usedClusterCount = React.useMemo(
     () => clusterSummaries.filter((summary) => summary.count > 0).length,
@@ -1747,17 +1731,12 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
           </Box>
           <Box sx={{ display: "flex", flexDirection: "column", gap: "6px" }}>
             {clusterSummaries.map(({ clusterId, count, driverLabel, timeLabel }) => {
-              const displaySnapshot = clusterDisplaySnapshotById.get(clusterId);
               const color = getClusterColor(clusterId);
               const textColor = getTextColorForBackground(color);
               const dividerColor =
                 textColor.toLowerCase() === "#ffffff"
                   ? "rgba(255, 255, 255, 0.38)"
                   : "rgba(0, 0, 0, 0.28)";
-              const cardDetails: string[] = [];
-              if (displaySnapshot && displaySnapshot.assignedCount > count) {
-                cardDetails.push(`of ${displaySnapshot.assignedCount} assigned`);
-              }
               return (
                 <Box
                   key={clusterId}
@@ -1840,19 +1819,6 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
                     >
                       {timeLabel}
                     </Typography>
-                    {cardDetails.length > 0 && (
-                      <Typography
-                        variant="caption"
-                        sx={{
-                          fontSize: "9px",
-                          color: textColor,
-                          opacity: 0.9,
-                          lineHeight: 1.2,
-                        }}
-                      >
-                        {cardDetails.join(" · ")}
-                      </Typography>
-                    )}
                   </Box>
                 </Box>
               );


### PR DESCRIPTION
## What changed
- restored the Delivery map overlay to its original static route-overview behavior
- kept the new stale-route-assignment notice and invalid-coordinates popover intact
- added regression coverage to ensure filters no longer change or hide route cards in the overview

## Why
The previous PR introduced a regression: the route overview overlay started using filtered counts from the current table working set. Team intent was for the overlay to remain a static overview of the day's saved route assignments, even when the table and pins are filtered.

This follow-up keeps the useful customer-facing improvements while restoring the overlay's intended semantics.

## Customer impact
- the route overview is stable again and no longer changes when the user filters
- the table and map pins still behave the same as they do today
- customers can still click the invalid-coordinates badge to see which deliveries are affected

## Validation
- `npx jest src/pages/Delivery/ClusterMap.test.ts src/pages/Delivery/utils/deliveryMapCounts.test.ts src/pages/Delivery/utils/clusterSummary.test.ts --runInBand`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Cluster overlay route counts now accurately display static totals independent of table filtering
* When active filters hide all deliveries in a cluster, users see a "No deliveries match current filter" message
* Cluster details and stale assignment information remain visible despite active filters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->