### PR TITLE
map/row highlight

### DIFF
--- a/my-app/src/components/Spreadsheet/PerformanceOptimizedSpreadsheet.tsx
+++ b/my-app/src/components/Spreadsheet/PerformanceOptimizedSpreadsheet.tsx
@@ -85,7 +85,7 @@ const SpreadsheetRow = withPerformanceOptimization(
 const SpreadsheetSearch = withPerformanceOptimization(
   ({
     onSearch,
-    placeholder = 'Search (e.g., "name: smith" "email: test")',
+    placeholder = 'Search (use ; between filters, e.g., "name: smith"; "email: test")',
     debounceMs = 300,
   }: {
     onSearch: (query: string) => void;

--- a/my-app/src/components/Spreadsheet/Spreadsheet.searchFilters.test.ts
+++ b/my-app/src/components/Spreadsheet/Spreadsheet.searchFilters.test.ts
@@ -12,6 +12,13 @@ describe("Spreadsheet search filter regression guards", () => {
     expect(source).toContain("normalizeSearchKeyword(keyword)");
   });
 
+  it("keeps client autocomplete suggestions aligned with visible header labels", () => {
+    expect(source).toContain("const tableFieldLabels = fields");
+    expect(source).toContain("const visibleCustomFieldLabels = customColumns");
+    expect(source).toContain("return Array.from(new Set([...tableFieldLabels, ...visibleCustomFieldLabels]));");
+    expect(source).toContain('"deliveryDetails.dietaryRestrictions": ["dietary restrictions", "dietary"]');
+  });
+
   it("shows multi-value examples in the Clients page search placeholder", () => {
     expect(source).toContain(
       'placeholder=\'Search clients (e.g., smith; name:john,jane; address:"main st"; gender:female,male)\''

--- a/my-app/src/components/Spreadsheet/Spreadsheet.searchFilters.test.ts
+++ b/my-app/src/components/Spreadsheet/Spreadsheet.searchFilters.test.ts
@@ -14,7 +14,7 @@ describe("Spreadsheet search filter regression guards", () => {
 
   it("shows multi-value examples in the Clients page search placeholder", () => {
     expect(source).toContain(
-      'placeholder=\'Search clients (e.g., smith, name:john,jane, address:"main st", gender:female,male)\''
+      'placeholder=\'Search clients (e.g., smith; name:john,jane; address:"main st"; gender:female,male)\''
     );
   });
 });

--- a/my-app/src/components/Spreadsheet/Spreadsheet.tsx
+++ b/my-app/src/components/Spreadsheet/Spreadsheet.tsx
@@ -102,6 +102,32 @@ const addablePropertyKeyLabelMap: Record<string, string> = {
   lastDeliveryDate: "Last Delivery Date",
 };
 
+const clientFieldMappings: Record<string, string[]> = {
+  fullname: ["name", "first name", "firstname", "last name", "lastname"],
+  address: ["address"],
+  phone: ["phone"],
+  email: ["email"],
+  "deliveryDetails.dietaryRestrictions": ["dietary restrictions", "dietary"],
+  "deliveryDetails.deliveryInstructions": ["delivery instructions", "instructions"],
+};
+
+const clientCustomColumnMappings: Record<string, string[]> = {
+  adults: ["adults"],
+  children: ["children"],
+  famStartDate: ["family start date"],
+  deliveryFreq: ["delivery freq", "delivery frequency"],
+  "deliveryDetails.dietaryRestrictions.dietaryPreferences": ["dietary preferences"],
+  ethnicity: ["ethnicity"],
+  gender: ["gender"],
+  language: ["language"],
+  notes: ["notes"],
+  referralEntity: ["referral entity", "referral"],
+  tags: ["tags", "tag"],
+  tefapCert: ["tefap", "tefap cert"],
+  dob: ["dob"],
+  lastDeliveryDate: ["last delivery date"],
+};
+
 const StyleChip = styled(Chip)(({ theme }) => ({
   fontWeight: 500,
   fontSize: "0.85rem",
@@ -649,13 +675,14 @@ const Spreadsheet: React.FC = () => {
       .filter((label) => Boolean(label))
       .map((label) => label.toLowerCase());
 
-    const addableFieldLabels = allowedPropertyKeys
+    const visibleCustomFieldLabels = customColumns
+      .map((column) => column.propertyKey)
       .filter((propertyKey) => propertyKey !== "none")
       .map((propertyKey) => addablePropertyKeyLabelMap[propertyKey] ?? propertyKey)
       .map((label) => label.toLowerCase());
 
-    return Array.from(new Set([...tableFieldLabels, ...addableFieldLabels]));
-  }, [fields]);
+    return Array.from(new Set([...tableFieldLabels, ...visibleCustomFieldLabels]));
+  }, [fields, customColumns]);
 
   const searchAutocomplete = useSearchKeyAutocomplete({
     value: searchQuery,
@@ -700,16 +727,7 @@ const Spreadsheet: React.FC = () => {
         const isVisibleField = (keyword: string): boolean => {
           const normalizedKeyword = normalizeSearchKeyword(keyword);
 
-          const fieldMappings: { [key: string]: string[] } = {
-            fullname: ["name", "first name", "firstname", "last name", "lastname"],
-            address: ["address"],
-            phone: ["phone"],
-            email: ["email"],
-            "deliveryDetails.dietaryRestrictions": ["dietary restrictions", "dietary"],
-            "deliveryDetails.deliveryInstructions": ["delivery instructions", "instructions"],
-          };
-
-          for (const [fieldKey, aliases] of Object.entries(fieldMappings)) {
+          for (const [fieldKey, aliases] of Object.entries(clientFieldMappings)) {
             if (
               visibleFieldKeys.has(fieldKey) &&
               aliases.some((alias) => normalizeSearchKeyword(alias) === normalizedKeyword)
@@ -718,22 +736,7 @@ const Spreadsheet: React.FC = () => {
             }
           }
 
-          const customColumnMappings: { [key: string]: string[] } = {
-            adults: ["adults"],
-            children: ["children"],
-            deliveryFreq: ["delivery freq", "delivery frequency"],
-            ethnicity: ["ethnicity"],
-            gender: ["gender"],
-            language: ["language"],
-            notes: ["notes"],
-            referralEntity: ["referral entity", "referral"],
-            tags: ["tags", "tag"],
-            tefapCert: ["tefap", "tefap cert"],
-            dob: ["dob"],
-            lastDeliveryDate: ["last delivery date"],
-          };
-
-          for (const [propertyKey, aliases] of Object.entries(customColumnMappings)) {
+          for (const [propertyKey, aliases] of Object.entries(clientCustomColumnMappings)) {
             if (
               visibleFieldKeys.has(propertyKey) &&
               aliases.some((alias) => normalizeSearchKeyword(alias) === normalizedKeyword)

--- a/my-app/src/components/Spreadsheet/Spreadsheet.tsx
+++ b/my-app/src/components/Spreadsheet/Spreadsheet.tsx
@@ -8,6 +8,7 @@ import {
   checkStringEquals,
   extractKeyValue,
   globalSearchMatch,
+  isNoneSearchToken,
   normalizeSearchKeyword,
   splitFilterValues,
 } from "../../utils/searchFilter";
@@ -69,6 +70,7 @@ import MoreVertIcon from "@mui/icons-material/MoreVert";
 import { styled } from "@mui/material/styles";
 import { useNavigate } from "react-router-dom";
 import { DateTime } from "luxon";
+import { useSearchKeyAutocomplete } from "../../hooks/useSearchKeyAutocomplete";
 
 import { exportQueryResults, exportAllClients } from "./export";
 const DeleteClientModal = React.lazy(() => import("./DeleteClientModal"));
@@ -79,6 +81,26 @@ import { useNotifications } from "../NotificationProvider";
 import { CsvExportError } from "../../utils/csvExport";
 import { getClientStatusPresentation } from "../../utils/clientStatus";
 import type { ClientDeliverySummary } from "../../utils/lastDeliveryDate";
+
+const addablePropertyKeyLabelMap: Record<string, string> = {
+  address: "Address",
+  adults: "Adults",
+  children: "Children",
+  famStartDate: "Family Start Date",
+  deliveryFreq: "Delivery Frequency",
+  "deliveryDetails.dietaryRestrictions": "Dietary Restrictions",
+  "deliveryDetails.dietaryRestrictions.dietaryPreferences": "Dietary Preferences",
+  ethnicity: "Ethnicity",
+  gender: "Gender",
+  language: "Language",
+  notes: "Notes",
+  phone: "Phone",
+  referralEntity: "Referral Entity",
+  tags: "Tags",
+  tefapCert: "TEFAP Cert",
+  dob: "DOB",
+  lastDeliveryDate: "Last Delivery Date",
+};
 
 const StyleChip = styled(Chip)(({ theme }) => ({
   fontWeight: 500,
@@ -363,32 +385,6 @@ const Spreadsheet: React.FC = () => {
   const { showError, showSuccess, showWarning } = useNotifications();
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [debouncedSearch, setDebouncedSearch] = useState<string>("");
-  const clientSearchKeySuggestions = useMemo(
-    () =>
-      [
-        "name",
-        "first name",
-        "last name",
-        "address",
-        "phone",
-        "email",
-        "dietary restrictions",
-        "delivery instructions",
-        "adults",
-        "children",
-        "delivery frequency",
-        "ethnicity",
-        "gender",
-        "language",
-        "notes",
-        "referral entity",
-        "tags",
-        "tefap cert",
-        "dob",
-        "last delivery date",
-      ].map((key) => `${key}:`),
-    []
-  );
   const [menuAnchorPosition, setMenuAnchorPosition] = useState<{
     top: number;
     left: number;
@@ -647,6 +643,26 @@ const Spreadsheet: React.FC = () => {
     []
   );
 
+  const clientSearchKeySuggestions = useMemo(() => {
+    const tableFieldLabels = fields
+      .map((field) => field.label)
+      .filter((label) => Boolean(label))
+      .map((label) => label.toLowerCase());
+
+    const addableFieldLabels = allowedPropertyKeys
+      .filter((propertyKey) => propertyKey !== "none")
+      .map((propertyKey) => addablePropertyKeyLabelMap[propertyKey] ?? propertyKey)
+      .map((label) => label.toLowerCase());
+
+    return Array.from(new Set([...tableFieldLabels, ...addableFieldLabels]));
+  }, [fields]);
+
+  const searchAutocomplete = useSearchKeyAutocomplete({
+    value: searchQuery,
+    onValueChange: setSearchQuery,
+    suggestions: clientSearchKeySuggestions,
+  });
+
   // --- Sorting and filtering logic (with sorting) ---
   // Ensure filteredRows is always the correct RowData shape for export, and optimize with useMemo
   const filteredRows: RowData[] = useMemo(() => {
@@ -668,11 +684,11 @@ const Spreadsheet: React.FC = () => {
           query: string,
           exactMatch = false
         ): boolean => {
-          if (value === undefined || value === null) {
-            return false;
-          }
-
           if (Array.isArray(value)) {
+            if (value.length === 0 && isNoneSearchToken(query)) {
+              return true;
+            }
+
             return value.some((item) =>
               exactMatch ? checkStringEquals(item, query) : checkStringContains(item, query)
             );
@@ -774,7 +790,9 @@ const Spreadsheet: React.FC = () => {
                 case "dietaryrestrictions":
                 case "dietary": {
                   const dr = row.deliveryDetails?.dietaryRestrictions;
-                  if (!dr) return false;
+                  if (!dr) {
+                    return matchesAnySearchValue((candidate) => isNoneSearchToken(candidate));
+                  }
                   const dietaryTerms = [
                     dr.halal ? "halal" : "",
                     dr.kidneyFriendly ? "kidney friendly" : "",
@@ -839,7 +857,7 @@ const Spreadsheet: React.FC = () => {
                         checkStringContains(referralEntity.organization, candidate)
                     );
                   }
-                  return false;
+                  return matchesAnySearchValue((candidate) => isNoneSearchToken(candidate));
                 }
                 case "tags":
                 case "tag":
@@ -869,7 +887,9 @@ const Spreadsheet: React.FC = () => {
                         let value: unknown = row;
                         for (const k of keys) {
                           value = value && (value as Record<string, unknown>)[k];
-                          if (value === undefined) return false;
+                          if (value === undefined) {
+                            return matchesAnySearchValue((candidate) => isNoneSearchToken(candidate));
+                          }
                         }
                         return matchesAnySearchValue((candidate) =>
                           checkValueOrInArray(value, candidate)
@@ -1013,11 +1033,16 @@ const Spreadsheet: React.FC = () => {
         <Stack spacing={3}>
           <Box sx={{ position: "relative", width: "100%" }}>
             <input
+              ref={searchAutocomplete.inputRef}
               type="text"
               value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              list="client-search-key-suggestions"
-              placeholder='Search clients (e.g., smith, name:john,jane, address:"main st", gender:female,male)'
+              onChange={searchAutocomplete.handleInputChange}
+              onFocus={searchAutocomplete.handleInputFocus}
+              onClick={searchAutocomplete.handleInputClick}
+              onBlur={searchAutocomplete.handleInputBlur}
+              onKeyDown={searchAutocomplete.handleInputKeyDown}
+              onKeyUp={searchAutocomplete.handleInputKeyUp}
+              placeholder='Search clients (e.g., smith; name:john,jane; address:"main st"; gender:female,male)'
               style={{
                 width: "100%",
                 height: "50px",
@@ -1032,11 +1057,6 @@ const Spreadsheet: React.FC = () => {
                 boxShadow: "inset 0 2px 3px rgba(0,0,0,0.05)",
               }}
             />
-            <datalist id="client-search-key-suggestions">
-              {clientSearchKeySuggestions.map((suggestion) => (
-                <option key={suggestion} value={suggestion} />
-              ))}
-            </datalist>
           </Box>
           <Stack
             direction={{ xs: "column", sm: "row" }}

--- a/my-app/src/components/Spreadsheet/Spreadsheet.tsx
+++ b/my-app/src/components/Spreadsheet/Spreadsheet.tsx
@@ -1057,6 +1057,44 @@ const Spreadsheet: React.FC = () => {
                 boxShadow: "inset 0 2px 3px rgba(0,0,0,0.05)",
               }}
             />
+            {searchQuery.trim() !== "" && (
+              <button
+                type="button"
+                aria-label="Clear client search"
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                }}
+                onClick={() => {
+                  setSearchQuery("");
+                  requestAnimationFrame(() => {
+                    const input = searchAutocomplete.inputRef.current;
+                    if (!input) return;
+                    input.focus();
+                    input.setSelectionRange(0, 0);
+                  });
+                }}
+                style={{
+                  position: "absolute",
+                  right: "12px",
+                  top: "50%",
+                  transform: "translateY(-50%)",
+                  width: "28px",
+                  height: "28px",
+                  borderRadius: "50%",
+                  border: "none",
+                  backgroundColor: "var(--color-border-light)",
+                  color: "var(--color-text-dark)",
+                  cursor: "pointer",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontSize: "16px",
+                  lineHeight: 1,
+                }}
+              >
+                x
+              </button>
+            )}
           </Box>
           <Stack
             direction={{ xs: "column", sm: "row" }}

--- a/my-app/src/components/Spreadsheet/Spreadsheet.tsx
+++ b/my-app/src/components/Spreadsheet/Spreadsheet.tsx
@@ -64,6 +64,7 @@ import AddIcon from "@mui/icons-material/Add";
 import DeleteIcon from "@mui/icons-material/Delete";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CancelIcon from "@mui/icons-material/Cancel";
+import ClearIcon from "@mui/icons-material/Clear";
 import { Select, MenuItem } from "@mui/material";
 import EditIcon from "@mui/icons-material/Edit";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
@@ -1095,7 +1096,7 @@ const Spreadsheet: React.FC = () => {
                   lineHeight: 1,
                 }}
               >
-                x
+                <ClearIcon fontSize="small" />
               </button>
             )}
           </Box>

--- a/my-app/src/components/Spreadsheet/Spreadsheet.tsx
+++ b/my-app/src/components/Spreadsheet/Spreadsheet.tsx
@@ -363,6 +363,32 @@ const Spreadsheet: React.FC = () => {
   const { showError, showSuccess, showWarning } = useNotifications();
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [debouncedSearch, setDebouncedSearch] = useState<string>("");
+  const clientSearchKeySuggestions = useMemo(
+    () =>
+      [
+        "name",
+        "first name",
+        "last name",
+        "address",
+        "phone",
+        "email",
+        "dietary restrictions",
+        "delivery instructions",
+        "adults",
+        "children",
+        "delivery frequency",
+        "ethnicity",
+        "gender",
+        "language",
+        "notes",
+        "referral entity",
+        "tags",
+        "tefap cert",
+        "dob",
+        "last delivery date",
+      ].map((key) => `${key}:`),
+    []
+  );
   const [menuAnchorPosition, setMenuAnchorPosition] = useState<{
     top: number;
     left: number;
@@ -990,6 +1016,7 @@ const Spreadsheet: React.FC = () => {
               type="text"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
+              list="client-search-key-suggestions"
               placeholder='Search clients (e.g., smith, name:john,jane, address:"main st", gender:female,male)'
               style={{
                 width: "100%",
@@ -1005,6 +1032,11 @@ const Spreadsheet: React.FC = () => {
                 boxShadow: "inset 0 2px 3px rgba(0,0,0,0.05)",
               }}
             />
+            <datalist id="client-search-key-suggestions">
+              {clientSearchKeySuggestions.map((suggestion) => (
+                <option key={suggestion} value={suggestion} />
+              ))}
+            </datalist>
           </Box>
           <Stack
             direction={{ xs: "column", sm: "row" }}

--- a/my-app/src/components/Spreadsheet/Spreadsheet.tsx
+++ b/my-app/src/components/Spreadsheet/Spreadsheet.tsx
@@ -12,6 +12,7 @@ import {
   normalizeSearchKeyword,
   splitFilterValues,
 } from "../../utils/searchFilter";
+import { deliveryDate } from "../../utils/deliveryDate";
 // Custom chevron icons for TableSortLabel with spacing
 const iconStyle = { verticalAlign: "middle", marginLeft: 6 };
 const ChevronUp = () => (
@@ -87,7 +88,7 @@ const addablePropertyKeyLabelMap: Record<string, string> = {
   address: "Address",
   adults: "Adults",
   children: "Children",
-  famStartDate: "Family Start Date",
+  famStartDate: "Fam Start Date",
   deliveryFreq: "Delivery Frequency",
   "deliveryDetails.dietaryRestrictions": "Dietary Restrictions",
   "deliveryDetails.dietaryRestrictions.dietaryPreferences": "Dietary Preferences",
@@ -115,7 +116,7 @@ const clientFieldMappings: Record<string, string[]> = {
 const clientCustomColumnMappings: Record<string, string[]> = {
   adults: ["adults"],
   children: ["children"],
-  famStartDate: ["family start date"],
+  famStartDate: ["fam start date", "family start date"],
   deliveryFreq: ["delivery freq", "delivery frequency"],
   "deliveryDetails.dietaryRestrictions.dietaryPreferences": ["dietary preferences"],
   ethnicity: ["ethnicity"],
@@ -871,6 +872,22 @@ const Spreadsheet: React.FC = () => {
                   return matchesAnySearchValue((candidate) =>
                     checkStringContains(row.tefapCert, candidate)
                   );
+                case "date":
+                case "famstartdate":
+                  return matchesAnySearchValue((candidate) => {
+                    const normalizedCandidateDate = deliveryDate.tryToDateTime(candidate);
+                    const normalizedRowDate = deliveryDate.tryToDateTime(row.famStartDate);
+
+                    if (!normalizedCandidateDate || !normalizedRowDate) {
+                      return false;
+                    }
+
+                    const candidateDisplay = deliveryDate.toDisplayString(normalizedCandidateDate);
+                    const rowDisplay = deliveryDate.toDisplayString(normalizedRowDate);
+                    const matches = checkStringEquals(rowDisplay, candidateDisplay);
+
+                    return matches;
+                  });
                 case "dob":
                   return matchesAnySearchValue((candidate) =>
                     checkValueOrInArray(row.dob, candidate, true)
@@ -1482,7 +1499,7 @@ const Spreadsheet: React.FC = () => {
                               let label = key.charAt(0).toUpperCase() + key.slice(1);
                               if (key === "deliveryDetails.dietaryRestrictions.dietaryPreferences")
                                 label = "Dietary Preferences";
-                              if (key === "famStartDate") label = "FAM Start Date";
+                              if (key === "famStartDate") label = "Fam Start Date";
                               return (
                                 <MenuItem key={key} value={key}>
                                   {key === "none" ? "None" : label}

--- a/my-app/src/components/Spreadsheet/export.tsx
+++ b/my-app/src/components/Spreadsheet/export.tsx
@@ -97,7 +97,7 @@ const getSpreadsheetExportColumnHeader = (propertyKey: string): string => {
     case "tefapCert":
       return "TEFAP Cert";
     case "famStartDate":
-      return "FAM Start Date";
+      return "Fam Start Date";
     case "tags":
       return "Tags";
     case "dob":

--- a/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.autocomplete.test.tsx
+++ b/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.autocomplete.test.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { createEvent, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, jest, beforeEach, afterEach } from "@jest/globals";
+import UsersSpreadsheet from "./UsersSpreadsheet";
+
+jest.mock("firebase/auth", () => ({
+  onAuthStateChanged: (_auth: unknown, callback: (user: { uid: string }) => void) => {
+    callback({ uid: "user-1" });
+    return () => undefined;
+  },
+}));
+
+jest.mock("../../auth/firebaseConfig", () => ({
+  auth: {},
+}));
+
+jest.mock("../../services/AuthUserService", () => ({
+  authUserService: {
+    getAllUsers: async () => [],
+    deleteUser: async () => undefined,
+  },
+}));
+
+jest.mock("../../auth/AuthProvider", () => ({
+  useAuth: () => ({ userRole: "Admin" }),
+}));
+
+jest.mock("react-router-dom", () => ({
+  useNavigate: () => () => undefined,
+}));
+
+jest.mock("./DeleteUserModal", () => () => null);
+jest.mock("./CreateUserModal", () => () => null);
+
+describe("UsersSpreadsheet autocomplete", () => {
+  beforeEach(() => {
+    jest
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        callback(0);
+        return 0;
+      });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("prevents tabbing out and commits autocomplete in the users search input", async () => {
+    render(<UsersSpreadsheet />);
+
+    const input = await screen.findByPlaceholderText(
+      "Search users (use ; between filters, e.g., role:admin,manager; name:jane,john; email:test@example.com)"
+    );
+
+    fireEvent.focus(input);
+    fireEvent.change(input, {
+      target: { value: "ro", selectionStart: 2, selectionEnd: 2 },
+    });
+
+    expect((input as HTMLInputElement).value).toBe("role");
+
+    const tabEvent = createEvent.keyDown(input, { key: "Tab" });
+    fireEvent(input, tabEvent);
+
+    await waitFor(() => {
+      expect((input as HTMLInputElement).value).toBe("role:");
+    });
+
+    expect(tabEvent.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(input);
+  });
+});

--- a/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.searchFilters.test.ts
+++ b/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.searchFilters.test.ts
@@ -12,6 +12,6 @@ describe("UsersSpreadsheet search filter regression guards", () => {
   });
 
   it("shows multi-value examples in the Clients page search placeholder", () => {
-    expect(source).toContain('placeholder="Search users (e.g., role:admin,manager, name:jane,john, email:test@example.com)"');
+    expect(source).toContain('placeholder="Search users (use ; between filters, e.g., role:admin,manager; name:jane,john; email:test@example.com)"');
   });
 });

--- a/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.searchFilters.test.ts
+++ b/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.searchFilters.test.ts
@@ -11,6 +11,12 @@ describe("UsersSpreadsheet search filter regression guards", () => {
     expect(source).toContain("matchesAnySearchValue");
   });
 
+  it("derives user autocomplete suggestions from the visible headers", () => {
+    expect(source).toContain("userFieldMappings");
+    expect(source).toContain("field.label");
+    expect(source).toContain("...Object.values(userFieldMappings).flat()");
+  });
+
   it("shows multi-value examples in the Clients page search placeholder", () => {
     expect(source).toContain('placeholder="Search users (use ; between filters, e.g., role:admin,manager; name:jane,john; email:test@example.com)"');
   });

--- a/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.tsx
+++ b/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.tsx
@@ -54,6 +54,13 @@ type Field = {
   compute?: (data: AuthUserRow) => string;
 };
 
+const userFieldMappings: Record<string, string[]> = {
+  name: ["name"],
+  role: ["role"],
+  phone: ["phone"],
+  email: ["email"],
+};
+
 const getRoleDisplayName = (role: UserType): string => {
   switch (role) {
     case UserType.Admin:
@@ -90,8 +97,6 @@ const UsersSpreadsheet: React.FC<UsersSpreadsheetProps> = ({ onAuthStateChangedO
   const [phoneSortDirection, setPhoneSortDirection] = useState<SortDirection | null>(null);
   const [emailSortDirection, setEmailSortDirection] = useState<SortDirection | null>(null);
 
-  const userSearchKeySuggestions = useMemo(() => ["name", "role", "phone", "email"], []);
-
   const { userRole } = useAuth();
   const navigate = useNavigate();
 
@@ -120,6 +125,20 @@ const UsersSpreadsheet: React.FC<UsersSpreadsheetProps> = ({ onAuthStateChangedO
     { key: "phone", label: "Phone", type: "text" },
     { key: "email", label: "Email", type: "text" },
   ];
+
+  const userSearchKeySuggestions = useMemo(
+    () =>
+      Array.from(
+        new Set([
+          ...fields
+            .map((field) => field.label)
+            .filter((label) => Boolean(label))
+            .map((label) => label.toLowerCase()),
+          ...Object.values(userFieldMappings).flat(),
+        ])
+      ),
+    [fields]
+  );
 
   const fetchData = useCallback(async () => {
     setIsLoading(true);
@@ -281,14 +300,7 @@ const UsersSpreadsheet: React.FC<UsersSpreadsheetProps> = ({ onAuthStateChangedO
       const isVisibleField = (keyword: string): boolean => {
         const normalizedKeyword = normalizeSearchKeyword(keyword);
 
-        const fieldMappings: { [key: string]: string[] } = {
-          name: ["name"],
-          role: ["role"],
-          phone: ["phone"],
-          email: ["email"],
-        };
-
-        for (const [fieldKey, aliases] of Object.entries(fieldMappings)) {
+        for (const [fieldKey, aliases] of Object.entries(userFieldMappings)) {
           if (
             visibleFieldKeys.has(fieldKey as keyof AuthUserRow) &&
             aliases.some((alias) => normalizeSearchKeyword(alias) === normalizedKeyword)

--- a/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.tsx
+++ b/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.tsx
@@ -1,4 +1,5 @@
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import ClearIcon from "@mui/icons-material/Clear";
 import ArrowDropUpIcon from "@mui/icons-material/ArrowDropUp";
 import DeleteIcon from "@mui/icons-material/Delete";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
@@ -489,7 +490,7 @@ const UsersSpreadsheet: React.FC<UsersSpreadsheetProps> = ({ onAuthStateChangedO
                     lineHeight: 1,
                   }}
                 >
-                  x
+                  <ClearIcon fontSize="small" />
                 </button>
               )}
             </Box>

--- a/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.tsx
+++ b/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.tsx
@@ -89,6 +89,11 @@ const UsersSpreadsheet: React.FC<UsersSpreadsheetProps> = ({ onAuthStateChangedO
   const [phoneSortDirection, setPhoneSortDirection] = useState<SortDirection | null>(null);
   const [emailSortDirection, setEmailSortDirection] = useState<SortDirection | null>(null);
 
+  const userSearchKeySuggestions = useMemo(
+    () => ["name", "role", "phone", "email"].map((key) => `${key}:`),
+    []
+  );
+
   const { userRole } = useAuth();
   const navigate = useNavigate();
 
@@ -413,6 +418,7 @@ const UsersSpreadsheet: React.FC<UsersSpreadsheetProps> = ({ onAuthStateChangedO
                 type="text"
                 value={searchQuery}
                 onChange={handleSearchChange}
+                list="users-search-key-suggestions"
                 placeholder="Search users (e.g., role:admin,manager, name:jane,john, email:test@example.com)"
                 style={{
                   width: "100%",
@@ -428,6 +434,11 @@ const UsersSpreadsheet: React.FC<UsersSpreadsheetProps> = ({ onAuthStateChangedO
                   boxShadow: "inset 0 2px 3px rgba(0,0,0,0.05)",
                 }}
               />
+              <datalist id="users-search-key-suggestions">
+                {userSearchKeySuggestions.map((suggestion) => (
+                  <option key={suggestion} value={suggestion} />
+                ))}
+              </datalist>
             </Box>
             <Stack
               direction={{ xs: "column", sm: "row" }}

--- a/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.tsx
+++ b/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.tsx
@@ -431,7 +431,7 @@ const UsersSpreadsheet: React.FC<UsersSpreadsheetProps> = ({ onAuthStateChangedO
                   backgroundColor: "var(--color-background-gray)",
                   border: "none",
                   borderRadius: "25px",
-                  padding: "0 20px",
+                  padding: "0 56px 0 20px",
                   fontSize: "16px",
                   color: "var(--color-text-dark)",
                   boxSizing: "border-box",
@@ -439,6 +439,44 @@ const UsersSpreadsheet: React.FC<UsersSpreadsheetProps> = ({ onAuthStateChangedO
                   boxShadow: "inset 0 2px 3px rgba(0,0,0,0.05)",
                 }}
               />
+              {searchQuery.trim() !== "" && (
+                <button
+                  type="button"
+                  aria-label="Clear user search"
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                  }}
+                  onClick={() => {
+                    setSearchQuery("");
+                    requestAnimationFrame(() => {
+                      const input = searchAutocomplete.inputRef.current;
+                      if (!input) return;
+                      input.focus();
+                      input.setSelectionRange(0, 0);
+                    });
+                  }}
+                  style={{
+                    position: "absolute",
+                    right: "12px",
+                    top: "50%",
+                    transform: "translateY(-50%)",
+                    width: "28px",
+                    height: "28px",
+                    borderRadius: "50%",
+                    border: "none",
+                    backgroundColor: "var(--color-border-light)",
+                    color: "var(--color-text-dark)",
+                    cursor: "pointer",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    fontSize: "16px",
+                    lineHeight: 1,
+                  }}
+                >
+                  x
+                </button>
+              )}
             </Box>
             <Stack
               direction={{ xs: "column", sm: "row" }}

--- a/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.tsx
+++ b/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.tsx
@@ -110,21 +110,24 @@ const UsersSpreadsheet: React.FC<UsersSpreadsheetProps> = ({ onAuthStateChangedO
     return () => unsubscribe();
   }, [navigate, onAuthStateChangedOverride]);
 
-  const fields: Field[] = [
-    {
-      key: "name",
-      label: "Name",
-      type: "text",
-    },
-    {
-      key: "role",
-      label: "Role",
-      type: "text",
-      compute: (data: AuthUserRow) => getRoleDisplayName(data.role),
-    },
-    { key: "phone", label: "Phone", type: "text" },
-    { key: "email", label: "Email", type: "text" },
-  ];
+  const fields: Field[] = useMemo(
+    () => [
+      {
+        key: "name" as const,
+        label: "Name",
+        type: "text",
+      },
+      {
+        key: "role" as const,
+        label: "Role",
+        type: "text",
+        compute: (data: AuthUserRow) => getRoleDisplayName(data.role),
+      },
+      { key: "phone" as const, label: "Phone", type: "text" },
+      { key: "email" as const, label: "Email", type: "text" },
+    ],
+    []
+  );
 
   const userSearchKeySuggestions = useMemo(
     () =>

--- a/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.tsx
+++ b/my-app/src/components/UsersSpreadsheet/UsersSpreadsheet.tsx
@@ -37,6 +37,7 @@ import {
   splitFilterValues,
 } from "../../utils/searchFilter";
 import { useNavigate } from "react-router-dom";
+import { useSearchKeyAutocomplete } from "../../hooks/useSearchKeyAutocomplete";
 import { auth } from "../../auth/firebaseConfig";
 import { authUserService } from "../../services/AuthUserService";
 import { sortData, SortDirection } from "../../utils/sorting";
@@ -89,10 +90,7 @@ const UsersSpreadsheet: React.FC<UsersSpreadsheetProps> = ({ onAuthStateChangedO
   const [phoneSortDirection, setPhoneSortDirection] = useState<SortDirection | null>(null);
   const [emailSortDirection, setEmailSortDirection] = useState<SortDirection | null>(null);
 
-  const userSearchKeySuggestions = useMemo(
-    () => ["name", "role", "phone", "email"].map((key) => `${key}:`),
-    []
-  );
+  const userSearchKeySuggestions = useMemo(() => ["name", "role", "phone", "email"], []);
 
   const { userRole } = useAuth();
   const navigate = useNavigate();
@@ -215,9 +213,11 @@ const UsersSpreadsheet: React.FC<UsersSpreadsheetProps> = ({ onAuthStateChangedO
     }
   }, [rows, nameSortDirection, roleSortDirection, phoneSortDirection, emailSortDirection]);
 
-  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchQuery(event.target.value);
-  };
+  const searchAutocomplete = useSearchKeyAutocomplete({
+    value: searchQuery,
+    onValueChange: setSearchQuery,
+    suggestions: userSearchKeySuggestions,
+  });
 
   const handleDeleteUser = async (uid: string) => {
     const originalRows = [...rows];
@@ -415,11 +415,16 @@ const UsersSpreadsheet: React.FC<UsersSpreadsheetProps> = ({ onAuthStateChangedO
           <Stack spacing={3}>
             <Box sx={{ position: "relative", width: "100%" }}>
               <input
+                ref={searchAutocomplete.inputRef}
                 type="text"
                 value={searchQuery}
-                onChange={handleSearchChange}
-                list="users-search-key-suggestions"
-                placeholder="Search users (e.g., role:admin,manager, name:jane,john, email:test@example.com)"
+                onChange={searchAutocomplete.handleInputChange}
+                onFocus={searchAutocomplete.handleInputFocus}
+                onClick={searchAutocomplete.handleInputClick}
+                onBlur={searchAutocomplete.handleInputBlur}
+                onKeyDown={searchAutocomplete.handleInputKeyDown}
+                onKeyUp={searchAutocomplete.handleInputKeyUp}
+                placeholder="Search users (use ; between filters, e.g., role:admin,manager; name:jane,john; email:test@example.com)"
                 style={{
                   width: "100%",
                   height: "50px",
@@ -434,11 +439,6 @@ const UsersSpreadsheet: React.FC<UsersSpreadsheetProps> = ({ onAuthStateChangedO
                   boxShadow: "inset 0 2px 3px rgba(0,0,0,0.05)",
                 }}
               />
-              <datalist id="users-search-key-suggestions">
-                {userSearchKeySuggestions.map((suggestion) => (
-                  <option key={suggestion} value={suggestion} />
-                ))}
-              </datalist>
             </Box>
             <Stack
               direction={{ xs: "column", sm: "row" }}

--- a/my-app/src/hooks/useSavedSearches.ts
+++ b/my-app/src/hooks/useSavedSearches.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  getSavedSearches,
+  saveSearch,
+  replaceByName,
+  deleteSearch,
+  SavedSearchItem,
+} from "../pages/Delivery/utils/savedSearches";
+
+export const useSavedSearches = (userId?: string | null) => {
+  const [savedSearches, setSavedSearches] = useState<SavedSearchItem[]>(() => getSavedSearches(userId));
+
+  useEffect(() => {
+    setSavedSearches(getSavedSearches(userId));
+  }, [userId]);
+
+  const saveCurrentSearch = useCallback(
+    (query: string, name?: string) => {
+      const next = saveSearch(userId, query, name);
+      setSavedSearches(next);
+      return next;
+    },
+    [userId]
+  );
+
+  const applySavedSearch = useCallback(
+    (query: string, onApply: (value: string) => void, name?: string) => {
+      const trimmedQuery = query.trim();
+      if (!trimmedQuery) {
+        return;
+      }
+
+      const next = saveSearch(userId, trimmedQuery, name);
+      setSavedSearches(next);
+      onApply(trimmedQuery);
+    },
+    [userId]
+  );
+
+  const overwriteSavedSearch = useCallback(
+    (name: string, newQuery: string) => {
+      const next = replaceByName(userId, name, newQuery);
+      setSavedSearches(next);
+      return next;
+    },
+    [userId]
+  );
+
+  const deleteSavedSearch = useCallback(
+    (query: string) => {
+      const next = deleteSearch(userId, query);
+      setSavedSearches(next);
+      return next;
+    },
+    [userId]
+  );
+
+  return {
+    savedSearches,
+    saveCurrentSearch,
+    applySavedSearch,
+    overwriteSavedSearch,
+    deleteSavedSearch,
+  };
+};

--- a/my-app/src/hooks/useSearchKeyAutocomplete.test.tsx
+++ b/my-app/src/hooks/useSearchKeyAutocomplete.test.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { useSearchKeyAutocomplete } from "./useSearchKeyAutocomplete";
+
+const suggestions = ["cluster id", "ward", "name"];
+
+const Harness = () => {
+  const [value, setValue] = React.useState("");
+  const autocomplete = useSearchKeyAutocomplete({
+    value,
+    onValueChange: setValue,
+    suggestions,
+  });
+
+  return (
+    <input
+      aria-label="search"
+      ref={autocomplete.inputRef}
+      value={value}
+      onChange={autocomplete.handleInputChange}
+      onFocus={autocomplete.handleInputFocus}
+      onClick={autocomplete.handleInputClick}
+      onBlur={autocomplete.handleInputBlur}
+      onKeyDown={autocomplete.handleInputKeyDown}
+      onKeyUp={autocomplete.handleInputKeyUp}
+    />
+  );
+};
+
+describe("useSearchKeyAutocomplete", () => {
+  beforeEach(() => {
+    jest
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback: FrameRequestCallback): number => {
+        callback(0);
+        return 0;
+      });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("commits inline completion with Tab and appends colon without duplicating suffix", () => {
+    render(<Harness />);
+    const input = screen.getByRole("textbox", { name: "search" }) as HTMLInputElement;
+
+    input.focus();
+    fireEvent.focus(input);
+    fireEvent.change(input, {
+      target: { value: "clu", selectionStart: 3, selectionEnd: 3 },
+    });
+
+    expect(input.value).toBe("cluster id");
+
+    fireEvent.keyDown(input, { key: "Tab" });
+
+    expect(input.value).toBe("cluster id:");
+    expect(input.selectionStart).toBe("cluster id:".length);
+    expect(input.selectionEnd).toBe("cluster id:".length);
+  });
+
+  it("commits inline completion with Enter and appends colon", () => {
+    render(<Harness />);
+    const input = screen.getByRole("textbox", { name: "search" }) as HTMLInputElement;
+
+    input.focus();
+    fireEvent.focus(input);
+    fireEvent.change(input, {
+      target: { value: "clu", selectionStart: 3, selectionEnd: 3 },
+    });
+
+    expect(input.value).toBe("cluster id");
+
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(input.value).toBe("cluster id:");
+    expect(input.selectionStart).toBe("cluster id:".length);
+    expect(input.selectionEnd).toBe("cluster id:".length);
+  });
+
+  it("lets users backspace without being forced back into autosuggest", () => {
+    render(<Harness />);
+    const input = screen.getByRole("textbox", { name: "search" }) as HTMLInputElement;
+
+    input.focus();
+    fireEvent.focus(input);
+    fireEvent.change(input, {
+      target: { value: "clu", selectionStart: 3, selectionEnd: 3 },
+    });
+
+    expect(input.value).toBe("cluster id");
+
+    fireEvent.keyDown(input, { key: "Backspace" });
+    fireEvent.change(input, {
+      target: { value: "clu", selectionStart: 3, selectionEnd: 3 },
+    });
+
+    expect(input.value).toBe("clu");
+    expect(input.value).not.toBe("cluster id");
+  });
+
+  it("does not start next key autocomplete after a value until a semicolon is typed", () => {
+    render(<Harness />);
+    const input = screen.getByRole("textbox", { name: "search" }) as HTMLInputElement;
+
+    input.focus();
+    fireEvent.focus(input);
+
+    const withoutSemicolon = "language:english wa";
+    fireEvent.change(input, {
+      target: {
+        value: withoutSemicolon,
+        selectionStart: withoutSemicolon.length,
+        selectionEnd: withoutSemicolon.length,
+      },
+    });
+
+    expect(input.value).toBe(withoutSemicolon);
+
+    const withSemicolon = "language:english; wa";
+    fireEvent.change(input, {
+      target: {
+        value: withSemicolon,
+        selectionStart: withSemicolon.length,
+        selectionEnd: withSemicolon.length,
+      },
+    });
+
+    expect(input.value).toBe("language:english; ward");
+  });
+});

--- a/my-app/src/hooks/useSearchKeyAutocomplete.test.tsx
+++ b/my-app/src/hooks/useSearchKeyAutocomplete.test.tsx
@@ -409,4 +409,37 @@ describe("useSearchKeyAutocomplete", () => {
     expect(document.activeElement).toBe(input);
     expect(input.value).toBe("delivery");
   });
+
+  it("prevents Tab from leaving input when query does not end with semicolon", () => {
+    render(<Harness />);
+    const input = screen.getByRole("textbox", { name: "search" }) as HTMLInputElement;
+
+    input.focus();
+    fireEvent.focus(input);
+    fireEvent.change(input, {
+      target: { value: "name:jamie", selectionStart: 10, selectionEnd: 10 },
+    });
+
+    const tabEvent = createEvent.keyDown(input, { key: "Tab" });
+    fireEvent(input, tabEvent);
+
+    expect(tabEvent.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("allows Tab to move focus when query ends with semicolon", () => {
+    render(<Harness />);
+    const input = screen.getByRole("textbox", { name: "search" }) as HTMLInputElement;
+
+    input.focus();
+    fireEvent.focus(input);
+    fireEvent.change(input, {
+      target: { value: "name:jamie;", selectionStart: 11, selectionEnd: 11 },
+    });
+
+    const tabEvent = createEvent.keyDown(input, { key: "Tab" });
+    fireEvent(input, tabEvent);
+
+    expect(tabEvent.defaultPrevented).toBe(false);
+  });
 });

--- a/my-app/src/hooks/useSearchKeyAutocomplete.test.tsx
+++ b/my-app/src/hooks/useSearchKeyAutocomplete.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { createEvent, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { useSearchKeyAutocomplete } from "./useSearchKeyAutocomplete";
 
@@ -129,5 +129,284 @@ describe("useSearchKeyAutocomplete", () => {
     });
 
     expect(input.value).toBe("language:english; ward");
+  });
+
+  it("supports next key autocomplete both with and without a space after semicolon", () => {
+    render(<Harness />);
+    const input = screen.getByRole("textbox", { name: "search" }) as HTMLInputElement;
+
+    input.focus();
+    fireEvent.focus(input);
+
+    const withSpace = "language:english; wa";
+    fireEvent.change(input, {
+      target: {
+        value: withSpace,
+        selectionStart: withSpace.length,
+        selectionEnd: withSpace.length,
+      },
+    });
+    expect(input.value).toBe("language:english; ward");
+
+    const withoutSpace = "language:english;wa";
+    fireEvent.change(input, {
+      target: {
+        value: withoutSpace,
+        selectionStart: withoutSpace.length,
+        selectionEnd: withoutSpace.length,
+      },
+    });
+    expect(input.value).toBe("language:english;ward");
+  });
+
+  it("autocompletes next key in compact multi-filter form without space after semicolon", () => {
+    const DeliveryHarness = () => {
+      const [value, setValue] = React.useState("");
+      const autocomplete = useSearchKeyAutocomplete({
+        value,
+        onValueChange: setValue,
+        suggestions: ["name", "delivery instructions", "delivery frequency", "gender"],
+      });
+
+      return (
+        <input
+          aria-label="search"
+          ref={autocomplete.inputRef}
+          value={value}
+          onChange={autocomplete.handleInputChange}
+          onFocus={autocomplete.handleInputFocus}
+          onClick={autocomplete.handleInputClick}
+          onBlur={autocomplete.handleInputBlur}
+          onKeyDown={autocomplete.handleInputKeyDown}
+          onKeyUp={autocomplete.handleInputKeyUp}
+        />
+      );
+    };
+
+    render(<DeliveryHarness />);
+    const input = screen.getByRole("textbox", { name: "search" }) as HTMLInputElement;
+
+    input.focus();
+    fireEvent.focus(input);
+
+    const compactQuery = "name:jamie;deliveryfr";
+    fireEvent.change(input, {
+      target: {
+        value: compactQuery,
+        selectionStart: compactQuery.length,
+        selectionEnd: compactQuery.length,
+      },
+    });
+
+    expect(input.value).toBe("name:jamie;delivery frequency");
+  });
+
+  it("commits selected inline key with Tab in compact multi-filter input", () => {
+    const DeliveryHarness = () => {
+      const [value, setValue] = React.useState("");
+      const autocomplete = useSearchKeyAutocomplete({
+        value,
+        onValueChange: setValue,
+        suggestions: ["name", "delivery instructions", "delivery frequency", "gender"],
+      });
+
+      return (
+        <input
+          aria-label="search"
+          ref={autocomplete.inputRef}
+          value={value}
+          onChange={autocomplete.handleInputChange}
+          onFocus={autocomplete.handleInputFocus}
+          onClick={autocomplete.handleInputClick}
+          onBlur={autocomplete.handleInputBlur}
+          onKeyDown={autocomplete.handleInputKeyDown}
+          onKeyUp={autocomplete.handleInputKeyUp}
+        />
+      );
+    };
+
+    render(<DeliveryHarness />);
+    const input = screen.getByRole("textbox", { name: "search" }) as HTMLInputElement;
+
+    input.focus();
+    fireEvent.focus(input);
+
+    const compactQuery = "name:jamie;deliveryfr";
+    fireEvent.change(input, {
+      target: {
+        value: compactQuery,
+        selectionStart: compactQuery.length,
+        selectionEnd: compactQuery.length,
+      },
+    });
+
+    expect(input.value).toBe("name:jamie;delivery frequency");
+
+    fireEvent.keyDown(input, { key: "Tab" });
+
+    expect(input.value).toBe("name:jamie;delivery frequency:");
+    expect(input.selectionStart).toBe("name:jamie;delivery frequency:".length);
+    expect(input.selectionEnd).toBe("name:jamie;delivery frequency:".length);
+  });
+
+  it("commits selected inline key with Enter in compact multi-filter input", () => {
+    const DeliveryHarness = () => {
+      const [value, setValue] = React.useState("");
+      const autocomplete = useSearchKeyAutocomplete({
+        value,
+        onValueChange: setValue,
+        suggestions: ["name", "delivery instructions", "delivery frequency", "gender"],
+      });
+
+      return (
+        <input
+          aria-label="search"
+          ref={autocomplete.inputRef}
+          value={value}
+          onChange={autocomplete.handleInputChange}
+          onFocus={autocomplete.handleInputFocus}
+          onClick={autocomplete.handleInputClick}
+          onBlur={autocomplete.handleInputBlur}
+          onKeyDown={autocomplete.handleInputKeyDown}
+          onKeyUp={autocomplete.handleInputKeyUp}
+        />
+      );
+    };
+
+    render(<DeliveryHarness />);
+    const input = screen.getByRole("textbox", { name: "search" }) as HTMLInputElement;
+
+    input.focus();
+    fireEvent.focus(input);
+
+    const compactQuery = "name:jamie;deliveryfr";
+    fireEvent.change(input, {
+      target: {
+        value: compactQuery,
+        selectionStart: compactQuery.length,
+        selectionEnd: compactQuery.length,
+      },
+    });
+
+    expect(input.value).toBe("name:jamie;delivery frequency");
+
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(input.value).toBe("name:jamie;delivery frequency:");
+    expect(input.selectionStart).toBe("name:jamie;delivery frequency:".length);
+    expect(input.selectionEnd).toBe("name:jamie;delivery frequency:".length);
+  });
+
+  it("prefers the strongest key match when typing deliveryfr", () => {
+    const DeliveryHarness = () => {
+      const [value, setValue] = React.useState("");
+      const autocomplete = useSearchKeyAutocomplete({
+        value,
+        onValueChange: setValue,
+        suggestions: ["delivery instructions", "delivery frequency", "name"],
+      });
+
+      return (
+        <input
+          aria-label="search"
+          ref={autocomplete.inputRef}
+          value={value}
+          onChange={autocomplete.handleInputChange}
+          onFocus={autocomplete.handleInputFocus}
+          onClick={autocomplete.handleInputClick}
+          onBlur={autocomplete.handleInputBlur}
+          onKeyDown={autocomplete.handleInputKeyDown}
+          onKeyUp={autocomplete.handleInputKeyUp}
+        />
+      );
+    };
+
+    render(<DeliveryHarness />);
+    const input = screen.getByRole("textbox", { name: "search" }) as HTMLInputElement;
+
+    input.focus();
+    fireEvent.focus(input);
+    fireEvent.change(input, {
+      target: { value: "deliveryfr", selectionStart: 10, selectionEnd: 10 },
+    });
+
+    expect(input.value).toBe("delivery frequency");
+  });
+
+  it("does not force autocomplete when a prefix matches multiple keys", () => {
+    const DeliveryHarness = () => {
+      const [value, setValue] = React.useState("");
+      const autocomplete = useSearchKeyAutocomplete({
+        value,
+        onValueChange: setValue,
+        suggestions: ["delivery instructions", "delivery frequency", "name"],
+      });
+
+      return (
+        <input
+          aria-label="search"
+          ref={autocomplete.inputRef}
+          value={value}
+          onChange={autocomplete.handleInputChange}
+          onFocus={autocomplete.handleInputFocus}
+          onClick={autocomplete.handleInputClick}
+          onBlur={autocomplete.handleInputBlur}
+          onKeyDown={autocomplete.handleInputKeyDown}
+          onKeyUp={autocomplete.handleInputKeyUp}
+        />
+      );
+    };
+
+    render(<DeliveryHarness />);
+    const input = screen.getByRole("textbox", { name: "search" }) as HTMLInputElement;
+
+    input.focus();
+    fireEvent.focus(input);
+    fireEvent.change(input, {
+      target: { value: "delivery", selectionStart: 8, selectionEnd: 8 },
+    });
+
+    expect(input.value).toBe("delivery");
+  });
+
+  it("keeps focus in input on Tab when editing an ambiguous key prefix", () => {
+    const DeliveryHarness = () => {
+      const [value, setValue] = React.useState("");
+      const autocomplete = useSearchKeyAutocomplete({
+        value,
+        onValueChange: setValue,
+        suggestions: ["delivery instructions", "delivery frequency", "name"],
+      });
+
+      return (
+        <input
+          aria-label="search"
+          ref={autocomplete.inputRef}
+          value={value}
+          onChange={autocomplete.handleInputChange}
+          onFocus={autocomplete.handleInputFocus}
+          onClick={autocomplete.handleInputClick}
+          onBlur={autocomplete.handleInputBlur}
+          onKeyDown={autocomplete.handleInputKeyDown}
+          onKeyUp={autocomplete.handleInputKeyUp}
+        />
+      );
+    };
+
+    render(<DeliveryHarness />);
+    const input = screen.getByRole("textbox", { name: "search" }) as HTMLInputElement;
+
+    input.focus();
+    fireEvent.focus(input);
+    fireEvent.change(input, {
+      target: { value: "delivery", selectionStart: 8, selectionEnd: 8 },
+    });
+
+    const tabEvent = createEvent.keyDown(input, { key: "Tab" });
+    fireEvent(input, tabEvent);
+
+    expect(tabEvent.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(input);
+    expect(input.value).toBe("delivery");
   });
 });

--- a/my-app/src/hooks/useSearchKeyAutocomplete.ts
+++ b/my-app/src/hooks/useSearchKeyAutocomplete.ts
@@ -430,7 +430,7 @@ export const useSearchKeyAutocomplete = ({
         }
       }
     },
-    [applyInlineAutocomplete, normalizedSuggestions, onValueChange]
+    [applyInlineAutocomplete, onValueChange]
   );
 
   return {

--- a/my-app/src/hooks/useSearchKeyAutocomplete.ts
+++ b/my-app/src/hooks/useSearchKeyAutocomplete.ts
@@ -351,6 +351,13 @@ export const useSearchKeyAutocomplete = ({
 
       if (isTabCommit || isEnterCommit) {
         const rawValue = event.currentTarget.value;
+
+        // Global rule for filter bars: only allow Tab to move focus when the
+        // current query explicitly ends with a semicolon.
+        if (isTabCommit && rawValue.endsWith(";")) {
+          return;
+        }
+
         const selectionStart = event.currentTarget.selectionStart ?? rawValue.length;
         const selectionEnd = event.currentTarget.selectionEnd ?? selectionStart;
         const hasSelection = selectionEnd > selectionStart;
@@ -358,9 +365,7 @@ export const useSearchKeyAutocomplete = ({
         // If inline autocomplete text is selected, commit from selectionEnd first so
         // Tab/Enter finalizes the full key rather than using a partial prefix.
         const commitCursors = hasSelection ? [selectionEnd, selectionStart] : [selectionStart];
-        const startSegmentInfo = getSegmentInfo(rawValue, selectionStart, normalizedSuggestions);
-        const endSegmentInfo = getSegmentInfo(rawValue, selectionEnd, normalizedSuggestions);
-        const shouldTrapTab = isTabCommit && Boolean(startSegmentInfo || endSegmentInfo);
+        const shouldTrapTab = isTabCommit;
 
         if (shouldTrapTab) {
           event.preventDefault();

--- a/my-app/src/hooks/useSearchKeyAutocomplete.ts
+++ b/my-app/src/hooks/useSearchKeyAutocomplete.ts
@@ -1,0 +1,373 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import { normalizeSearchKeyword } from "../utils/searchFilter";
+
+interface SegmentInfo {
+  keyStart: number;
+  keyEnd: number;
+  typedKeyRaw: string;
+  hasColon: boolean;
+}
+
+const getSegmentInfo = (
+  value: string,
+  cursorPosition: number,
+  normalizedSuggestions: Array<{ raw: string; normalized: string }>
+): SegmentInfo | null => {
+  const safeCursor = Math.max(0, Math.min(cursorPosition, value.length));
+  const baseStart = value.lastIndexOf(";", Math.max(0, safeCursor - 1)) + 1;
+  const preCursorSegment = value.slice(baseStart, safeCursor);
+  const firstColonInSegment = preCursorSegment.indexOf(":");
+
+  // Autocomplete keys only while the user is in the key part (before ':')
+  // of the current semicolon-delimited segment.
+  if (firstColonInSegment !== -1) {
+    return null;
+  }
+
+  const findMatchingKeyStart = (text: string): number | null => {
+    let bestMatchStart: number | null = null;
+    let bestMatchLength = -1;
+
+    for (let start = 0; start < text.length; start += 1) {
+      const candidateRaw = text.slice(start);
+      if (candidateRaw.includes(":")) {
+        continue;
+      }
+
+      const leadingWhitespace = (candidateRaw.match(/^\s*/) ?? [""])[0];
+      const keyCandidate = candidateRaw.slice(leadingWhitespace.length);
+      if (!keyCandidate.trim()) {
+        continue;
+      }
+
+      const normalizedCandidate = normalizeSearchKeyword(keyCandidate);
+      if (!normalizedCandidate) {
+        continue;
+      }
+
+      const hasPrefixMatch = normalizedSuggestions.some((suggestion) =>
+        suggestion.normalized.startsWith(normalizedCandidate)
+      );
+
+      if (hasPrefixMatch && normalizedCandidate.length > bestMatchLength) {
+        bestMatchStart = start + leadingWhitespace.length;
+        bestMatchLength = normalizedCandidate.length;
+      }
+    }
+
+    return bestMatchStart;
+  };
+
+  const activeOffsetWithinSegment = findMatchingKeyStart(preCursorSegment);
+
+  if (activeOffsetWithinSegment === null) {
+    return null;
+  }
+
+  const keyStart = baseStart + activeOffsetWithinSegment;
+
+  const nextSemicolonFromKey = value.indexOf(";", keyStart);
+  const endBoundary = nextSemicolonFromKey === -1 ? value.length : nextSemicolonFromKey;
+  const colonAfterKey = value.indexOf(":", keyStart);
+  const hasColon = colonAfterKey !== -1 && colonAfterKey < endBoundary;
+
+  if (hasColon && safeCursor > colonAfterKey) {
+    return null;
+  }
+
+  const keyEnd = hasColon ? colonAfterKey : safeCursor;
+  const typedKeyRaw = value.slice(keyStart, safeCursor);
+
+  return {
+    keyStart,
+    keyEnd,
+    typedKeyRaw,
+    hasColon,
+  };
+};
+
+interface UseSearchKeyAutocompleteParams {
+  value: string;
+  onValueChange: (value: string) => void;
+  suggestions: string[];
+}
+
+export const useSearchKeyAutocomplete = ({
+  value,
+  onValueChange,
+  suggestions,
+}: UseSearchKeyAutocompleteParams) => {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const suppressInlineAutocompleteRef = useRef(false);
+  const [cursorPosition, setCursorPosition] = useState(0);
+
+  const normalizedSuggestions = useMemo(
+    () =>
+      Array.from(new Set(suggestions)).map((suggestion) => ({
+        raw: suggestion,
+        normalized: normalizeSearchKeyword(suggestion),
+      })),
+    [suggestions]
+  );
+
+  const updateCursorPosition = useCallback((target: HTMLInputElement) => {
+    setCursorPosition(target.selectionStart ?? target.value.length);
+  }, []);
+
+  const getBestSuggestionFor = useCallback(
+    (typedKeyRaw: string): string | null => {
+      const normalizedKey = normalizeSearchKeyword(typedKeyRaw);
+      if (!normalizedKey) {
+        return null;
+      }
+
+      const startsWithMatches = normalizedSuggestions.filter((suggestion) =>
+        suggestion.normalized.startsWith(normalizedKey)
+      );
+
+      const bestSuggestion = startsWithMatches[0]?.raw ?? null;
+
+      if (!bestSuggestion) {
+        return null;
+      }
+
+      return bestSuggestion;
+    },
+    [normalizedSuggestions]
+  );
+
+  const getExactSuggestionFor = useCallback(
+    (typedKeyRaw: string): string | null => {
+      const normalizedKey = normalizeSearchKeyword(typedKeyRaw);
+      if (!normalizedKey) {
+        return null;
+      }
+
+      const exactMatch = normalizedSuggestions.find(
+        (suggestion) => suggestion.normalized === normalizedKey
+      );
+
+      return exactMatch?.raw ?? null;
+    },
+    [normalizedSuggestions]
+  );
+
+  const applyInlineAutocomplete = useCallback(
+    (rawValue: string, rawCursorPosition: number, force = false) => {
+      const info = getSegmentInfo(rawValue, rawCursorPosition, normalizedSuggestions);
+      if (!info) {
+        return { nextValue: rawValue, nextCursor: rawCursorPosition, selectionEnd: rawCursorPosition };
+      }
+
+      const typedKeyRaw = info.typedKeyRaw;
+      const normalizedTypedKey = normalizeSearchKeyword(typedKeyRaw);
+      if (!normalizedTypedKey) {
+        return { nextValue: rawValue, nextCursor: rawCursorPosition, selectionEnd: rawCursorPosition };
+      }
+
+      const suggestion = getBestSuggestionFor(typedKeyRaw);
+      const exactSuggestion = getExactSuggestionFor(typedKeyRaw);
+
+      if (!suggestion && !exactSuggestion) {
+        return { nextValue: rawValue, nextCursor: rawCursorPosition, selectionEnd: rawCursorPosition };
+      }
+
+      if (!suggestion && exactSuggestion && !info.hasColon) {
+        const nextValue = `${rawValue.slice(0, info.keyEnd)}:${rawValue.slice(info.keyEnd)}`;
+        const nextCursor = info.keyEnd + 1;
+
+        return {
+          nextValue,
+          nextCursor,
+          selectionEnd: nextCursor,
+        };
+      }
+
+      if (!suggestion) {
+        return { nextValue: rawValue, nextCursor: rawCursorPosition, selectionEnd: rawCursorPosition };
+      }
+
+      const typedAlreadyMatchesStart = normalizeSearchKeyword(suggestion).startsWith(normalizedTypedKey);
+      if (!typedAlreadyMatchesStart && !force) {
+        return { nextValue: rawValue, nextCursor: rawCursorPosition, selectionEnd: rawCursorPosition };
+      }
+
+      const shouldAppendColon = info.hasColon || force || normalizeSearchKeyword(suggestion) === normalizedTypedKey;
+      let suffix = rawValue.slice(info.keyEnd);
+
+      // When inline autocomplete already filled the remainder (e.g. "clu" -> "cluster id"
+      // with "ster id" selected), committing with Tab should not duplicate that tail.
+      if (!info.hasColon) {
+        const suggestedRemainder = suggestion.slice(typedKeyRaw.length);
+        if (suggestedRemainder && suffix.startsWith(suggestedRemainder)) {
+          suffix = suffix.slice(suggestedRemainder.length);
+        }
+      }
+
+      const separator = info.hasColon ? "" : shouldAppendColon ? ":" : "";
+
+      const nextValue = `${rawValue.slice(0, info.keyStart)}${suggestion}${separator}${suffix}`;
+
+      const selectionStart = info.keyStart + typedKeyRaw.length;
+      const suggestionEnd = info.keyStart + suggestion.length;
+      const completedCursor = suggestionEnd + (info.hasColon || shouldAppendColon ? 1 : 0);
+
+      if (force) {
+        return {
+          nextValue,
+          nextCursor: completedCursor,
+          selectionEnd: completedCursor,
+        };
+      }
+
+      if (!info.hasColon && normalizeSearchKeyword(suggestion) === normalizedTypedKey) {
+        return {
+          nextValue,
+          nextCursor: completedCursor,
+          selectionEnd: completedCursor,
+        };
+      }
+
+      return {
+        nextValue,
+        nextCursor: selectionStart,
+        selectionEnd: suggestionEnd,
+      };
+    },
+    [getBestSuggestionFor, getExactSuggestionFor, normalizedSuggestions]
+  );
+
+  const handleInputChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const rawValue = event.target.value;
+      const rawCursorPosition = event.target.selectionStart ?? rawValue.length;
+
+      if (suppressInlineAutocompleteRef.current) {
+        suppressInlineAutocompleteRef.current = false;
+        onValueChange(rawValue);
+        setCursorPosition(rawCursorPosition);
+
+        requestAnimationFrame(() => {
+          const input = inputRef.current;
+          if (!input) return;
+
+          input.focus();
+          input.setSelectionRange(rawCursorPosition, rawCursorPosition);
+        });
+
+        return;
+      }
+
+      const { nextValue, nextCursor, selectionEnd } = applyInlineAutocomplete(
+        rawValue,
+        rawCursorPosition
+      );
+
+      onValueChange(nextValue);
+      setCursorPosition(nextCursor);
+
+      requestAnimationFrame(() => {
+        const input = inputRef.current;
+        if (!input) return;
+
+        input.focus();
+        input.setSelectionRange(nextCursor, selectionEnd);
+      });
+    },
+    [applyInlineAutocomplete, onValueChange]
+  );
+
+  const handleInputFocus = useCallback(
+    (event: React.FocusEvent<HTMLInputElement>) => {
+      updateCursorPosition(event.target);
+    },
+    [updateCursorPosition]
+  );
+
+  const handleInputClick = useCallback(
+    (event: React.MouseEvent<HTMLInputElement>) => {
+      updateCursorPosition(event.currentTarget);
+    },
+    [updateCursorPosition]
+  );
+
+  const handleInputBlur = useCallback(
+    (event: React.FocusEvent<HTMLInputElement>) => {
+      setCursorPosition(event.target.selectionStart ?? event.target.value.length);
+    },
+    []
+  );
+
+  const handleInputKeyUp = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      updateCursorPosition(event.currentTarget);
+    },
+    [updateCursorPosition]
+  );
+
+  const handleInputKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === "Backspace" || event.key === "Delete") {
+        suppressInlineAutocompleteRef.current = true;
+      }
+
+      const isTabCommit = event.key === "Tab" && !event.shiftKey;
+      const isEnterCommit = event.key === "Enter";
+
+      if (isTabCommit || isEnterCommit) {
+        const cursor = event.currentTarget.selectionStart ?? event.currentTarget.value.length;
+        const { nextValue, nextCursor, selectionEnd } = applyInlineAutocomplete(
+          event.currentTarget.value,
+          cursor,
+          true
+        );
+
+        if (nextValue !== event.currentTarget.value) {
+          event.preventDefault();
+          onValueChange(nextValue);
+          setCursorPosition(nextCursor);
+          requestAnimationFrame(() => {
+            const input = inputRef.current;
+            if (!input) return;
+            input.focus();
+            input.setSelectionRange(nextCursor, selectionEnd);
+          });
+        }
+
+        return;
+      }
+
+      if ((event.ctrlKey || event.metaKey) && event.code === "Space") {
+        event.preventDefault();
+        const cursor = event.currentTarget.selectionStart ?? event.currentTarget.value.length;
+        const { nextValue, nextCursor, selectionEnd } = applyInlineAutocomplete(
+          event.currentTarget.value,
+          cursor,
+          true
+        );
+
+        if (nextValue !== event.currentTarget.value) {
+          onValueChange(nextValue);
+          setCursorPosition(nextCursor);
+          requestAnimationFrame(() => {
+            const input = inputRef.current;
+            if (!input) return;
+            input.focus();
+            input.setSelectionRange(nextCursor, selectionEnd);
+          });
+        }
+      }
+    },
+    [applyInlineAutocomplete, onValueChange]
+  );
+
+  return {
+    handleInputBlur,
+    handleInputChange,
+    handleInputClick,
+    handleInputFocus,
+    handleInputKeyDown,
+    handleInputKeyUp,
+    inputRef,
+  };
+};

--- a/my-app/src/hooks/useSearchKeyAutocomplete.ts
+++ b/my-app/src/hooks/useSearchKeyAutocomplete.ts
@@ -25,6 +25,22 @@ const getSegmentInfo = (
   }
 
   const findMatchingKeyStart = (text: string): number | null => {
+    // Prefer the straightforward segment-start key candidate first so both
+    // ";nextKey" and "; nextKey" behave the same.
+    const segmentLeadingWhitespace = (text.match(/^\s*/) ?? [""])[0].length;
+    const segmentStartCandidateRaw = text.slice(segmentLeadingWhitespace);
+    const normalizedSegmentStartCandidate = normalizeSearchKeyword(segmentStartCandidateRaw);
+
+    if (normalizedSegmentStartCandidate) {
+      const hasSegmentStartPrefixMatch = normalizedSuggestions.some((suggestion) =>
+        suggestion.normalized.startsWith(normalizedSegmentStartCandidate)
+      );
+
+      if (hasSegmentStartPrefixMatch) {
+        return segmentLeadingWhitespace;
+      }
+    }
+
     let bestMatchStart: number | null = null;
     let bestMatchLength = -1;
 
@@ -124,6 +140,25 @@ export const useSearchKeyAutocomplete = ({
       const startsWithMatches = normalizedSuggestions.filter((suggestion) =>
         suggestion.normalized.startsWith(normalizedKey)
       );
+
+      if (startsWithMatches.length === 0) {
+        return null;
+      }
+
+      const exactMatch = startsWithMatches.find(
+        (suggestion) => suggestion.normalized === normalizedKey
+      );
+
+      if (exactMatch) {
+        return exactMatch.raw;
+      }
+
+      // Do not auto-fill on ambiguous prefixes (for example, "delivery" can match
+      // both "delivery instructions" and "delivery frequency"). Wait until the
+      // user types enough characters to uniquely identify one key.
+      if (startsWithMatches.length > 1) {
+        return null;
+      }
 
       const bestSuggestion = startsWithMatches[0]?.raw ?? null;
 
@@ -315,22 +350,54 @@ export const useSearchKeyAutocomplete = ({
       const isEnterCommit = event.key === "Enter";
 
       if (isTabCommit || isEnterCommit) {
-        const cursor = event.currentTarget.selectionStart ?? event.currentTarget.value.length;
-        const { nextValue, nextCursor, selectionEnd } = applyInlineAutocomplete(
-          event.currentTarget.value,
-          cursor,
-          true
-        );
+        const rawValue = event.currentTarget.value;
+        const selectionStart = event.currentTarget.selectionStart ?? rawValue.length;
+        const selectionEnd = event.currentTarget.selectionEnd ?? selectionStart;
+        const hasSelection = selectionEnd > selectionStart;
 
-        if (nextValue !== event.currentTarget.value) {
+        // If inline autocomplete text is selected, commit from selectionEnd first so
+        // Tab/Enter finalizes the full key rather than using a partial prefix.
+        const commitCursors = hasSelection ? [selectionEnd, selectionStart] : [selectionStart];
+        const startSegmentInfo = getSegmentInfo(rawValue, selectionStart, normalizedSuggestions);
+        const endSegmentInfo = getSegmentInfo(rawValue, selectionEnd, normalizedSuggestions);
+        const shouldTrapTab = isTabCommit && Boolean(startSegmentInfo || endSegmentInfo);
+
+        if (shouldTrapTab) {
           event.preventDefault();
+        }
+
+        let commitResult = {
+          nextValue: rawValue,
+          nextCursor: selectionStart,
+          selectionEnd,
+        };
+
+        for (const commitCursor of commitCursors) {
+          const candidate = applyInlineAutocomplete(rawValue, commitCursor, true);
+          commitResult = candidate;
+          if (candidate.nextValue !== rawValue) {
+            break;
+          }
+        }
+
+        const { nextValue, nextCursor, selectionEnd: nextSelectionEnd } = commitResult;
+
+        if (nextValue !== rawValue) {
           onValueChange(nextValue);
           setCursorPosition(nextCursor);
           requestAnimationFrame(() => {
             const input = inputRef.current;
             if (!input) return;
             input.focus();
-            input.setSelectionRange(nextCursor, selectionEnd);
+            input.setSelectionRange(nextCursor, nextSelectionEnd);
+          });
+        } else if (shouldTrapTab) {
+          setCursorPosition(selectionStart);
+          requestAnimationFrame(() => {
+            const input = inputRef.current;
+            if (!input) return;
+            input.focus();
+            input.setSelectionRange(selectionStart, selectionEnd);
           });
         }
 
@@ -358,7 +425,7 @@ export const useSearchKeyAutocomplete = ({
         }
       }
     },
-    [applyInlineAutocomplete, onValueChange]
+    [applyInlineAutocomplete, normalizedSuggestions, onValueChange]
   );
 
   return {

--- a/my-app/src/hooks/useSearchKeyAutocomplete.ts
+++ b/my-app/src/hooks/useSearchKeyAutocomplete.ts
@@ -348,8 +348,14 @@ export const useSearchKeyAutocomplete = ({
 
       const isTabCommit = event.key === "Tab" && !event.shiftKey;
       const isEnterCommit = event.key === "Enter";
+      const isRightArrowCommit =
+        event.key === "ArrowRight" &&
+        !event.shiftKey &&
+        !event.altKey &&
+        !event.ctrlKey &&
+        !event.metaKey;
 
-      if (isTabCommit || isEnterCommit) {
+      if (isTabCommit || isEnterCommit || isRightArrowCommit) {
         const rawValue = event.currentTarget.value;
 
         // Global rule for filter bars: only allow Tab to move focus when the
@@ -363,7 +369,7 @@ export const useSearchKeyAutocomplete = ({
         const hasSelection = selectionEnd > selectionStart;
 
         // If inline autocomplete text is selected, commit from selectionEnd first so
-        // Tab/Enter finalizes the full key rather than using a partial prefix.
+        // Tab/Enter/Right Arrow finalizes the full key rather than using a partial prefix.
         const commitCursors = hasSelection ? [selectionEnd, selectionStart] : [selectionStart];
         const shouldTrapTab = isTabCommit;
 
@@ -388,6 +394,9 @@ export const useSearchKeyAutocomplete = ({
         const { nextValue, nextCursor, selectionEnd: nextSelectionEnd } = commitResult;
 
         if (nextValue !== rawValue) {
+          if (isRightArrowCommit) {
+            event.preventDefault();
+          }
           onValueChange(nextValue);
           setCursorPosition(nextCursor);
           requestAnimationFrame(() => {

--- a/my-app/src/pages/Calendar/CalendarPage.test.tsx
+++ b/my-app/src/pages/Calendar/CalendarPage.test.tsx
@@ -1,0 +1,336 @@
+import React from "react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { DayPilot } from "@daypilot/daypilot-lite-react";
+import { MemoryRouter } from "react-router-dom";
+import CalendarPage from "./CalendarPage";
+import { DeliveryEvent } from "../../types/calendar-types";
+
+const mockGetEventsByDateRange = jest.fn();
+const mockGetDailyLimits = jest.fn();
+const mockScheduleClientDeliveries = jest.fn();
+const mockGetAllDrivers = jest.fn();
+const mockGetClientsByIds = jest.fn();
+const mockGetClientDeliverySummaries = jest.fn();
+const mockGetAllClients = jest.fn();
+const mockGetClientById = jest.fn();
+const mockShowSuccess = jest.fn();
+const mockShowError = jest.fn();
+
+jest.mock("firebase/auth", () => ({
+  onAuthStateChanged: (_auth: unknown, callback: (user: { uid: string }) => void) => {
+    callback({ uid: "staff-user" });
+    return () => undefined;
+  },
+}));
+
+jest.mock("../../auth/firebaseConfig", () => ({
+  auth: {},
+  db: {},
+}));
+
+jest.mock("../../components/NotificationProvider", () => ({
+  useNotifications: () => ({
+    showSuccess: (...args: Parameters<typeof mockShowSuccess>) => mockShowSuccess(...args),
+    showError: (...args: Parameters<typeof mockShowError>) => mockShowError(...args),
+  }),
+}));
+
+jest.mock("../../context/RecurringDeliveryContext", () => ({
+  RecurringDeliveryProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("./components/useLimits", () => ({
+  useLimits: () => [5, 5, 5, 5, 5, 5, 5],
+}));
+
+jest.mock("../../utils/deliveryEventEmitter", () => ({
+  deliveryEventEmitter: {
+    subscribe: () => () => undefined,
+  },
+}));
+
+jest.mock("../../services/delivery-service", () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => ({
+      getEventsByDateRange: (...args: Parameters<typeof mockGetEventsByDateRange>) =>
+        mockGetEventsByDateRange(...args),
+      getDailyLimits: (...args: Parameters<typeof mockGetDailyLimits>) =>
+        mockGetDailyLimits(...args),
+      scheduleClientDeliveries: (...args: Parameters<typeof mockScheduleClientDeliveries>) =>
+        mockScheduleClientDeliveries(...args),
+    }),
+  },
+}));
+
+jest.mock("../../services/driver-service", () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => ({
+      getAllDrivers: (...args: Parameters<typeof mockGetAllDrivers>) => mockGetAllDrivers(...args),
+    }),
+  },
+}));
+
+jest.mock("../../services/client-service", () => ({
+  clientService: {
+    getClientsByIds: (...args: Parameters<typeof mockGetClientsByIds>) =>
+      mockGetClientsByIds(...args),
+    getClientDeliverySummaries: (...args: Parameters<typeof mockGetClientDeliverySummaries>) =>
+      mockGetClientDeliverySummaries(...args),
+    getAllClients: (...args: Parameters<typeof mockGetAllClients>) => mockGetAllClients(...args),
+    getClientById: (...args: Parameters<typeof mockGetClientById>) => mockGetClientById(...args),
+  },
+}));
+
+jest.mock("./components/CalendarHeader", () => ({
+  __esModule: true,
+  default: ({
+    currentDate,
+    viewType,
+    onViewTypeChange,
+    onNavigatePrev,
+    onNavigateNext,
+  }: {
+    currentDate: { toString: (format: string) => string };
+    viewType: "Day" | "Month";
+    onViewTypeChange: (viewType: "Day" | "Month") => void;
+    onNavigatePrev: () => void;
+    onNavigateNext: () => void;
+  }) => (
+    <div>
+      <div data-testid="current-date">{currentDate.toString("yyyy-MM-dd")}</div>
+      <div data-testid="view-type">{viewType}</div>
+      <button
+        type="button"
+        onClick={() => onViewTypeChange(viewType === "Day" ? "Month" : "Day")}
+      >
+        toggle-view
+      </button>
+      <button type="button" onClick={onNavigatePrev}>
+        prev-day
+      </button>
+      <button type="button" onClick={onNavigateNext}>
+        next-day
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock("./components/MonthView", () => ({
+  __esModule: true,
+  default: ({
+    onTimeRangeSelected,
+  }: {
+    onTimeRangeSelected: (args: { start: unknown }) => void;
+  }) => {
+    const { DayPilot: MockDayPilot } = require("@daypilot/daypilot-lite-react");
+
+    return (
+      <button
+        type="button"
+        onClick={() => onTimeRangeSelected({ start: new MockDayPilot.Date("2026-03-16") })}
+      >
+        select-month-day
+      </button>
+    );
+  },
+}));
+
+jest.mock("./components/DayView", () => ({
+  __esModule: true,
+  default: ({ events }: { events: Array<{ id: string }> }) => (
+    <div>
+      <div data-testid="day-count">{events.length}</div>
+      <div data-testid="event-ids">{events.map((event) => event.id).join(",")}</div>
+    </div>
+  ),
+}));
+
+jest.mock("./components/AddDeliveryDialog", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("./components/CalendarPopper", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("../../components/skeletons/CalendarSkeleton", () => ({
+  __esModule: true,
+  default: () => <div>loading calendar</div>,
+}));
+
+jest.mock("../../components/skeletons/CalendarHeaderSkeleton", () => ({
+  __esModule: true,
+  default: () => <div>loading header</div>,
+}));
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error?: unknown) => void;
+};
+
+const createDeferred = <T,>(): Deferred<T> => {
+  let resolve!: (value: T) => void;
+  let reject!: (error?: unknown) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+};
+
+const buildEvent = (id: string, deliveryDate: string, clientId = `${id}-client`): DeliveryEvent => ({
+  id,
+  assignedDriverId: "driver-1",
+  assignedDriverName: "Driver One",
+  clientId,
+  clientName: `${id} client`,
+  deliveryDate,
+  time: "12:00",
+  cluster: 1,
+  recurrence: "None",
+});
+
+const renderCalendarPage = (date = "2026-03-10") =>
+  render(
+    <MemoryRouter initialEntries={[`/calendar?date=${date}`]}>
+      <CalendarPage />
+    </MemoryRouter>
+  );
+
+describe("CalendarPage stale fetch protection", () => {
+  beforeEach(() => {
+    mockGetEventsByDateRange.mockReset();
+    mockGetDailyLimits.mockReset();
+    mockScheduleClientDeliveries.mockReset();
+    mockGetAllDrivers.mockReset();
+    mockGetClientsByIds.mockReset();
+    mockGetClientDeliverySummaries.mockReset();
+    mockGetAllClients.mockReset();
+    mockGetClientById.mockReset();
+    mockShowSuccess.mockReset();
+    mockShowError.mockReset();
+
+    mockGetDailyLimits.mockImplementation(async () => []);
+    mockGetAllDrivers.mockImplementation(async () => []);
+    mockGetClientsByIds.mockImplementation(async () => []);
+    mockGetClientDeliverySummaries.mockImplementation(async () => new Map());
+    mockGetAllClients.mockImplementation(async () => ({ clients: [] }));
+    mockGetClientById.mockImplementation(async () => null);
+
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("keeps the selected day count after switching from month view even if older requests finish later", async () => {
+    const initialDayRequest = createDeferred<DeliveryEvent[]>();
+    const monthRequest = createDeferred<DeliveryEvent[]>();
+    const selectedDayRequest = createDeferred<DeliveryEvent[]>();
+
+    mockGetEventsByDateRange
+      .mockImplementationOnce(() => initialDayRequest.promise)
+      .mockImplementationOnce(() => monthRequest.promise)
+      .mockImplementationOnce(() => selectedDayRequest.promise);
+
+    renderCalendarPage();
+
+    await screen.findByTestId("current-date");
+
+    fireEvent.click(screen.getByRole("button", { name: "toggle-view" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("view-type").textContent).toBe("Month");
+      expect(mockGetEventsByDateRange).toHaveBeenCalledTimes(2);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "select-month-day" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("view-type").textContent).toBe("Day");
+      expect(screen.getByTestId("current-date").textContent).toBe("2026-03-16");
+      expect(mockGetEventsByDateRange).toHaveBeenCalledTimes(3);
+    });
+
+    await act(async () => {
+      selectedDayRequest.resolve([buildEvent("selected-day", "2026-03-16")]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("day-count").textContent).toBe("1");
+      expect(screen.getByTestId("event-ids").textContent).toBe("selected-day");
+    });
+
+    await act(async () => {
+      monthRequest.resolve([
+        buildEvent("month-a", "2026-03-01"),
+        buildEvent("month-b", "2026-03-02"),
+      ]);
+      initialDayRequest.resolve([buildEvent("initial-day", "2026-03-10")]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("current-date").textContent).toBe("2026-03-16");
+      expect(screen.getByTestId("view-type").textContent).toBe("Day");
+      expect(screen.getByTestId("day-count").textContent).toBe("1");
+      expect(screen.getByTestId("event-ids").textContent).toBe("selected-day");
+    });
+  });
+
+  it("keeps the latest day count when navigating next and back while requests resolve out of order", async () => {
+    const initialDayRequest = createDeferred<DeliveryEvent[]>();
+    const nextDayRequest = createDeferred<DeliveryEvent[]>();
+    const returnedDayRequest = createDeferred<DeliveryEvent[]>();
+
+    mockGetEventsByDateRange
+      .mockImplementationOnce(() => initialDayRequest.promise)
+      .mockImplementationOnce(() => nextDayRequest.promise)
+      .mockImplementationOnce(() => returnedDayRequest.promise);
+
+    renderCalendarPage("2026-03-16");
+
+    await screen.findByTestId("current-date");
+
+    fireEvent.click(screen.getByRole("button", { name: "next-day" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("current-date").textContent).toBe("2026-03-17");
+      expect(mockGetEventsByDateRange).toHaveBeenCalledTimes(2);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "prev-day" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("current-date").textContent).toBe("2026-03-16");
+      expect(mockGetEventsByDateRange).toHaveBeenCalledTimes(3);
+    });
+
+    await act(async () => {
+      returnedDayRequest.resolve([buildEvent("returned-day", "2026-03-16")]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("day-count").textContent).toBe("1");
+      expect(screen.getByTestId("event-ids").textContent).toBe("returned-day");
+    });
+
+    await act(async () => {
+      nextDayRequest.resolve([
+        buildEvent("next-day-a", "2026-03-17"),
+        buildEvent("next-day-b", "2026-03-17"),
+      ]);
+      initialDayRequest.resolve([buildEvent("initial-day", "2026-03-16")]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("current-date").textContent).toBe("2026-03-16");
+      expect(screen.getByTestId("day-count").textContent).toBe("1");
+      expect(screen.getByTestId("event-ids").textContent).toBe("returned-day");
+    });
+  });
+});

--- a/my-app/src/pages/Calendar/CalendarPage.test.tsx
+++ b/my-app/src/pages/Calendar/CalendarPage.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter } from "react-router-dom";
 import CalendarPage from "./CalendarPage";
 import { DeliveryEvent } from "../../types/calendar-types";
 
+const mockDayPilot = DayPilot;
 const mockGetEventsByDateRange = jest.fn();
 const mockGetDailyLimits = jest.fn();
 const mockScheduleClientDeliveries = jest.fn();
@@ -125,12 +126,10 @@ jest.mock("./components/MonthView", () => ({
   }: {
     onTimeRangeSelected: (args: { start: unknown }) => void;
   }) => {
-    const { DayPilot: MockDayPilot } = require("@daypilot/daypilot-lite-react");
-
     return (
       <button
         type="button"
-        onClick={() => onTimeRangeSelected({ start: new MockDayPilot.Date("2026-03-16") })}
+        onClick={() => onTimeRangeSelected({ start: new mockDayPilot.Date("2026-03-16") })}
       >
         select-month-day
       </button>

--- a/my-app/src/pages/Calendar/CalendarPage.tsx
+++ b/my-app/src/pages/Calendar/CalendarPage.tsx
@@ -143,6 +143,7 @@ const CalendarPage: React.FC = React.memo(() => {
   const [isInitialLoad, setIsInitialLoad] = useState<boolean>(true);
   const limits = useLimits();
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const fetchEventsRequestIdRef = useRef(0);
 
   // Memoized client lookup map for O(1) performance instead of O(n) array.find
   const clientLookupMap = useMemo(() => {
@@ -272,6 +273,8 @@ const CalendarPage: React.FC = React.memo(() => {
   };
 
   const fetchEvents = useCallback(async () => {
+    const requestId = ++fetchEventsRequestIdRef.current;
+
     try {
       const { queryStart, queryEndExclusive } = getCalendarViewRange(currentDate, viewType);
 
@@ -284,6 +287,10 @@ const CalendarPage: React.FC = React.memo(() => {
 
       // Lazy load only the clients we need for these events
       const neededClients = await fetchClientsLazy(uniqueClientIds);
+
+      if (requestId !== fetchEventsRequestIdRef.current) {
+        return [];
+      }
 
       // Create efficient lookup map from the clients we just fetched
       const eventClientLookupMap = new Map();
@@ -328,6 +335,9 @@ const CalendarPage: React.FC = React.memo(() => {
 
       return updatedEvents;
     } catch (error) {
+      if (requestId !== fetchEventsRequestIdRef.current) {
+        return [];
+      }
       console.error("Error fetching events:", error);
       return [];
     }

--- a/my-app/src/pages/Calendar/components/AddDeliveryDialog.tsx
+++ b/my-app/src/pages/Calendar/components/AddDeliveryDialog.tsx
@@ -26,7 +26,12 @@ import { validateDeliveryDateRange } from "../../../utils/dateValidation";
 import { clientService } from "../../../services/client-service";
 import { deliveryDate } from "../../../utils/deliveryDate";
 import { DeliveryService } from "../../../services";
-import { calculateRecurrenceDates } from "./CalendarUtils";
+import {
+  calculateRecurrenceDates,
+  generateMonthlyRecurrencePatternDates,
+  WeekPosition,
+  PatternDayOfWeek,
+} from "./CalendarUtils";
 import {
   buildDailyLimitsMap,
   buildProjectedCapacityWarnings,
@@ -244,6 +249,8 @@ const AddDeliveryDialog: React.FC<AddDeliveryDialogProps> = (props) => {
   const [newDelivery, setNewDelivery] = useState<NewDelivery>(() => buildInitialDeliveryState());
 
   const [customDates, setCustomDates] = useState<Date[]>([]);
+  const [weekPosition, setWeekPosition] = useState<WeekPosition>("first");
+  const [patternDayOfWeek, setPatternDayOfWeek] = useState<PatternDayOfWeek>("monday");
   const [startDateError, setStartDateError] = useState<string>("");
   const [endDateError, setEndDateError] = useState<string>("");
 
@@ -271,6 +278,14 @@ const AddDeliveryDialog: React.FC<AddDeliveryDialogProps> = (props) => {
       return isValidDateFormat(newDelivery.deliveryDate);
     }
     if (["Weekly", "2x-Monthly", "Monthly"].includes(newDelivery.recurrence)) {
+      if (!newDelivery.deliveryDate || !newDelivery.repeatsEndDate) return false;
+      if (hasStartDateError || hasEndDateError || hasDeliveryDateError || hasRepeatsEndDateError)
+        return false;
+      return (
+        isValidDateFormat(newDelivery.deliveryDate) && isValidDateFormat(newDelivery.repeatsEndDate)
+      );
+    }
+    if (newDelivery.recurrence === "Monthly-Pattern") {
       if (!newDelivery.deliveryDate || !newDelivery.repeatsEndDate) return false;
       if (hasStartDateError || hasEndDateError || hasDeliveryDateError || hasRepeatsEndDateError)
         return false;
@@ -392,6 +407,8 @@ const AddDeliveryDialog: React.FC<AddDeliveryDialogProps> = (props) => {
     setNewDelivery(buildInitialDeliveryState());
     setSelectedClientProfile(preSelectedClient?.clientProfile || null);
     setCustomDates([]);
+    setWeekPosition("first");
+    setPatternDayOfWeek("monday");
     setStartDateError("");
     setEndDateError("");
     setFormError("");
@@ -483,6 +500,22 @@ const AddDeliveryDialog: React.FC<AddDeliveryDialogProps> = (props) => {
       let candidateDates: string[] = [];
       if (newDelivery.recurrence === "Custom") {
         candidateDates = normalizedCustomDates;
+      } else if (newDelivery.recurrence === "Monthly-Pattern") {
+        if (normalizedDeliveryDate && normalizedRepeatsEndDate) {
+          const patternDates = generateMonthlyRecurrencePatternDates({
+            startDate: new Date(normalizedDeliveryDate + "T00:00:00"),
+            endDate: new Date(normalizedRepeatsEndDate + "T00:00:00"),
+            weekPosition,
+            dayOfWeek: patternDayOfWeek,
+          });
+          candidateDates = patternDates
+            .map((d) => {
+              const mm = String(d.getMonth() + 1).padStart(2, "0");
+              const dd = String(d.getDate()).padStart(2, "0");
+              return `${d.getFullYear()}-${mm}-${dd}`;
+            })
+            .filter(Boolean);
+        }
       } else if (normalizedDeliveryDate) {
         if (newDelivery.recurrence === "None") {
           candidateDates = [normalizedDeliveryDate];
@@ -499,7 +532,17 @@ const AddDeliveryDialog: React.FC<AddDeliveryDialogProps> = (props) => {
       const uniqueCandidateDates = Array.from(new Set(candidateDates));
 
       if (!uniqueCandidateDates.length) {
-        setFormError("Please select at least one delivery date.");
+        if (newDelivery.recurrence === "Monthly-Pattern") {
+          const positionLabel =
+            weekPosition.charAt(0).toUpperCase() + weekPosition.slice(1);
+          const dayLabel =
+            patternDayOfWeek.charAt(0).toUpperCase() + patternDayOfWeek.slice(1);
+          setFormError(
+            `No ${positionLabel} ${dayLabel} dates fall between the delivery date and end date. Try extending the end date.`
+          );
+        } else {
+          setFormError("Please select at least one delivery date.");
+        }
         return;
       }
 
@@ -580,6 +623,14 @@ const AddDeliveryDialog: React.FC<AddDeliveryDialogProps> = (props) => {
         deliveryToSubmit.customDates = uniqueCustomDates;
         deliveryToSubmit.deliveryDate = uniqueCustomDates[0] || normalizedDeliveryDate;
         deliveryToSubmit.repeatsEndDate = undefined;
+      } else if (newDelivery.recurrence === "Monthly-Pattern") {
+        const sortedDates = Array.from(new Set(nonConflictingCandidateDates)).sort();
+        deliveryToSubmit.deliveryDate = sortedDates[0] || normalizedDeliveryDate;
+        deliveryToSubmit.repeatsEndDate = normalizedRepeatsEndDate;
+        deliveryToSubmit.monthlyPatternWeekPosition = weekPosition;
+        deliveryToSubmit.monthlyPatternDayOfWeek = patternDayOfWeek;
+        // Store all generated dates the same way Custom does so the service can create each one
+        deliveryToSubmit.customDates = sortedDates;
       } else {
         deliveryToSubmit.deliveryDate = normalizedDeliveryDate;
         if (newDelivery.recurrence !== "None") {
@@ -960,12 +1011,50 @@ const AddDeliveryDialog: React.FC<AddDeliveryDialogProps> = (props) => {
               <MenuItem value="Weekly">Weekly</MenuItem>
               <MenuItem value="2x-Monthly">2x-Monthly</MenuItem>
               <MenuItem value="Monthly">Monthly (Every 4 Weeks)</MenuItem>
+              <MenuItem value="Monthly-Pattern">Monthly Recurrence Pattern</MenuItem>
               <MenuItem value="Custom">Custom (Select Dates)</MenuItem>
             </Select>
           </FormControl>
         </Box>
         {newDelivery.recurrence === "Custom" ? (
           <>
+            <Box
+              sx={{
+                mb: 2,
+                p: 2,
+                bgcolor: "info.50",
+                border: "1px solid",
+                borderColor: "info.200",
+                borderRadius: 1,
+                display: "flex",
+                alignItems: "flex-start",
+                gap: 1,
+              }}
+            >
+              <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                For repeating monthly patterns like the third Friday, use{" "}
+                <Box
+                  component="span"
+                  onClick={() => {
+                    setNewDelivery((prev) => ({
+                      ...prev,
+                      recurrence: "Monthly-Pattern",
+                      customDates: undefined,
+                    }));
+                    setCustomDates([]);
+                  }}
+                  sx={{
+                    color: "primary.main",
+                    textDecoration: "underline",
+                    cursor: "pointer",
+                    fontWeight: 500,
+                  }}
+                >
+                  Monthly Recurrence Pattern
+                </Box>
+                .
+              </Typography>
+            </Box>
             <Typography variant="body1" sx={{ mb: 2 }}>
               Select Custom Dates
             </Typography>
@@ -979,7 +1068,89 @@ const AddDeliveryDialog: React.FC<AddDeliveryDialogProps> = (props) => {
         ) : (
           <Box sx={{ mb: 2 }} />
         )}
-        {newDelivery.recurrence !== "None" && newDelivery.recurrence !== "Custom" ? (
+        {newDelivery.recurrence === "Monthly-Pattern" ? (
+          <>
+            <Box
+              sx={{
+                mt: 1,
+                mb: 2,
+                p: 2,
+                border: "1px solid",
+                borderColor: "divider",
+                borderRadius: 1,
+              }}
+            >
+              <Typography variant="subtitle2" sx={{ mb: 2, fontWeight: 600 }}>
+                Monthly Recurrence Pattern
+              </Typography>
+              <Typography variant="body2" sx={{ mb: 2, color: "text.secondary" }}>
+                Create deliveries on the{" "}
+                <strong>
+                  {{ first: "First", second: "Second", third: "Third", fourth: "Fourth", last: "Last" }[weekPosition]}
+                </strong>{" "}
+                <strong>
+                  {{ monday: "Monday", tuesday: "Tuesday", wednesday: "Wednesday", thursday: "Thursday", friday: "Friday", saturday: "Saturday", sunday: "Sunday" }[patternDayOfWeek]}
+                </strong>{" "}
+                of each month.
+              </Typography>
+              <Box sx={{ display: "flex", gap: 2 }}>
+                <FormControl fullWidth variant="outlined" size="small">
+                  <InputLabel id="week-position-label">Week position</InputLabel>
+                  <Select
+                    label="Week position"
+                    labelId="week-position-label"
+                    value={weekPosition}
+                    onChange={(e) => setWeekPosition(e.target.value as WeekPosition)}
+                  >
+                    <MenuItem value="first">First</MenuItem>
+                    <MenuItem value="second">Second</MenuItem>
+                    <MenuItem value="third">Third</MenuItem>
+                    <MenuItem value="fourth">Fourth</MenuItem>
+                    <MenuItem value="last">Last</MenuItem>
+                  </Select>
+                </FormControl>
+                <FormControl fullWidth variant="outlined" size="small">
+                  <InputLabel id="day-of-week-label">Day of week</InputLabel>
+                  <Select
+                    label="Day of week"
+                    labelId="day-of-week-label"
+                    value={patternDayOfWeek}
+                    onChange={(e) => setPatternDayOfWeek(e.target.value as PatternDayOfWeek)}
+                  >
+                    <MenuItem value="monday">Monday</MenuItem>
+                    <MenuItem value="tuesday">Tuesday</MenuItem>
+                    <MenuItem value="wednesday">Wednesday</MenuItem>
+                    <MenuItem value="thursday">Thursday</MenuItem>
+                    <MenuItem value="friday">Friday</MenuItem>
+                    <MenuItem value="saturday">Saturday</MenuItem>
+                    <MenuItem value="sunday">Sunday</MenuItem>
+                  </Select>
+                </FormControl>
+              </Box>
+            </Box>
+            <DateField
+              label="End Date"
+              value={newDelivery.repeatsEndDate || ""}
+              onChange={(dateStr: string) => {
+                setNewDelivery({ ...newDelivery, repeatsEndDate: dateStr });
+              }}
+              required
+              error={newDelivery._repeatsEndDateError}
+              min={newDelivery.deliveryDate || clientStartDateISO || undefined}
+              max={clientEndDateISO || undefined}
+              setError={(err: string | null) => {
+                setNewDelivery((prev: NewDelivery) => ({
+                  ...prev,
+                  _repeatsEndDateError: err || undefined,
+                }));
+              }}
+            />
+            <Typography sx={{ color: "red" }}>{endDateError}</Typography>
+          </>
+        ) : null}
+        {newDelivery.recurrence !== "None" &&
+        newDelivery.recurrence !== "Custom" &&
+        newDelivery.recurrence !== "Monthly-Pattern" ? (
           <>
             <DateField
               label="End Date"

--- a/my-app/src/pages/Calendar/components/CalendarUtils.ts
+++ b/my-app/src/pages/Calendar/components/CalendarUtils.ts
@@ -78,6 +78,9 @@ export const getNextMonthlyDate = (
 };
 
 export const calculateRecurrenceDates = (newDelivery: NewDelivery): string[] => {
+  // Monthly-Pattern has its own generator; this function does not handle it.
+  if (newDelivery.recurrence === "Monthly-Pattern") return [];
+
   const deliveryDateTime = deliveryDate.toDateTime(newDelivery.deliveryDate);
   const endDateTime = newDelivery.repeatsEndDate
     ? deliveryDate.toDateTime(newDelivery.repeatsEndDate)
@@ -93,3 +96,105 @@ export const calculateRecurrenceDates = (newDelivery: NewDelivery): string[] => 
   // Return as local date strings (YYYY-MM-DD)
   return recurrenceDates.map((dt) => TimeUtils.toDateString(dt));
 };
+
+// ── Monthly Recurrence Pattern ────────────────────────────────────────────────
+
+export type WeekPosition = "first" | "second" | "third" | "fourth" | "last";
+export type PatternDayOfWeek =
+  | "monday"
+  | "tuesday"
+  | "wednesday"
+  | "thursday"
+  | "friday"
+  | "saturday"
+  | "sunday";
+
+const DAY_OF_WEEK_INDEX: Record<PatternDayOfWeek, number> = {
+  sunday: 0,
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
+};
+
+/**
+ * Returns the Date for a given weekday occurrence inside a calendar month.
+ * @param year       Full year, e.g. 2026
+ * @param month      0-based month index (0 = January)
+ * @param position   "first" | "second" | "third" | "fourth" | "last"
+ * @param dayIndex   0 = Sunday … 6 = Saturday
+ */
+function getPatternDateInMonth(
+  year: number,
+  month: number,
+  position: WeekPosition,
+  dayIndex: number
+): Date | null {
+  if (position === "last") {
+    // Start from the last day of the month and walk backwards
+    const lastDay = new Date(year, month + 1, 0); // day 0 of next month = last day
+    let d = lastDay.getDate();
+    while (new Date(year, month, d).getDay() !== dayIndex) {
+      d--;
+    }
+    return new Date(year, month, d);
+  }
+
+  // Count up occurrences from the 1st
+  const ordinal = { first: 1, second: 2, third: 3, fourth: 4 }[position];
+  let count = 0;
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  for (let d = 1; d <= daysInMonth; d++) {
+    if (new Date(year, month, d).getDay() === dayIndex) {
+      count++;
+      if (count === ordinal) {
+        return new Date(year, month, d);
+      }
+    }
+  }
+  return null; // shouldn't happen for first–fourth
+}
+
+/**
+ * Generates all dates matching the monthly weekday-position pattern that fall
+ * on or after `startDate` and on or before `endDate` (both inclusive).
+ */
+export function generateMonthlyRecurrencePatternDates({
+  startDate,
+  endDate,
+  weekPosition,
+  dayOfWeek,
+}: {
+  startDate: Date;
+  endDate: Date;
+  weekPosition: WeekPosition;
+  dayOfWeek: PatternDayOfWeek;
+}): Date[] {
+  const dayIndex = DAY_OF_WEEK_INDEX[dayOfWeek];
+  const results: Date[] = [];
+
+  // Normalise to midnight local time so comparisons are date-only
+  const start = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());
+  const end = new Date(endDate.getFullYear(), endDate.getMonth(), endDate.getDate());
+
+  let year = start.getFullYear();
+  let month = start.getMonth();
+  const endYear = end.getFullYear();
+  const endMonth = end.getMonth();
+
+  while (year < endYear || (year === endYear && month <= endMonth)) {
+    const candidate = getPatternDateInMonth(year, month, weekPosition, dayIndex);
+    if (candidate && candidate >= start && candidate <= end) {
+      results.push(candidate);
+    }
+    month++;
+    if (month > 11) {
+      month = 0;
+      year++;
+    }
+  }
+
+  return results;
+}

--- a/my-app/src/pages/Calendar/components/DayView.tsx
+++ b/my-app/src/pages/Calendar/components/DayView.tsx
@@ -31,7 +31,7 @@ const DayView: React.FC<DayViewProps> = React.memo(function DayView({
   const containerRef = useRef<HTMLDivElement>(null);
 
   // Constants for virtual scrolling
-  const DELIVERY_CARD_HEIGHT = 120; // 108px from CSS + margin
+  const DELIVERY_CARD_HEIGHT = 160; // Increased to preserve recurrence date visibility when names wrap
   const VIRTUAL_SCROLL_THRESHOLD = 50; // Use virtual scrolling when more than 50 items
 
   // Memoized client lookup for better performance
@@ -44,6 +44,39 @@ const DayView: React.FC<DayViewProps> = React.memo(function DayView({
     });
     return map;
   }, [clients]);
+
+  const getSortableClientName = useCallback(
+    (event: DeliveryEvent) => {
+      const eventName = (event.clientName || "").trim();
+      if (eventName) {
+        return eventName;
+      }
+
+      const client = clientLookupMap.get(event.clientId);
+      const fullName = `${client?.firstName || ""} ${client?.lastName || ""}`.trim();
+      if (fullName) {
+        return fullName;
+      }
+
+      return event.clientId || "";
+    },
+    [clientLookupMap]
+  );
+
+  const sortedEvents = useMemo(() => {
+    return [...events].sort((a, b) => {
+      const nameCompare = getSortableClientName(a).localeCompare(getSortableClientName(b), undefined, {
+        sensitivity: "base",
+        numeric: true,
+      });
+
+      if (nameCompare !== 0) {
+        return nameCompare;
+      }
+
+      return (a.id || "").localeCompare(b.id || "");
+    });
+  }, [events, getSortableClientName]);
 
   const updateHeight = useCallback(() => {
     if (containerRef.current) {
@@ -111,7 +144,7 @@ const DayView: React.FC<DayViewProps> = React.memo(function DayView({
     >
       <EventCountHeader events={events} limit={dailyLimit} />
 
-      {events.length === 0 ? (
+      {sortedEvents.length === 0 ? (
         <Box
           sx={{
             flex: 1,
@@ -135,9 +168,9 @@ const DayView: React.FC<DayViewProps> = React.memo(function DayView({
             overflow: "hidden",
           }}
         >
-          {events.length > VIRTUAL_SCROLL_THRESHOLD ? (
+          {sortedEvents.length > VIRTUAL_SCROLL_THRESHOLD ? (
             <VirtualScroll
-              items={events}
+              items={sortedEvents}
               itemHeight={DELIVERY_CARD_HEIGHT}
               containerHeight={containerHeight}
               renderItem={renderDeliveryCard}
@@ -151,7 +184,7 @@ const DayView: React.FC<DayViewProps> = React.memo(function DayView({
                 width: "100%",
               }}
             >
-              {events.map((event) => {
+              {sortedEvents.map((event) => {
                 const client = clientLookupMap.get(event.clientId);
                 return (
                   <DeliveryCard

--- a/my-app/src/pages/Calendar/components/DayView.tsx
+++ b/my-app/src/pages/Calendar/components/DayView.tsx
@@ -33,6 +33,7 @@ const DayView: React.FC<DayViewProps> = React.memo(function DayView({
   // Constants for virtual scrolling
   const DELIVERY_CARD_HEIGHT = 160; // Increased to preserve recurrence date visibility when names wrap
   const VIRTUAL_SCROLL_THRESHOLD = 50; // Use virtual scrolling when more than 50 items
+  const INFO_HEADERS = ["PHONE", "ADDRESS", "DIETARY RESTRICTIONS", "TAGS", "NOTES"];
 
   // Memoized client lookup for better performance
   const clientLookupMap = useMemo(() => {
@@ -160,45 +161,97 @@ const DayView: React.FC<DayViewProps> = React.memo(function DayView({
         </Box>
       ) : (
         <Box
-          ref={containerRef}
           sx={{
             flex: 1,
             width: "100%",
             minHeight: 0,
             overflow: "hidden",
+            display: "flex",
+            flexDirection: "column",
           }}
         >
-          {sortedEvents.length > VIRTUAL_SCROLL_THRESHOLD ? (
-            <VirtualScroll
-              items={sortedEvents}
-              itemHeight={DELIVERY_CARD_HEIGHT}
-              containerHeight={containerHeight}
-              renderItem={renderDeliveryCard}
-              overscan={10}
-            />
-          ) : (
+          <Box
+            sx={{
+              px: "var(--spacing-lg)",
+              pr: "3.5rem",
+              pb: 0.75,
+              display: "flex",
+              alignItems: "center",
+              borderBottom: "1px solid var(--color-divider)",
+              flexShrink: 0,
+              backgroundColor: "var(--color-background-main)",
+            }}
+          >
+            <Box sx={{ flex: "0 0 calc(220px + var(--spacing-lg))" }} />
+            <Box sx={{ width: "2px", alignSelf: "stretch", mr: "var(--spacing-lg)" }} />
             <Box
               sx={{
-                height: "100%",
-                overflowY: "scroll",
+                display: "grid",
+                gridTemplateColumns: "repeat(5, minmax(0, 1fr))",
+                alignItems: "start",
+                gap: "24px",
                 width: "100%",
+                minWidth: 0,
               }}
             >
-              {sortedEvents.map((event) => {
-                const client = clientLookupMap.get(event.clientId);
-                return (
-                  <DeliveryCard
-                    key={event.id}
-                    event={event}
-                    client={client}
-                    onEventModified={onEventModified}
-                    weeklyLimits={weeklyLimits}
-                    dailyLimits={dailyLimits}
-                  />
-                );
-              })}
+              {INFO_HEADERS.map((header) => (
+                <Typography
+                  key={header}
+                  variant="subtitle2"
+                  sx={{
+                    fontWeight: 700,
+                    fontSize: "0.75rem",
+                    letterSpacing: "0.04em",
+                    color: "var(--color-text-tertiary)",
+                  }}
+                >
+                  {header}
+                </Typography>
+              ))}
             </Box>
-          )}
+          </Box>
+
+          <Box
+            ref={containerRef}
+            sx={{
+              flex: 1,
+              minHeight: 0,
+              width: "100%",
+              overflow: "hidden",
+            }}
+          >
+            {sortedEvents.length > VIRTUAL_SCROLL_THRESHOLD ? (
+              <VirtualScroll
+                items={sortedEvents}
+                itemHeight={DELIVERY_CARD_HEIGHT}
+                containerHeight={containerHeight}
+                renderItem={renderDeliveryCard}
+                overscan={10}
+              />
+            ) : (
+              <Box
+                sx={{
+                  height: "100%",
+                  overflowY: "scroll",
+                  width: "100%",
+                }}
+              >
+                {sortedEvents.map((event) => {
+                  const client = clientLookupMap.get(event.clientId);
+                  return (
+                    <DeliveryCard
+                      key={event.id}
+                      event={event}
+                      client={client}
+                      onEventModified={onEventModified}
+                      weeklyLimits={weeklyLimits}
+                      dailyLimits={dailyLimits}
+                    />
+                  );
+                })}
+              </Box>
+            )}
+          </Box>
         </Box>
       )}
     </Box>

--- a/my-app/src/pages/Calendar/components/DeliveryCard.module.css
+++ b/my-app/src/pages/Calendar/components/DeliveryCard.module.css
@@ -9,19 +9,25 @@
   background-color: var(--color-background-accent);
   width: 100%;
   box-sizing: border-box;
+  min-height: 152px;
 }
 
 .clientSection {
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
+  justify-content: flex-start;
+  align-items: flex-start;
   margin-right: var(--spacing-lg);
+  flex: 0 0 220px;
   width: 220px;
-  min-width: 180px;
-  max-width: 280px;
   box-sizing: border-box;
-  flex-shrink: 1;
+  min-height: 0;
+}
+
+.clientSectionContent {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
 }
 
 .clientName {
@@ -83,7 +89,7 @@
 }
 
 .infoValue {
-  font-weight: bold;
+  font-weight: 400;
   color: var(--color-text-secondary);
 }
 
@@ -105,14 +111,26 @@
   color: var(--color-primary-darker);
   text-decoration: underline;
   font-weight: 600;
-  font-size: 1.25rem;
+  font-size: 1.15rem;
+  line-height: 1.2;
   cursor: pointer;
+  display: block;
+  flex: 1;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .clientNameRow {
-  display: flex;
-  align-items: center;
-  gap: 6px;
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  align-items: start;
+  column-gap: 6px;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
 }
 
 .clientStatusIcon {
@@ -126,8 +144,8 @@
 
 .deliveryTypeIndicator {
   font-weight: 700;
-  font-size: 1.1rem;
-  margin-top: 0.5rem;
+  font-size: 1rem;
+  margin-top: 0.25rem;
 }
 
 .weekly {

--- a/my-app/src/pages/Calendar/components/DeliveryCard.module.css
+++ b/my-app/src/pages/Calendar/components/DeliveryCard.module.css
@@ -68,18 +68,15 @@
 }
 
 .infoContainer {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  align-items: start;
   width: 100%;
-  gap: 30px;
+  gap: 24px;
 }
 
 .infoItem {
-  display: flex;
-  flex-direction: column;
-  margin-left: var(--spacing-sm);
-  width: 150px;
+  min-width: 0;
 }
 
 .infoLabel {

--- a/my-app/src/pages/Calendar/components/DeliveryCard.tsx
+++ b/my-app/src/pages/Calendar/components/DeliveryCard.tsx
@@ -65,7 +65,7 @@ const DeliveryCard: React.FC<DeliveryCardProps> = React.memo(function DeliveryCa
       }}
     >
       <Box className={styles.clientSection}>
-        <Box>
+        <Box className={styles.clientSectionContent}>
           <Box className={styles.clientNameRow}>
             <span
               title={statusPresentation.tooltip}
@@ -90,11 +90,14 @@ const DeliveryCard: React.FC<DeliveryCardProps> = React.memo(function DeliveryCa
               className={styles.clientNameLink}
               aria-label={`View profile for ${event.clientName}`}
               onClick={(e) => e.stopPropagation()}
+               title={event.clientName}
             >
               {event.clientName}
             </Typography>
           </Box>
-          <DeliveryRecurrenceDisplay event={event} />
+          <Box sx={{ pl: "24px" }}>
+            <DeliveryRecurrenceDisplay event={event} />
+          </Box>
         </Box>
       </Box>
 

--- a/my-app/src/pages/Calendar/components/DeliveryCard.tsx
+++ b/my-app/src/pages/Calendar/components/DeliveryCard.tsx
@@ -106,38 +106,35 @@ const DeliveryCard: React.FC<DeliveryCardProps> = React.memo(function DeliveryCa
       <Box className={styles.infoContainer}>
         {[
           {
-            label: "PHONE",
+            key: "phone",
             value: client?.phone ? formatPhoneNumber(client.phone) : "N/A",
           },
           {
-            label: "ADDRESS",
+            key: "address",
             value: client
               ? `${client.address}${client.address2 ? " " + client.address2 : ""}`
               : "N/A",
           },
           {
-            label: "DIETARY RESTRICTIONS",
+            key: "dietary",
             value: dietaryRestrictions.length ? dietaryRestrictions.join(", ") : "N/A",
           },
           {
-            label: "TAGS",
+            key: "tags",
             value: client?.tags?.length ? client.tags.join(", ") : "N/A",
           },
           {
-            label: "NOTES",
+            key: "notes",
             value: client?.notes || "N/A",
           },
-        ].map(({ label, value }) => (
-          <Box key={label} className={styles.infoItem}>
-            <Typography variant="subtitle2" className={styles.infoLabel}>
-              {label}
-            </Typography>
+        ].map(({ key, value }) => (
+          <Box key={key} className={styles.infoItem}>
             <Typography
               variant="body1"
               className={`${styles.infoValue} ${
-                label === "NOTES"
+                key === "notes"
                   ? styles.truncatedNotes
-                  : label === "DIETARY RESTRICTIONS"
+                  : key === "dietary"
                     ? styles.truncatedDiet
                     : ""
               }`}

--- a/my-app/src/pages/Calendar/components/DeliveryRecurrenceDisplay.tsx
+++ b/my-app/src/pages/Calendar/components/DeliveryRecurrenceDisplay.tsx
@@ -15,6 +15,8 @@ const getDeliveryTypeInfo = (recurrence: string) => {
       return { label: "2x-MONTHLY DELIVERY", className: styles.twoXMonthly };
     case "Monthly":
       return { label: "MONTHLY DELIVERY", className: styles.monthly };
+    case "Monthly-Pattern":
+      return { label: "MONTHLY PATTERN DELIVERY", className: styles.monthly };
     case "Custom":
       return { label: "CUSTOM DELIVERY", className: styles.custom };
     default:

--- a/my-app/src/pages/Calendar/components/EventMenu.tsx
+++ b/my-app/src/pages/Calendar/components/EventMenu.tsx
@@ -47,7 +47,10 @@ const EventMenu: React.FC<EventMenuProps> = ({
   dailyLimits,
 }) => {
   const deliveryService = useMemo(() => DeliveryService.getInstance(), []);
-  const supportsFutureDelete = event.recurrence !== "None" && Boolean(event.recurrenceId);
+  const supportsFutureDelete =
+    event.recurrence !== "None" &&
+    event.recurrence !== "Monthly-Pattern" &&
+    Boolean(event.recurrenceId);
   const supportsFutureEdit = supportsFutureDelete && event.recurrence !== "Custom";
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);

--- a/my-app/src/pages/Calendar/components/monthlyRecurrencePattern.test.ts
+++ b/my-app/src/pages/Calendar/components/monthlyRecurrencePattern.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "@jest/globals";
+import { generateMonthlyRecurrencePatternDates } from "./CalendarUtils";
+
+const iso = (d: Date) => {
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${d.getFullYear()}-${mm}-${dd}`;
+};
+
+describe("generateMonthlyRecurrencePatternDates", () => {
+  it("generates Third Friday dates from spec example", () => {
+    const results = generateMonthlyRecurrencePatternDates({
+      startDate: new Date(2026, 4, 1),  // 2026-05-01
+      endDate:   new Date(2026, 9, 16), // 2026-10-16
+      weekPosition: "third",
+      dayOfWeek: "friday",
+    }).map(iso);
+
+    expect(results).toEqual([
+      "2026-05-15",
+      "2026-06-19",
+      "2026-07-17",
+      "2026-08-21",
+      "2026-09-18",
+      "2026-10-16",
+    ]);
+  });
+
+  it("includes end date when it exactly matches the pattern", () => {
+    // Third Friday of October 2026 is 10/16/2026 — endDate matches exactly
+    const results = generateMonthlyRecurrencePatternDates({
+      startDate: new Date(2026, 9, 1),
+      endDate:   new Date(2026, 9, 16),
+      weekPosition: "third",
+      dayOfWeek: "friday",
+    }).map(iso);
+
+    expect(results).toContain("2026-10-16");
+  });
+
+  it("excludes dates before startDate", () => {
+    // First Monday of May 2026 is 05/04/2026; start is 05/05 so it should be skipped
+    const results = generateMonthlyRecurrencePatternDates({
+      startDate: new Date(2026, 4, 5),
+      endDate:   new Date(2026, 5, 30),
+      weekPosition: "first",
+      dayOfWeek: "monday",
+    }).map(iso);
+
+    expect(results).not.toContain("2026-05-04");
+    expect(results).toContain("2026-06-01");
+  });
+
+  it("finds the last Friday of each month", () => {
+    const results = generateMonthlyRecurrencePatternDates({
+      startDate: new Date(2026, 0, 1),
+      endDate:   new Date(2026, 2, 31),
+      weekPosition: "last",
+      dayOfWeek: "friday",
+    }).map(iso);
+
+    // Last Friday Jan 2026 = 30th, Feb = 27th, Mar = 27th
+    expect(results).toEqual(["2026-01-30", "2026-02-27", "2026-03-27"]);
+  });
+
+  it("returns empty array when no dates fall in range", () => {
+    const results = generateMonthlyRecurrencePatternDates({
+      startDate: new Date(2026, 4, 16), // after 3rd Friday of May (15th)
+      endDate:   new Date(2026, 4, 20), // before any next occurrence
+      weekPosition: "third",
+      dayOfWeek: "friday",
+    });
+
+    expect(results).toHaveLength(0);
+  });
+});

--- a/my-app/src/pages/Delivery/ClusterMap.tsx
+++ b/my-app/src/pages/Delivery/ClusterMap.tsx
@@ -1367,6 +1367,7 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
             const bringToFront = () => {
               topPopupZIndexRef.current += 1;
               popupWrapper.style.zIndex = String(topPopupZIndexRef.current);
+              (window as any).scrollToSpreadsheetRow?.(client.id);
             };
             popupWrapper.addEventListener("mousedown", bringToFront);
             // Clean up listener when popup closes

--- a/my-app/src/pages/Delivery/ClusterMap.tsx
+++ b/my-app/src/pages/Delivery/ClusterMap.tsx
@@ -85,7 +85,7 @@ interface ClusterMapProps {
   onRenumberClusters?: () => Promise<boolean>;
   onOpenPopup?: (clientId: string) => void; // Prop to handle table row clicks
   onMarkerClick?: (clientId: string) => void; // Prop to handle marker clicks
-  onClearHighlight?: () => void; // Prop to clear row highlighting
+  onClearHighlight?: (clientId?: string) => void; // Prop to clear row highlighting
   refreshDriversTrigger?: number; // Optional prop to trigger driver refresh
 }
 
@@ -250,6 +250,8 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
   const markersMapRef = useRef<Map<string, L.Marker>>(new Map()); // Store markers by client ID
   const previousVisibleRowsKeyRef = useRef<string>("");
   const isPopupOpening = useRef<boolean>(false); // Prevent close handler from firing during opening
+  const isOpeningFromTableRef = useRef<boolean>(false); // True when popup is opened via table row click
+  const topPopupZIndexRef = useRef<number>(700); // Base Leaflet popup z-index is ~700
   const clustersRef = useRef<Cluster[]>(clusters);
 
   const scheduleClusterMapTimeout = useCallback((callback: () => void, delay = 0) => {
@@ -787,17 +789,24 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
       markerGroupRef.current = L.featureGroup().addTo(mapRef.current);
 
       if (!popupCloseHandlerRef.current) {
-        popupCloseHandlerRef.current = () => {
+        popupCloseHandlerRef.current = (e: L.LeafletEvent) => {
           if (!isMapAliveRef.current || isPopupOpening.current) {
             return;
           }
+
+          const popup = (e as L.PopupEvent).popup;
+          const contentEl = popup.getElement();
+          const clientId =
+            contentEl
+              ?.querySelector("[data-client-id]")
+              ?.getAttribute("data-client-id") ?? undefined;
 
           scheduleClusterMapTimeout(() => {
             if (!isMapAliveRef.current || isPopupOpening.current) {
               return;
             }
 
-            onClearHighlightRef.current?.();
+            onClearHighlightRef.current?.(clientId);
           }, 200);
         };
       }
@@ -823,6 +832,8 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
       (window as any).openMapPopup = (clientId: string) => {
         // Suppress popupclose clearing while we open the new popup (same as marker clicks)
         isPopupOpening.current = true;
+        // Flag so popupopen knows not to highlight the row (table click already did it)
+        isOpeningFromTableRef.current = true;
 
         const marker = markersMapRef.current.get(clientId);
         if (marker) {
@@ -832,14 +843,22 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
         // Reset after the open sequence completes so future closes clear the row
         scheduleClusterMapTimeout(() => {
           isPopupOpening.current = false;
+          isOpeningFromTableRef.current = false;
         }, 350);
       };
 
       // Also set up the close popup function
-      (window as any).closeMapPopup = () => {
-        withLiveMap((map) => {
-          map.closePopup();
-        });
+      (window as any).closeMapPopup = (clientId?: string) => {
+        if (clientId) {
+          const marker = markersMapRef.current.get(clientId);
+          if (marker) {
+            marker.closePopup();
+          }
+        } else {
+          withLiveMap((map) => {
+            map.closePopup();
+          });
+        }
       };
 
       // Set up function to clear row highlighting
@@ -1332,15 +1351,35 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
         .on("click", () => {
           isPopupOpening.current = true;
           marker.openPopup();
-
-          if (onMarkerClickRef.current) {
-            onMarkerClickRef.current(client.id);
-          }
+          // Row highlight is triggered from popupopen to guarantee popup ↔ row sync
         })
-        .on("popupopen", () => {
+        .on("popupopen", (e: L.LeafletEvent) => {
           scheduleClusterMapTimeout(() => {
             isPopupOpening.current = false;
           }, 350);
+
+          // Bring this popup to the front when clicked
+          const popupWrapper = (e as L.PopupEvent).popup.getElement();
+          if (popupWrapper) {
+            topPopupZIndexRef.current += 1;
+            popupWrapper.style.zIndex = String(topPopupZIndexRef.current);
+
+            const bringToFront = () => {
+              topPopupZIndexRef.current += 1;
+              popupWrapper.style.zIndex = String(topPopupZIndexRef.current);
+            };
+            popupWrapper.addEventListener("mousedown", bringToFront);
+            // Clean up listener when popup closes
+            marker.once("popupclose", () => {
+              popupWrapper.removeEventListener("mousedown", bringToFront);
+            });
+          }
+
+          // Sync row highlight from popup open (not from marker click) so they always match.
+          // Skip when opened by a table row click — the table already highlighted the row.
+          if (!isOpeningFromTableRef.current && onMarkerClickRef.current) {
+            onMarkerClickRef.current(client.id);
+          }
         })
         .on("popupclose", () => {
           isPopupOpening.current = false;

--- a/my-app/src/pages/Delivery/ClusterMap.tsx
+++ b/my-app/src/pages/Delivery/ClusterMap.tsx
@@ -251,6 +251,7 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
   const previousVisibleRowsKeyRef = useRef<string>("");
   const isPopupOpening = useRef<boolean>(false); // Prevent close handler from firing during opening
   const isOpeningFromTableRef = useRef<boolean>(false); // True when popup is opened via table row click
+  const suppressedPopupClientIdsRef = useRef<Set<string>>(new Set());
   const topPopupZIndexRef = useRef<number>(700); // Base Leaflet popup z-index is ~700
   const clustersRef = useRef<Cluster[]>(clusters);
 
@@ -801,6 +802,10 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
               ?.querySelector("[data-client-id]")
               ?.getAttribute("data-client-id") ?? undefined;
 
+          if (clientId && suppressedPopupClientIdsRef.current.has(clientId)) {
+            return;
+          }
+
           scheduleClusterMapTimeout(() => {
             if (!isMapAliveRef.current || isPopupOpening.current) {
               return;
@@ -887,6 +892,21 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
   useEffect(() => {
     if (!mapRef.current || !markerGroupRef.current || !isMapAliveRef.current) return;
 
+    // Find which client's popup is currently open before we destroy the markers.
+    // We'll re-open it after rebuilding so the highlight is preserved.
+    // Find all clients whose popups are open before we destroy markers.
+    // Multiple rows can be highlighted simultaneously, each with an open popup.
+    const clientIdsToReopen: string[] = [];
+    markersMapRef.current.forEach((marker, clientId) => {
+      if (marker.isPopupOpen()) {
+        clientIdsToReopen.push(clientId);
+      }
+    });
+
+    // Suppress the map-level popupclose handler while we programmatically
+    // close popups and clear layers — this prevents clearRowHighlight from firing.
+    isPopupOpening.current = true;
+
     withLiveMap((map) => {
       map.stop();
       map.closePopup();
@@ -899,6 +919,7 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
 
     if (visibleRows.length < 1) {
       previousVisibleRowsKeyRef.current = "";
+      isPopupOpening.current = false;
       return;
     }
 
@@ -1378,11 +1399,18 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
 
           // Sync row highlight from popup open (not from marker click) so they always match.
           // Skip when opened by a table row click — the table already highlighted the row.
-          if (!isOpeningFromTableRef.current && onMarkerClickRef.current) {
+          if (
+            !isOpeningFromTableRef.current &&
+            !suppressedPopupClientIdsRef.current.has(client.id) &&
+            onMarkerClickRef.current
+          ) {
             onMarkerClickRef.current(client.id);
           }
         })
         .on("popupclose", () => {
+          if (suppressedPopupClientIdsRef.current.has(client.id)) {
+            return;
+          }
           isPopupOpening.current = false;
         })
         .addTo(markerGroupRef.current!);
@@ -1430,6 +1458,28 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
         });
       });
       previousVisibleRowsKeyRef.current = visibleRowsKey;
+    }
+
+    // Re-open the popup that was open before the rebuild (if any).
+    // Set isOpeningFromTableRef so popupopen doesn't double-add the highlight.
+    // Re-open all popups that were open before the rebuild.
+    // Suppress popupclose/popupopen side effects for these client IDs during restoration.
+    if (clientIdsToReopen.length > 0) {
+      suppressedPopupClientIdsRef.current = new Set(clientIdsToReopen);
+      isOpeningFromTableRef.current = true;
+      clientIdsToReopen.forEach((id) => {
+        const markerToReopen = markersMapRef.current.get(id);
+        if (markerToReopen) {
+          markerToReopen.openPopup();
+        }
+      });
+      scheduleClusterMapTimeout(() => {
+        isPopupOpening.current = false;
+        isOpeningFromTableRef.current = false;
+        suppressedPopupClientIdsRef.current.clear();
+      }, 350);
+    } else {
+      isPopupOpening.current = false;
     }
   }, [
     visibleRows,

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.searchAliases.test.ts
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.searchAliases.test.ts
@@ -21,9 +21,17 @@ describe("DeliverySpreadsheet search alias regression guards", () => {
   });
 
   it("normalizes custom column aliases for visible-field matching", () => {
-    expect(source).toMatch(
-      /customColumnMappings[\s\S]*aliases\.some\(\(alias\) => normalizeSearchKeyword\(alias\) === normalizedKeyword\)/
-    );
+    expect(source).toContain("routeCustomColumnMappings");
+    expect(source).toContain("aliases.some((alias) => normalizeSearchKeyword(alias) === normalizedKeyword)");
+    expect(source).toContain('"deliveryDetails.dietaryRestrictions.dietaryPreferences": ["dietary preferences"]');
+    expect(source).toContain('famStartDate: ["family start date"]');
+  });
+
+  it("keeps delivery autocomplete suggestions aligned with visible header labels", () => {
+    expect(source).toContain("const tableFieldLabels = fields");
+    expect(source).toContain("const visibleCustomFieldLabels = customColumns");
+    expect(source).toContain("return Array.from(new Set([...tableFieldLabels, ...visibleCustomFieldLabels]));");
+    expect(source).toContain('"deliveryDetails.dietaryRestrictions": ["dietary restrictions", "dietary"]');
   });
 
   it("bulk reassigns all checked rows when changing the route dropdown for a selected cluster", () => {

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.searchAliases.test.ts
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.searchAliases.test.ts
@@ -68,4 +68,10 @@ describe("DeliverySpreadsheet search alias regression guards", () => {
     expect(source).toContain("Showing {sortedRows.length} filtered ");
     expect(source).toContain("of {rows.length}");
   });
+
+  it("shows semicolon-delimited filter guidance in the search placeholder", () => {
+    expect(source).toContain(
+      'placeholder=\'Search deliveries (use ; between filters, e.g., cluster:1,2; ward:7; driver:maria; name:"john smith")\''
+    );
+  });
 });

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.searchAliases.test.ts
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.searchAliases.test.ts
@@ -27,7 +27,8 @@ describe("DeliverySpreadsheet search alias regression guards", () => {
     expect(source).toContain('famStartDate: ["fam start date", "family start date"]');
     expect(source).toContain('famStartDate: "Fam Start Date"');
     expect(source).toContain('case "famstartdate":');
-    expect(source).toContain('deliveryDate.tryToISODateString(candidate)');
+    expect(source).toContain("deliveryDate.tryToDateTime(candidate)");
+    expect(source).toContain("deliveryDate.toDisplayString(normalizedRowDate)");
   });
 
   it("keeps delivery autocomplete suggestions aligned with visible header labels", () => {

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.searchAliases.test.ts
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.searchAliases.test.ts
@@ -24,7 +24,10 @@ describe("DeliverySpreadsheet search alias regression guards", () => {
     expect(source).toContain("routeCustomColumnMappings");
     expect(source).toContain("aliases.some((alias) => normalizeSearchKeyword(alias) === normalizedKeyword)");
     expect(source).toContain('"deliveryDetails.dietaryRestrictions.dietaryPreferences": ["dietary preferences"]');
-    expect(source).toContain('famStartDate: ["family start date"]');
+    expect(source).toContain('famStartDate: ["fam start date", "family start date"]');
+    expect(source).toContain('famStartDate: "Fam Start Date"');
+    expect(source).toContain('case "famstartdate":');
+    expect(source).toContain('deliveryDate.tryToISODateString(candidate)');
   });
 
   it("keeps delivery autocomplete suggestions aligned with visible header labels", () => {

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.searchAliases.test.ts
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.searchAliases.test.ts
@@ -65,6 +65,12 @@ describe("DeliverySpreadsheet search alias regression guards", () => {
     );
   });
 
+  it("clears checked rows when the delivery search X button is clicked", () => {
+    expect(source).toMatch(
+      /aria-label="Clear delivery search"[\s\S]*setSearchQuery\(""\);[\s\S]*setSelectedRows\(new Set\(\)\);[\s\S]*setSelectedClusters\(new Set\(\)\);/
+    );
+  });
+
   it("preserves empty source clusters after moving all deliveries to a new route", () => {
     expect(source).not.toContain("if (!normalizedClusterId || normalizedDeliveries.length === 0)");
     expect(source).toContain("if (!normalizedClusterId) {");

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -568,6 +568,8 @@ const DeliverySpreadsheet: React.FC = () => {
   const selectRefs = React.useRef<{ [key: string]: HTMLInputElement | null }>({});
   // Ref for TableVirtuoso to enable scrolling to specific rows
   const virtuosoRef = React.useRef<TableVirtuosoHandle>(null);
+  // Kept current so window.scrollToSpreadsheetRow never captures a stale closure
+  const sortedRowsRef = React.useRef<typeof sortedRows>([]);
   // Workaround for opening modal after Select closes (track row id)
   const [pendingOpenAddClusterModalRow, setPendingOpenAddClusterModalRow] = useState<string | null>(
     null
@@ -2494,6 +2496,29 @@ const DeliverySpreadsheet: React.FC = () => {
 
     return sorted;
   }, [visibleRows, sortOrder, sortedColumn, clusters, customColumns, clientOverrides]);
+
+  // Keep ref current so window.scrollToSpreadsheetRow never captures a stale closure
+  sortedRowsRef.current = sortedRows;
+
+  // Expose a scroll-only function for use by the map (e.g. bring-to-front clicks)
+  useEffect(() => {
+    (window as any).scrollToSpreadsheetRow = (clientId: string) => {
+      if (!virtuosoRef.current) return;
+      const rowIndex = sortedRowsRef.current.findIndex((row) => row.id === clientId);
+      if (rowIndex !== -1) {
+        setTimeout(() => {
+          virtuosoRef.current?.scrollToIndex({
+            index: rowIndex,
+            align: "center",
+            behavior: "smooth",
+          });
+        }, 100);
+      }
+    };
+    return () => {
+      delete (window as any).scrollToSpreadsheetRow;
+    };
+  }, []);
 
   const selectedExportRows = useMemo(
     () => rows.filter((row) => selectedRows.has(row.id)),

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -668,25 +668,6 @@ const DeliverySpreadsheet: React.FC = () => {
   const [rows, setRows] = useState<DeliveryRowData[]>([]);
   const [rawClientData, setRawClientData] = useState<DeliveryRowData[]>([]);
   const [searchQuery, setSearchQuery] = useState<string>("");
-  const routeSearchKeySuggestions = useMemo(() => {
-    const tableFieldLabels = fields
-      .map((field) => field.label)
-      .filter((label) => Boolean(label))
-      .map((label) => label.toLowerCase());
-
-    const visibleCustomFieldLabels = customColumns
-      .map((column) => column.propertyKey)
-      .filter((propertyKey) => propertyKey !== "none")
-      .map((propertyKey) => addablePropertyKeyLabelMap[propertyKey] ?? propertyKey)
-      .map((label) => label.toLowerCase());
-
-    return Array.from(new Set([...tableFieldLabels, ...visibleCustomFieldLabels]));
-  }, [customColumns]);
-  const searchAutocomplete = useSearchKeyAutocomplete({
-    value: searchQuery,
-    onValueChange: setSearchQuery,
-    suggestions: routeSearchKeySuggestions,
-  });
   const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
 
   const [popupMode, setPopupMode] = useState("");
@@ -906,6 +887,26 @@ const DeliverySpreadsheet: React.FC = () => {
     handleCustomHeaderChange,
     handleRemoveCustomColumn,
   } = useCustomColumns({ page: "DeliverySpreadsheet" });
+
+  const routeSearchKeySuggestions = useMemo(() => {
+    const tableFieldLabels = fields
+      .map((field) => field.label)
+      .filter((label) => Boolean(label))
+      .map((label) => label.toLowerCase());
+
+    const visibleCustomFieldLabels = customColumns
+      .map((column) => column.propertyKey)
+      .filter((propertyKey) => propertyKey !== "none")
+      .map((propertyKey) => addablePropertyKeyLabelMap[propertyKey] ?? propertyKey)
+      .map((label) => label.toLowerCase());
+
+    return Array.from(new Set([...tableFieldLabels, ...visibleCustomFieldLabels]));
+  }, [customColumns]);
+  const searchAutocomplete = useSearchKeyAutocomplete({
+    value: searchQuery,
+    onValueChange: setSearchQuery,
+    suggestions: routeSearchKeySuggestions,
+  });
 
   // Function to trigger driver refresh across components
   const triggerDriverRefresh = () => {

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -648,7 +648,34 @@ const DeliverySpreadsheet: React.FC = () => {
       .map((propertyKey) => addablePropertyKeyLabelMap[propertyKey] ?? propertyKey)
       .map((label) => label.toLowerCase());
 
-    return Array.from(new Set([...tableFieldLabels, ...addableFieldLabels]));
+    const routeFilterAliases = [
+      "name",
+      "first name",
+      "last name",
+      "cluster id",
+      "route id",
+      "ward",
+      "driver",
+      "assigned driver",
+      "time",
+      "assigned time",
+      "delivery instructions",
+      "instructions",
+      "delivery freq",
+      "delivery frequency",
+      "tags",
+      "tag",
+      "zip",
+      "zip code",
+      "zipcode",
+      "referral",
+      "referral entity",
+      "tefap",
+      "tefap cert",
+      "tefapcert",
+    ];
+
+    return Array.from(new Set([...tableFieldLabels, ...addableFieldLabels, ...routeFilterAliases]));
   }, []);
   const searchAutocomplete = useSearchKeyAutocomplete({
     value: searchQuery,

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -39,6 +39,7 @@ import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import ArrowDropUpIcon from "@mui/icons-material/ArrowDropUp";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CancelIcon from "@mui/icons-material/Cancel";
+import ClearIcon from "@mui/icons-material/Clear";
 import DeleteIcon from "@mui/icons-material/Delete";
 import AssignmentIndIcon from "@mui/icons-material/AssignmentInd";
 import AccessTimeIcon from "@mui/icons-material/AccessTime";
@@ -3055,7 +3056,7 @@ const DeliverySpreadsheet: React.FC = () => {
                   lineHeight: 1,
                 }}
               >
-                x
+                <ClearIcon fontSize="small" />
               </button>
             )}
           </Box>

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -2587,6 +2587,25 @@ const DeliverySpreadsheet: React.FC = () => {
     () => rows.filter((row) => selectedRows.has(row.id)),
     [rows, selectedRows]
   );
+  const selectedRouteAssignment = useMemo(() => {
+    const selectedRouteIds = Array.from(selectedClusters)
+      .map((cluster) => normalizeClusterIdValue(cluster?.id))
+      .filter((routeId): routeId is string => Boolean(routeId));
+
+    if (selectedRouteIds.length !== 1) {
+      return { driverName: "", time: "" };
+    }
+
+    const selectedRouteId = selectedRouteIds[0];
+    const selectedCluster = clusters.find(
+      (candidateCluster) => normalizeClusterIdValue(candidateCluster.id) === selectedRouteId
+    );
+
+    return {
+      driverName: normalizeDriverAssignmentValue(selectedCluster?.driver) ?? "",
+      time: normalizeAssignmentValue(selectedCluster?.time) ?? "",
+    };
+  }, [clusters, selectedClusters]);
   const hasActiveRouteFilter = searchQuery.trim() !== "";
   const defaultExportScope: RouteExportScope =
     selectedExportRows.length > 0 ? "selected" : hasActiveRouteFilter ? "visible" : "all";
@@ -4129,6 +4148,8 @@ const DeliverySpreadsheet: React.FC = () => {
           <AssignDriverPopup
             assignDriverAndTime={assignDriverAndTime}
             setPopupMode={setPopupMode}
+            initialDriverName={selectedRouteAssignment.driverName}
+            initialTime={selectedRouteAssignment.time}
             onDriversUpdated={triggerDriverRefresh}
           />
         </DialogContent>

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -8,6 +8,7 @@ import { useAuth } from "../../auth/AuthProvider";
 import EventCountHeader from "../../components/EventCountHeader";
 import { useLimits } from "../Calendar/components/useLimits";
 import React, { useState, useEffect, useMemo, Suspense } from "react";
+import { useSearchKeyAutocomplete } from "../../hooks/useSearchKeyAutocomplete";
 import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
 import { getEventsByViewType } from "../Calendar/components/getEventsByViewType";
 import CircularProgress from "@mui/material/CircularProgress";
@@ -25,6 +26,7 @@ import {
   checkStringEquals as utilCheckStringEquals,
   extractKeyValue,
   globalSearchMatch,
+  isNoneSearchToken,
   normalizeSearchKeyword,
   splitFilterValues,
 } from "../../utils/searchFilter";
@@ -419,6 +421,26 @@ const formatDriverNameList = (driverNames: string[]): string => {
   return `${firstName}, ${secondName}, and ${remainingNames.length} others`;
 };
 
+const addablePropertyKeyLabelMap: Record<string, string> = {
+  address: "Address",
+  adults: "Adults",
+  children: "Children",
+  famStartDate: "Family Start Date",
+  deliveryFreq: "Delivery Frequency",
+  "deliveryDetails.dietaryRestrictions": "Dietary Restrictions",
+  "deliveryDetails.dietaryRestrictions.dietaryPreferences": "Dietary Preferences",
+  ethnicity: "Ethnicity",
+  gender: "Gender",
+  language: "Language",
+  notes: "Notes",
+  phone: "Phone",
+  referralEntity: "Referral Entity",
+  tags: "Tags",
+  tefapCert: "TEFAP Cert",
+  dob: "DOB",
+  lastDeliveryDate: "Last Delivery Date",
+};
+
 const formatClusterDriverReplacementWarning = (
   routeIds: string[],
   incomingDriverName: string,
@@ -615,30 +637,24 @@ const DeliverySpreadsheet: React.FC = () => {
   const [rows, setRows] = useState<DeliveryRowData[]>([]);
   const [rawClientData, setRawClientData] = useState<DeliveryRowData[]>([]);
   const [searchQuery, setSearchQuery] = useState<string>("");
-  const routeSearchKeySuggestions = useMemo(
-    () =>
-      [
-        "name",
-        "client",
-        "route",
-        "route id",
-        "cluster",
-        "cluster id",
-        "driver",
-        "assigned driver",
-        "time",
-        "assigned time",
-        "ward",
-        "zip",
-        "zip code",
-        "address",
-        "delivery instructions",
-        "tags",
-        "phone",
-        "dietary restrictions",
-      ].map((key) => `${key}:`),
-    []
-  );
+  const routeSearchKeySuggestions = useMemo(() => {
+    const tableFieldLabels = fields
+      .map((field) => field.label)
+      .filter((label) => Boolean(label))
+      .map((label) => label.toLowerCase());
+
+    const addableFieldLabels = allowedPropertyKeys
+      .filter((propertyKey) => propertyKey !== "none")
+      .map((propertyKey) => addablePropertyKeyLabelMap[propertyKey] ?? propertyKey)
+      .map((label) => label.toLowerCase());
+
+    return Array.from(new Set([...tableFieldLabels, ...addableFieldLabels]));
+  }, []);
+  const searchAutocomplete = useSearchKeyAutocomplete({
+    value: searchQuery,
+    onValueChange: setSearchQuery,
+    suggestions: routeSearchKeySuggestions,
+  });
   const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
 
   const [popupMode, setPopupMode] = useState("");
@@ -2001,11 +2017,11 @@ const DeliverySpreadsheet: React.FC = () => {
           query: string,
           exactMatch = false
         ): boolean => {
-          if (value === undefined || value === null) {
-            return false;
-          }
-
           if (Array.isArray(value)) {
+            if (value.length === 0 && isNoneSearchToken(query)) {
+              return true;
+            }
+
             return value.some((item) =>
               exactMatch ? checkStringEquals(item, query) : checkStringContains(item, query)
             );
@@ -2200,7 +2216,7 @@ const DeliverySpreadsheet: React.FC = () => {
                       checkStringContains(row.referralEntity.organization, candidate)
                   );
                 }
-                return false;
+                return matchesAnySearchValue((candidate) => isNoneSearchToken(candidate));
               }
               default: {
                 const matchesCustomColumn = customColumns.some((col) => {
@@ -2209,11 +2225,13 @@ const DeliverySpreadsheet: React.FC = () => {
                     normalizeSearchKeyword(col.propertyKey).includes(normalizedKeyword)
                   ) {
                     const fieldValue = getNestedPropertyValue(row, col.propertyKey);
-                    if (fieldValue !== undefined) {
-                      return matchesAnySearchValue((candidate) =>
-                        checkStringContains(fieldValue, candidate)
-                      );
+                    if (fieldValue === undefined) {
+                      return matchesAnySearchValue((candidate) => isNoneSearchToken(candidate));
                     }
+
+                    return matchesAnySearchValue((candidate) =>
+                      checkStringContains(fieldValue, candidate)
+                    );
                   }
                   return false;
                 });
@@ -2976,11 +2994,16 @@ const DeliverySpreadsheet: React.FC = () => {
         <Box sx={{ display: "flex", flexDirection: "column", gap: "8px" }}>
           <Box sx={{ position: "relative", width: "100%" }}>
             <input
+              ref={searchAutocomplete.inputRef}
               type="text"
               value={searchQuery}
-              onChange={handleSearchChange}
-              list="route-search-key-suggestions"
-              placeholder='Search deliveries (e.g., cluster:1,2, ward:7, driver:maria, name:"john smith")'
+              onChange={searchAutocomplete.handleInputChange}
+              onFocus={searchAutocomplete.handleInputFocus}
+              onClick={searchAutocomplete.handleInputClick}
+              onBlur={searchAutocomplete.handleInputBlur}
+              onKeyDown={searchAutocomplete.handleInputKeyDown}
+              onKeyUp={searchAutocomplete.handleInputKeyUp}
+              placeholder='Search deliveries (use ; between filters, e.g., cluster:1,2; ward:7; driver:maria; name:"john smith")'
               style={{
                 width: "100%",
                 height: "60px",
@@ -2993,11 +3016,6 @@ const DeliverySpreadsheet: React.FC = () => {
                 boxSizing: "border-box",
               }}
             />
-            <datalist id="route-search-key-suggestions">
-              {routeSearchKeySuggestions.map((suggestion) => (
-                <option key={suggestion} value={suggestion} />
-              ))}
-            </datalist>
           </Box>
           {hasActiveRouteFilter && (
             <Typography variant="body2" sx={{ color: "text.secondary", px: 1 }}>

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -3010,12 +3010,50 @@ const DeliverySpreadsheet: React.FC = () => {
                 backgroundColor: "var(--color-background-gray)",
                 border: "none",
                 borderRadius: "30px",
-                padding: "0 24px",
+                padding: "0 56px 0 24px",
                 fontSize: "16px",
                 color: "var(--color-text-dark)",
                 boxSizing: "border-box",
               }}
             />
+            {searchQuery.trim() !== "" && (
+              <button
+                type="button"
+                aria-label="Clear delivery search"
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                }}
+                onClick={() => {
+                  setSearchQuery("");
+                  requestAnimationFrame(() => {
+                    const input = searchAutocomplete.inputRef.current;
+                    if (!input) return;
+                    input.focus();
+                    input.setSelectionRange(0, 0);
+                  });
+                }}
+                style={{
+                  position: "absolute",
+                  right: "16px",
+                  top: "50%",
+                  transform: "translateY(-50%)",
+                  width: "28px",
+                  height: "28px",
+                  borderRadius: "50%",
+                  border: "none",
+                  backgroundColor: "var(--color-border-light)",
+                  color: "var(--color-text-dark)",
+                  cursor: "pointer",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontSize: "16px",
+                  lineHeight: 1,
+                }}
+              >
+                x
+              </button>
+            )}
           </Box>
           {hasActiveRouteFilter && (
             <Typography variant="body2" sx={{ color: "text.secondary", px: 1 }}>

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -1952,9 +1952,16 @@ const DeliverySpreadsheet: React.FC = () => {
 
   // Handle checkbox selection (radio button behavior - only one cluster can be selected)
   const handleCheckboxChange = (row: DeliveryRowData) => {
+    if (selectedRows.has(row.id)) {
+      setSelectedClusters(new Set());
+      setSelectedRows(new Set());
+      return;
+    }
+
     const newSelectedRows = new Set<string>();
     const newSelectedClusters = new Set<Cluster>();
-    const clickedClusterId = row.clusterId;
+    const clickedClusterId = normalizeClusterIdValue(row.clusterId);
+    const shownRows = sortedRows;
 
     if (clickedClusterId) {
       const clickedCluster = clusters?.find((c) => c.id.toString() === clickedClusterId);
@@ -1967,13 +1974,30 @@ const DeliverySpreadsheet: React.FC = () => {
 
         if (!isCurrentlySelected) {
           // Select all rows with the clicked cluster ID
-          const rowsWithSameClusterID = rows.filter((row) => row.clusterId === clickedClusterId);
+          const rowsWithSameClusterID = shownRows.filter(
+            (candidateRow) => normalizeClusterIdValue(candidateRow.clusterId) === clickedClusterId
+          );
           rowsWithSameClusterID.forEach((row) => {
             newSelectedRows.add(row.id);
           });
           newSelectedClusters.add(clickedCluster);
         }
         // If it's already selected, clicking it will deselect (newSelectedRows and newSelectedClusters remain empty)
+      }
+    } else {
+      const unassignedRows = shownRows.filter(
+        (candidateRow) => !normalizeClusterIdValue(candidateRow.clusterId)
+      );
+      const hasUnassignedRows = unassignedRows.length > 0;
+      const allUnassignedAlreadySelected =
+        hasUnassignedRows &&
+        unassignedRows.every((candidateRow) => selectedRows.has(candidateRow.id)) &&
+        selectedClusters.size === 0;
+
+      if (!allUnassignedAlreadySelected) {
+        unassignedRows.forEach((candidateRow) => {
+          newSelectedRows.add(candidateRow.id);
+        });
       }
     }
 
@@ -2587,10 +2611,15 @@ const DeliverySpreadsheet: React.FC = () => {
     () => rows.filter((row) => selectedRows.has(row.id)),
     [rows, selectedRows]
   );
+  const selectedRouteIdsForAction = useMemo(
+    () =>
+      Array.from(selectedClusters)
+        .map((cluster) => normalizeClusterIdValue(cluster?.id))
+        .filter((routeId): routeId is string => Boolean(routeId)),
+    [selectedClusters]
+  );
   const selectedRouteAssignment = useMemo(() => {
-    const selectedRouteIds = Array.from(selectedClusters)
-      .map((cluster) => normalizeClusterIdValue(cluster?.id))
-      .filter((routeId): routeId is string => Boolean(routeId));
+    const selectedRouteIds = selectedRouteIdsForAction;
 
     if (selectedRouteIds.length !== 1) {
       return { driverName: "", time: "" };
@@ -2605,7 +2634,7 @@ const DeliverySpreadsheet: React.FC = () => {
       driverName: normalizeDriverAssignmentValue(selectedCluster?.driver) ?? "",
       time: normalizeAssignmentValue(selectedCluster?.time) ?? "",
     };
-  }, [clusters, selectedClusters]);
+  }, [clusters, selectedRouteIdsForAction]);
   const hasActiveRouteFilter = searchQuery.trim() !== "";
   const defaultExportScope: RouteExportScope =
     selectedExportRows.length > 0 ? "selected" : hasActiveRouteFilter ? "visible" : "all";
@@ -3107,7 +3136,7 @@ const DeliverySpreadsheet: React.FC = () => {
                 variant="contained"
                 size="medium"
                 startIcon={<AssignmentIndIcon />}
-                disabled={selectedRows.size <= 0}
+                disabled={selectedRouteIdsForAction.length <= 0}
                 style={{
                   whiteSpace: "nowrap",
                   borderRadius: 5,

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -622,9 +622,7 @@ const DeliverySpreadsheet: React.FC = () => {
   const [exportScope, setExportScope] = useState<RouteExportScope>("all");
 
   const [driversRefreshTrigger, setDriversRefreshTrigger] = useState<number>(0);
-  const [highlightedRowId, setHighlightedRowId] = useState<string | null>(null);
-  // Suppress highlight clearing when switching rows/popups
-  const suppressClearHighlightRef = React.useRef(false);
+  const [highlightedRowIds, setHighlightedRowIds] = useState<Set<string>>(new Set());
 
   const normalizeClusters = React.useCallback((clusters: Cluster[]): Cluster[] => {
     const clustersById = new Map<string, Cluster>();
@@ -1892,20 +1890,18 @@ const DeliverySpreadsheet: React.FC = () => {
   };
 
   const handleRowClick = (clientId: string, fromTable = true) => {
-    // Only suppress clearing when switching FROM one row TO another,
-    // so the old popup's popupclose doesn't clear the new selection.
-    // When opening the first popup (no current highlight), don't suppress,
-    // so closing that popup correctly deselects the row.
-    if (highlightedRowId !== null && highlightedRowId !== clientId) {
-      suppressClearHighlightRef.current = true;
-    }
-    if (fromTable && highlightedRowId === clientId) {
-      setHighlightedRowId(null);
-      if ((window as any).closeMapPopup) {
-        (window as any).closeMapPopup();
+    const isCurrentlyHighlighted = highlightedRowIds.has(clientId);
+    if (isCurrentlyHighlighted) {
+      setHighlightedRowIds((prev) => {
+        const next = new Set(prev);
+        next.delete(clientId);
+        return next;
+      });
+      if (fromTable && (window as any).closeMapPopup) {
+        (window as any).closeMapPopup(clientId);
       }
     } else {
-      setHighlightedRowId(clientId);
+      setHighlightedRowIds((prev) => new Set([...prev, clientId]));
       if (fromTable && (window as any).openMapPopup) {
         (window as any).openMapPopup(clientId);
       }
@@ -1913,10 +1909,11 @@ const DeliverySpreadsheet: React.FC = () => {
   };
 
   const handleMarkerClick = (clientId: string) => {
+    const isCurrentlyHighlighted = highlightedRowIds.has(clientId);
     handleRowClick(clientId, false);
 
-    // Scroll to the highlighted row with smooth animation
-    if (virtuosoRef.current && sortedRows.length > 0) {
+    // Scroll to the highlighted row when adding a highlight
+    if (!isCurrentlyHighlighted && virtuosoRef.current && sortedRows.length > 0) {
       const rowIndex = sortedRows.findIndex((row) => row.id === clientId);
       if (rowIndex !== -1) {
         // Use setTimeout to ensure the highlight state has been updated
@@ -1931,12 +1928,16 @@ const DeliverySpreadsheet: React.FC = () => {
     }
   };
 
-  const clearRowHighlight = () => {
-    if (suppressClearHighlightRef.current) {
-      suppressClearHighlightRef.current = false;
-      return;
+  const clearRowHighlight = (clientId?: string) => {
+    if (clientId) {
+      setHighlightedRowIds((prev) => {
+        const next = new Set(prev);
+        next.delete(clientId);
+        return next;
+      });
+    } else {
+      setHighlightedRowIds(new Set());
     }
-    setHighlightedRowId(null);
   };
 
   const clientsWithDeliveriesOnSelectedDate = rows.filter((row) =>
@@ -2522,13 +2523,24 @@ const DeliverySpreadsheet: React.FC = () => {
   );
 
   useEffect(() => {
-    if (highlightedRowId && !visibleRows.some((row) => row.id === highlightedRowId)) {
-      setHighlightedRowId(null);
-      if ((window as any).closeMapPopup) {
-        (window as any).closeMapPopup();
-      }
-    }
-  }, [visibleRows, highlightedRowId]);
+    setHighlightedRowIds((prev) => {
+      const toRemove: string[] = [];
+      prev.forEach((id) => {
+        if (!visibleRows.some((row) => row.id === id)) {
+          toRemove.push(id);
+        }
+      });
+      if (toRemove.length === 0) return prev;
+      const next = new Set(prev);
+      toRemove.forEach((id) => {
+        next.delete(id);
+        if ((window as any).closeMapPopup) {
+          (window as any).closeMapPopup(id);
+        }
+      });
+      return next;
+    });
+  }, [visibleRows]);
 
   useEffect(() => {
     if (rawClientData.length === 0) {
@@ -3234,7 +3246,7 @@ const DeliverySpreadsheet: React.FC = () => {
               data={sortedRows}
               components={VirtuosoTableComponents}
               itemContent={(index, row) => {
-                const isHighlighted = highlightedRowId === row.id;
+                const isHighlighted = highlightedRowIds.has(row.id);
                 const cellIndex = { current: 0 };
                 const getCellSx = () => {
                   const isFirst = cellIndex.current === 0;

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -441,6 +441,37 @@ const addablePropertyKeyLabelMap: Record<string, string> = {
   lastDeliveryDate: "Last Delivery Date",
 };
 
+const routeFieldMappings: Record<string, string[]> = {
+  fullname: ["name", "client"],
+  clusterIdChange: ["cluster", "cluster id", "clusterid", "route", "route id", "routeid"],
+  tags: ["tags", "tag"],
+  zipCode: ["zip", "zipcode", "zip code"],
+  ward: ["ward"],
+  assignedDriver: ["driver", "assigned driver"],
+  assignedTime: ["time", "assigned time"],
+  "deliveryDetails.deliveryInstructions": ["delivery instructions", "instructions"],
+};
+
+const routeCustomColumnMappings: Record<string, string[]> = {
+  address: ["address"],
+  adults: ["adults"],
+  children: ["children"],
+  famStartDate: ["family start date"],
+  deliveryFreq: ["delivery freq", "delivery frequency"],
+  "deliveryDetails.dietaryRestrictions": ["dietary restrictions", "dietary"],
+  "deliveryDetails.dietaryRestrictions.dietaryPreferences": ["dietary preferences"],
+  ethnicity: ["ethnicity"],
+  gender: ["gender"],
+  language: ["language"],
+  notes: ["notes"],
+  phone: ["phone"],
+  referralEntity: ["referral entity", "referral"],
+  tags: ["tags", "tag"],
+  tefapCert: ["tefap", "tefap cert"],
+  dob: ["dob"],
+  lastDeliveryDate: ["last delivery date"],
+};
+
 const formatClusterDriverReplacementWarning = (
   routeIds: string[],
   incomingDriverName: string,
@@ -643,40 +674,14 @@ const DeliverySpreadsheet: React.FC = () => {
       .filter((label) => Boolean(label))
       .map((label) => label.toLowerCase());
 
-    const addableFieldLabels = allowedPropertyKeys
+    const visibleCustomFieldLabels = customColumns
+      .map((column) => column.propertyKey)
       .filter((propertyKey) => propertyKey !== "none")
       .map((propertyKey) => addablePropertyKeyLabelMap[propertyKey] ?? propertyKey)
       .map((label) => label.toLowerCase());
 
-    const routeFilterAliases = [
-      "name",
-      "first name",
-      "last name",
-      "cluster id",
-      "route id",
-      "ward",
-      "driver",
-      "assigned driver",
-      "time",
-      "assigned time",
-      "delivery instructions",
-      "instructions",
-      "delivery freq",
-      "delivery frequency",
-      "tags",
-      "tag",
-      "zip",
-      "zip code",
-      "zipcode",
-      "referral",
-      "referral entity",
-      "tefap",
-      "tefap cert",
-      "tefapcert",
-    ];
-
-    return Array.from(new Set([...tableFieldLabels, ...addableFieldLabels, ...routeFilterAliases]));
-  }, []);
+    return Array.from(new Set([...tableFieldLabels, ...visibleCustomFieldLabels]));
+  }, [customColumns]);
   const searchAutocomplete = useSearchKeyAutocomplete({
     value: searchQuery,
     onValueChange: setSearchQuery,
@@ -2065,20 +2070,9 @@ const DeliverySpreadsheet: React.FC = () => {
         const isVisibleField = (keyword: string): boolean => {
           const lowerKeyword = keyword.toLowerCase();
 
-          const fieldMappings: { [key: string]: string[] } = {
-            fullname: ["name", "client"],
-            clusterIdChange: ["cluster", "cluster id", "clusterid", "route", "route id", "routeid"],
-            tags: ["tags", "tag"],
-            zipCode: ["zip", "zipcode", "zip code"],
-            ward: ["ward"],
-            assignedDriver: ["driver", "assigned driver"],
-            assignedTime: ["time", "assigned time"],
-            "deliveryDetails.deliveryInstructions": ["delivery instructions", "instructions"],
-          };
-
           const normalizedKeyword = normalizeSearchKeyword(lowerKeyword);
 
-          for (const [fieldKey, aliases] of Object.entries(fieldMappings)) {
+          for (const [fieldKey, aliases] of Object.entries(routeFieldMappings)) {
             if (
               visibleFieldKeys.has(fieldKey) &&
               aliases.some((alias) => normalizeSearchKeyword(alias) === normalizedKeyword)
@@ -2087,25 +2081,7 @@ const DeliverySpreadsheet: React.FC = () => {
             }
           }
 
-          const customColumnMappings: { [key: string]: string[] } = {
-            address: ["address"],
-            adults: ["adults"],
-            children: ["children"],
-            deliveryFreq: ["delivery freq", "delivery frequency"],
-            "deliveryDetails.dietaryRestrictions": ["dietary restrictions"],
-            ethnicity: ["ethnicity"],
-            gender: ["gender"],
-            language: ["language"],
-            notes: ["notes"],
-            phone: ["phone"],
-            referralEntity: ["referral entity", "referral"],
-            tags: ["tags", "tag"],
-            tefapCert: ["tefap", "tefap cert"],
-            dob: ["dob"],
-            lastDeliveryDate: ["last delivery date"],
-          };
-
-          for (const [propertyKey, aliases] of Object.entries(customColumnMappings)) {
+          for (const [propertyKey, aliases] of Object.entries(routeCustomColumnMappings)) {
             if (
               visibleFieldKeys.has(propertyKey) &&
               aliases.some((alias) => normalizeSearchKeyword(alias) === normalizedKeyword)

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -42,7 +42,6 @@ import CancelIcon from "@mui/icons-material/Cancel";
 import ClearIcon from "@mui/icons-material/Clear";
 import DeleteIcon from "@mui/icons-material/Delete";
 import AssignmentIndIcon from "@mui/icons-material/AssignmentInd";
-import AccessTimeIcon from "@mui/icons-material/AccessTime";
 import FileDownloadIcon from "@mui/icons-material/FileDownload";
 import GroupWorkIcon from "@mui/icons-material/GroupWork";
 import TodayIcon from "@mui/icons-material/Today";
@@ -83,7 +82,6 @@ import { onAuthStateChanged } from "firebase/auth";
 const ClusterMap = React.lazy(() => import("./ClusterMap"));
 import AssignDriverPopup from "./components/AssignDriverPopup";
 import GenerateClustersPopup from "./components/GenerateClustersPopup";
-import AssignTimePopup from "./components/AssignTimePopup";
 import RouteExportOptions, {
   RouteExportOption,
   RouteExportScope,
@@ -914,26 +912,6 @@ const DeliverySpreadsheet: React.FC = () => {
     setDriversRefreshTrigger((prev) => prev + 1);
   };
 
-  const [menuOpen, setOpen] = useState(false);
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
-  const open = menuOpen && Boolean(anchorEl);
-  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
-    setOpen(true);
-  };
-  const handleTimeMenuClose = () => {
-    setOpen(false);
-    setAnchorEl(null);
-  };
-
-  const handleTimeMenuSelect = async (time: string) => {
-    const didAssign = await assignTime(time);
-    if (didAssign) {
-      setOpen(false);
-      setAnchorEl(null);
-    }
-  };
-
   const notifyExportFeedback = React.useCallback(
     (feedback: ExportFeedback) => {
       switch (feedback.status) {
@@ -972,6 +950,44 @@ const DeliverySpreadsheet: React.FC = () => {
       return didSave;
     } catch (error) {
       handleAssignmentSaveError(error, "Unable to assign time. Please try again.");
+      return false;
+    }
+  };
+
+  const assignDriverAndTime = async (driver: Driver | null, time: string): Promise<boolean> => {
+    const selectedRouteIds = getSelectedRouteIds();
+    if (!driver || !time || !selectedRouteIds.length) {
+      return false;
+    }
+
+    const driverReplacementWarning = getClusterDriverReplacementWarning(
+      { clusters, clientOverrides },
+      selectedRouteIds,
+      driver.name
+    );
+
+    try {
+      const didSave = await commitRouteAssignmentMutation((currentState) => {
+        const withDriver = assignDriverToRoutes(currentState, selectedRouteIds, driver.name);
+        return assignTimeToRoutes(withDriver, selectedRouteIds, time);
+      });
+
+      if (didSave) {
+        resetSelections();
+        if (driverReplacementWarning) {
+          showWarning(
+            formatClusterDriverReplacementWarning(
+              selectedRouteIds,
+              driver.name,
+              driverReplacementWarning
+            )
+          );
+        }
+      }
+
+      return didSave;
+    } catch (error) {
+      handleAssignmentSaveError(error, "Unable to assign driver and time. Please try again.");
       return false;
     }
   };
@@ -3066,7 +3082,7 @@ const DeliverySpreadsheet: React.FC = () => {
             </Typography>
           )}
           <Box sx={{ display: "flex", justifyContent: "space-between", marginTop: "16px" }}>
-            {/* Left group: Assign Driver and Assign Time */}
+            {/* Left group: Assign Driver & Time */}
             <Box sx={{ display: "flex", width: "100%", gap: "8px", flexWrap: "wrap" }}>
               <Button
                 variant="contained"
@@ -3084,66 +3100,8 @@ const DeliverySpreadsheet: React.FC = () => {
                 }}
                 onClick={() => setPopupMode("Driver")}
               >
-                Assign Driver
+                Assign Driver & Time
               </Button>
-              <Button
-                variant="contained"
-                size="medium"
-                id="demo-positioned-button"
-                aria-controls={open ? "demo-positioned-menu" : undefined}
-                aria-haspopup="true"
-                aria-expanded={open ? "true" : undefined}
-                startIcon={<AccessTimeIcon />}
-                onClick={handleClick}
-                disabled={selectedRows.size <= 0}
-                style={{
-                  whiteSpace: "nowrap",
-                  borderRadius: 5,
-                  marginRight: "0px",
-                  minWidth: "auto",
-                  width: "auto",
-                  fontSize: "0.875rem",
-                  padding: "8px 16px",
-                }}
-              >
-                Assign Time
-              </Button>
-
-              <Menu
-                id="demo-positioned-menu"
-                aria-labelledby="demo-positioned-button"
-                anchorEl={anchorEl}
-                open={open}
-                onClose={handleTimeMenuClose}
-                anchorOrigin={{
-                  vertical: "bottom",
-                  horizontal: "left",
-                }}
-                transformOrigin={{
-                  vertical: "top",
-                  horizontal: "left",
-                }}
-                MenuListProps={{
-                  "aria-labelledby": "demo-positioned-button",
-                  sx: {
-                    width: anchorEl ? anchorEl.offsetWidth : "200px",
-                    maxHeight: 320, // ~8 items visible
-                    overflowY: "auto",
-                  },
-                }}
-              >
-                {TIME_SLOTS.map((slot) => (
-                  <MenuItem
-                    key={slot.value}
-                    data-key={slot.value}
-                    onClick={() => {
-                      void handleTimeMenuSelect(slot.value);
-                    }}
-                  >
-                    {slot.label}
-                  </MenuItem>
-                ))}
-              </Menu>
             </Box>
             {/* Right group: Export button */}
             <Box>
@@ -4166,21 +4124,13 @@ const DeliverySpreadsheet: React.FC = () => {
 
       {/* Assign Driver Popup */}
       <Dialog open={popupMode === "Driver"} onClose={resetSelections} maxWidth="xs" fullWidth>
-        <DialogTitle>Assign Driver</DialogTitle>
+        <DialogTitle>Assign Driver & Time</DialogTitle>
         <DialogContent>
           <AssignDriverPopup
-            assignDriver={assignDriver}
+            assignDriverAndTime={assignDriverAndTime}
             setPopupMode={setPopupMode}
             onDriversUpdated={triggerDriverRefresh}
           />
-        </DialogContent>
-      </Dialog>
-
-      {/* Assign Time Popup */}
-      <Dialog open={popupMode === "Time"} onClose={resetSelections} maxWidth="xs" fullWidth>
-        <DialogTitle>Assign Time</DialogTitle>
-        <DialogContent>
-          <AssignTimePopup assignTime={assignTime} setPopupMode={setPopupMode} />
         </DialogContent>
       </Dialog>
 

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -615,6 +615,30 @@ const DeliverySpreadsheet: React.FC = () => {
   const [rows, setRows] = useState<DeliveryRowData[]>([]);
   const [rawClientData, setRawClientData] = useState<DeliveryRowData[]>([]);
   const [searchQuery, setSearchQuery] = useState<string>("");
+  const routeSearchKeySuggestions = useMemo(
+    () =>
+      [
+        "name",
+        "client",
+        "route",
+        "route id",
+        "cluster",
+        "cluster id",
+        "driver",
+        "assigned driver",
+        "time",
+        "assigned time",
+        "ward",
+        "zip",
+        "zip code",
+        "address",
+        "delivery instructions",
+        "tags",
+        "phone",
+        "dietary restrictions",
+      ].map((key) => `${key}:`),
+    []
+  );
   const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
 
   const [popupMode, setPopupMode] = useState("");
@@ -2955,6 +2979,7 @@ const DeliverySpreadsheet: React.FC = () => {
               type="text"
               value={searchQuery}
               onChange={handleSearchChange}
+              list="route-search-key-suggestions"
               placeholder='Search deliveries (e.g., cluster:1,2, ward:7, driver:maria, name:"john smith")'
               style={{
                 width: "100%",
@@ -2968,6 +2993,11 @@ const DeliverySpreadsheet: React.FC = () => {
                 boxSizing: "border-box",
               }}
             />
+            <datalist id="route-search-key-suggestions">
+              {routeSearchKeySuggestions.map((suggestion) => (
+                <option key={suggestion} value={suggestion} />
+              ))}
+            </datalist>
           </Box>
           {hasActiveRouteFilter && (
             <Typography variant="body2" sx={{ color: "text.secondary", px: 1 }}>

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -3094,6 +3094,8 @@ const DeliverySpreadsheet: React.FC = () => {
                 }}
                 onClick={() => {
                   setSearchQuery("");
+                  setSelectedRows(new Set());
+                  setSelectedClusters(new Set());
                   requestAnimationFrame(() => {
                     const input = searchAutocomplete.inputRef.current;
                     if (!input) return;

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -9,6 +9,7 @@ import EventCountHeader from "../../components/EventCountHeader";
 import { useLimits } from "../Calendar/components/useLimits";
 import React, { useState, useEffect, useMemo, Suspense } from "react";
 import { useSearchKeyAutocomplete } from "../../hooks/useSearchKeyAutocomplete";
+import { useSavedSearches } from "../../hooks/useSavedSearches";
 import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
 import { getEventsByViewType } from "../Calendar/components/getEventsByViewType";
 import CircularProgress from "@mui/material/CircularProgress";
@@ -82,6 +83,7 @@ import { onAuthStateChanged } from "firebase/auth";
 const ClusterMap = React.lazy(() => import("./ClusterMap"));
 import AssignDriverPopup from "./components/AssignDriverPopup";
 import GenerateClustersPopup from "./components/GenerateClustersPopup";
+import RouteSearchSavedFilters from "./components/RouteSearchSavedFilters";
 import RouteExportOptions, {
   RouteExportOption,
   RouteExportScope,
@@ -667,6 +669,7 @@ const DeliverySpreadsheet: React.FC = () => {
   const [rows, setRows] = useState<DeliveryRowData[]>([]);
   const [rawClientData, setRawClientData] = useState<DeliveryRowData[]>([]);
   const [searchQuery, setSearchQuery] = useState<string>("");
+  const [currentUserId, setCurrentUserId] = useState<string>(auth.currentUser?.uid ?? "guest");
   const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
 
   const [popupMode, setPopupMode] = useState("");
@@ -906,6 +909,49 @@ const DeliverySpreadsheet: React.FC = () => {
     onValueChange: setSearchQuery,
     suggestions: routeSearchKeySuggestions,
   });
+  const { savedSearches, saveCurrentSearch, applySavedSearch, overwriteSavedSearch, deleteSavedSearch } = useSavedSearches(currentUserId);
+
+  const handleSaveCurrentRouteSearch = React.useCallback(
+    (searchName?: string) => {
+      saveCurrentSearch(searchQuery, searchName);
+    },
+    [saveCurrentSearch, searchQuery]
+  );
+
+  const handleApplySavedRouteSearch = React.useCallback(
+    (query: string) => {
+      const savedItem = savedSearches.find((item) => item.query === query);
+      applySavedSearch(
+        query,
+        (nextQuery) => {
+        setSearchQuery(nextQuery);
+        requestAnimationFrame(() => {
+          const input = searchAutocomplete.inputRef.current;
+          if (!input) return;
+          input.focus();
+          const end = nextQuery.length;
+          input.setSelectionRange(end, end);
+        });
+        },
+        savedItem?.name
+      );
+    },
+    [applySavedSearch, savedSearches, searchAutocomplete.inputRef]
+  );
+
+  const handleOverwriteRouteSearch = React.useCallback(
+    (name: string, newQuery: string) => {
+      overwriteSavedSearch(name, newQuery);
+    },
+    [overwriteSavedSearch]
+  );
+
+  const handleDeleteRouteSearch = React.useCallback(
+    (query: string) => {
+      deleteSavedSearch(query);
+    },
+    [deleteSavedSearch]
+  );
 
   // Function to trigger driver refresh across components
   const triggerDriverRefresh = () => {
@@ -1194,6 +1240,7 @@ const DeliverySpreadsheet: React.FC = () => {
   // Route Protection
   React.useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, (user: any) => {
+      setCurrentUserId(user?.uid ?? "guest");
       if (!user) {
         navigate("/");
       }
@@ -3061,70 +3108,81 @@ const DeliverySpreadsheet: React.FC = () => {
         }}
       >
         <Box sx={{ display: "flex", flexDirection: "column", gap: "8px" }}>
-          <Box sx={{ position: "relative", width: "100%" }}>
-            <input
-              ref={searchAutocomplete.inputRef}
-              type="text"
-              value={searchQuery}
-              onChange={searchAutocomplete.handleInputChange}
-              onFocus={searchAutocomplete.handleInputFocus}
-              onClick={searchAutocomplete.handleInputClick}
-              onBlur={searchAutocomplete.handleInputBlur}
-              onKeyDown={searchAutocomplete.handleInputKeyDown}
-              onKeyUp={searchAutocomplete.handleInputKeyUp}
-              placeholder='Search deliveries (use ; between filters, e.g., cluster:1,2; ward:7; driver:maria; name:"john smith")'
-              style={{
-                width: "100%",
-                height: "60px",
-                backgroundColor: "var(--color-background-gray)",
-                border: "none",
-                borderRadius: "30px",
-                padding: "0 56px 0 24px",
-                fontSize: "16px",
-                color: "var(--color-text-dark)",
-                boxSizing: "border-box",
-              }}
-            />
-            {searchQuery.trim() !== "" && (
-              <button
-                type="button"
-                aria-label="Clear delivery search"
-                onMouseDown={(event) => {
-                  event.preventDefault();
-                }}
-                onClick={() => {
-                  setSearchQuery("");
-                  setSelectedRows(new Set());
-                  setSelectedClusters(new Set());
-                  requestAnimationFrame(() => {
-                    const input = searchAutocomplete.inputRef.current;
-                    if (!input) return;
-                    input.focus();
-                    input.setSelectionRange(0, 0);
-                  });
-                }}
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1, width: "100%" }}>
+            <Box sx={{ position: "relative", flex: 1, minWidth: 0 }}>
+              <input
+                ref={searchAutocomplete.inputRef}
+                type="text"
+                value={searchQuery}
+                onChange={searchAutocomplete.handleInputChange}
+                onFocus={searchAutocomplete.handleInputFocus}
+                onClick={searchAutocomplete.handleInputClick}
+                onBlur={searchAutocomplete.handleInputBlur}
+                onKeyDown={searchAutocomplete.handleInputKeyDown}
+                onKeyUp={searchAutocomplete.handleInputKeyUp}
+                placeholder='Search deliveries (use ; between filters, e.g., cluster:1,2; ward:7; driver:maria; name:"john smith")'
                 style={{
-                  position: "absolute",
-                  right: "16px",
-                  top: "50%",
-                  transform: "translateY(-50%)",
-                  width: "28px",
-                  height: "28px",
-                  borderRadius: "50%",
+                  width: "100%",
+                  height: "60px",
+                  backgroundColor: "var(--color-background-gray)",
                   border: "none",
-                  backgroundColor: "var(--color-border-light)",
-                  color: "var(--color-text-dark)",
-                  cursor: "pointer",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
+                  borderRadius: "30px",
+                  padding: "0 56px 0 24px",
                   fontSize: "16px",
-                  lineHeight: 1,
+                  color: "var(--color-text-dark)",
+                  boxSizing: "border-box",
                 }}
-              >
-                <ClearIcon fontSize="small" />
-              </button>
-            )}
+              />
+              {searchQuery.trim() !== "" && (
+                <button
+                  type="button"
+                  aria-label="Clear delivery search"
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                  }}
+                  onClick={() => {
+                    setSearchQuery("");
+                    setSelectedRows(new Set());
+                    setSelectedClusters(new Set());
+                    requestAnimationFrame(() => {
+                      const input = searchAutocomplete.inputRef.current;
+                      if (!input) return;
+                      input.focus();
+                      input.setSelectionRange(0, 0);
+                    });
+                  }}
+                  style={{
+                    position: "absolute",
+                    right: "16px",
+                    top: "50%",
+                    transform: "translateY(-50%)",
+                    width: "28px",
+                    height: "28px",
+                    borderRadius: "50%",
+                    border: "none",
+                    backgroundColor: "var(--color-border-light)",
+                    color: "var(--color-text-dark)",
+                    cursor: "pointer",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    fontSize: "16px",
+                    lineHeight: 1,
+                  }}
+                >
+                  <ClearIcon fontSize="small" />
+                </button>
+              )}
+            </Box>
+
+            <RouteSearchSavedFilters
+              currentQuery={searchQuery}
+              savedSearches={savedSearches}
+              onSaveCurrentSearch={handleSaveCurrentRouteSearch}
+              onApplySavedSearch={handleApplySavedRouteSearch}
+              onOverwriteSavedSearch={handleOverwriteRouteSearch}
+              onDeleteSavedSearch={handleDeleteRouteSearch}
+            />
           </Box>
           {hasActiveRouteFilter && (
             <Typography variant="body2" sx={{ color: "text.secondary", px: 1 }}>

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -3182,6 +3182,7 @@ const DeliverySpreadsheet: React.FC = () => {
               onApplySavedSearch={handleApplySavedRouteSearch}
               onOverwriteSavedSearch={handleOverwriteRouteSearch}
               onDeleteSavedSearch={handleDeleteRouteSearch}
+              hasDeliveries={rows.length > 0}
             />
           </Box>
           {hasActiveRouteFilter && (

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -2130,10 +2130,14 @@ const DeliverySpreadsheet: React.FC = () => {
 
   const handleMarkerClick = (clientId: string) => {
     const isCurrentlyHighlighted = highlightedRowIds.has(clientId);
+    if (isCurrentlyHighlighted) {
+      return;
+    }
+
     handleRowClick(clientId, false);
 
     // Scroll to the highlighted row when adding a highlight
-    if (!isCurrentlyHighlighted && virtuosoRef.current && sortedRows.length > 0) {
+    if (virtuosoRef.current && sortedRows.length > 0) {
       const rowIndex = sortedRows.findIndex((row) => row.id === clientId);
       if (rowIndex !== -1) {
         // Use setTimeout to ensure the highlight state has been updated

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -63,6 +63,7 @@ import {
   Paper,
   Checkbox,
   Dialog,
+  DialogActions,
   DialogContent,
   DialogTitle,
   Typography,
@@ -426,7 +427,7 @@ const addablePropertyKeyLabelMap: Record<string, string> = {
   address: "Address",
   adults: "Adults",
   children: "Children",
-  famStartDate: "Family Start Date",
+  famStartDate: "Fam Start Date",
   deliveryFreq: "Delivery Frequency",
   "deliveryDetails.dietaryRestrictions": "Dietary Restrictions",
   "deliveryDetails.dietaryRestrictions.dietaryPreferences": "Dietary Preferences",
@@ -457,7 +458,7 @@ const routeCustomColumnMappings: Record<string, string[]> = {
   address: ["address"],
   adults: ["adults"],
   children: ["children"],
-  famStartDate: ["family start date"],
+  famStartDate: ["fam start date", "family start date"],
   deliveryFreq: ["delivery freq", "delivery frequency"],
   "deliveryDetails.dietaryRestrictions": ["dietary restrictions", "dietary"],
   "deliveryDetails.dietaryRestrictions.dietaryPreferences": ["dietary preferences"],
@@ -642,6 +643,8 @@ const DeliverySpreadsheet: React.FC = () => {
   const [addClusterModalOpen, setAddClusterModalOpen] = useState(false);
   const [numClustersToAdd, setNumClustersToAdd] = useState(1);
   // Reset clusters to empty for the current day
+  const [isResetClustersConfirmOpen, setIsResetClustersConfirmOpen] = React.useState(false);
+
   const handleResetClusters = async () => {
     // Close map popup if open
     if (typeof window !== "undefined" && (window as any).closeMapPopup) {
@@ -680,6 +683,21 @@ const DeliverySpreadsheet: React.FC = () => {
 
   const [driversRefreshTrigger, setDriversRefreshTrigger] = useState<number>(0);
   const [highlightedRowIds, setHighlightedRowIds] = useState<Set<string>>(new Set());
+  const highlightedRowIdsRef = React.useRef<Set<string>>(new Set());
+  const highlightRestoreLockRef = React.useRef(false);
+
+  React.useEffect(() => {
+    highlightedRowIdsRef.current = highlightedRowIds;
+  }, [highlightedRowIds]);
+
+  const preserveHighlightedRowsForAssignment = React.useCallback(() => {
+    highlightRestoreLockRef.current = true;
+    return new Set(highlightedRowIdsRef.current);
+  }, []);
+
+  const releaseHighlightedRowsForAssignment = React.useCallback(() => {
+    highlightRestoreLockRef.current = false;
+  }, []);
 
   const normalizeClusters = React.useCallback((clusters: Cluster[]): Cluster[] => {
     const clustersById = new Map<string, Cluster>();
@@ -1370,6 +1388,7 @@ const DeliverySpreadsheet: React.FC = () => {
       : [row.id];
     let resolvedNewClusterId = "";
     let didMoveClients = false;
+    const highlightedRowsToPreserve = preserveHighlightedRowsForAssignment();
 
     try {
       const didSave = await commitRouteAssignmentMutation((currentState) => {
@@ -1423,8 +1442,26 @@ const DeliverySpreadsheet: React.FC = () => {
         }
       }
 
+      if (didSave && didMoveClients) {
+        setHighlightedRowIds(highlightedRowsToPreserve);
+        window.setTimeout(() => {
+          highlightedRowsToPreserve.forEach((id) => {
+            if ((window as any).openMapPopup) {
+              (window as any).openMapPopup(id);
+            }
+          });
+          window.setTimeout(() => {
+            setHighlightedRowIds(highlightedRowsToPreserve);
+            releaseHighlightedRowsForAssignment();
+          }, 1200);
+        }, 0);
+      } else {
+        releaseHighlightedRowsForAssignment();
+      }
+
       return didSave;
     } catch (error) {
+      releaseHighlightedRowsForAssignment();
       handleAssignmentSaveError(error, "Unable to update the route assignment. Please try again.");
       return false;
     }
@@ -1506,6 +1543,7 @@ const DeliverySpreadsheet: React.FC = () => {
     }
 
     try {
+      const highlightedRowsToPreserve = preserveHighlightedRowsForAssignment();
       const resolvedClusterId =
         newClusterId === "__add__" || newClusterId === "__add_new_cluster__"
           ? ""
@@ -1610,6 +1648,7 @@ const DeliverySpreadsheet: React.FC = () => {
       });
 
       if (!didSave) {
+        releaseHighlightedRowsForAssignment();
         return false;
       }
 
@@ -1671,8 +1710,26 @@ const DeliverySpreadsheet: React.FC = () => {
         );
       }
 
+      if (didChangeClusters) {
+        setHighlightedRowIds(highlightedRowsToPreserve);
+        window.setTimeout(() => {
+          highlightedRowsToPreserve.forEach((id) => {
+            if ((window as any).openMapPopup) {
+              (window as any).openMapPopup(id);
+            }
+          });
+          window.setTimeout(() => {
+            setHighlightedRowIds(highlightedRowsToPreserve);
+            releaseHighlightedRowsForAssignment();
+          }, 1200);
+        }, 0);
+      } else {
+        releaseHighlightedRowsForAssignment();
+      }
+
       return true;
     } catch (error) {
+      releaseHighlightedRowsForAssignment();
       handleAssignmentSaveError(error, "Unable to update the route assignment. Please try again.");
       return false;
     }
@@ -2092,6 +2149,9 @@ const DeliverySpreadsheet: React.FC = () => {
   };
 
   const clearRowHighlight = (clientId?: string) => {
+    if (highlightRestoreLockRef.current) {
+      return;
+    }
     if (clientId) {
       setHighlightedRowIds((prev) => {
         const next = new Set(prev);
@@ -2194,7 +2254,6 @@ const DeliverySpreadsheet: React.FC = () => {
             const searchValues = splitFilterValues(searchValue);
             const matchesAnySearchValue = (matcher: (candidate: string) => boolean): boolean =>
               searchValues.some((candidate: string) => matcher(candidate));
-
             switch (normalizedKeyword) {
               case "name":
               case "client":
@@ -2295,6 +2354,23 @@ const DeliverySpreadsheet: React.FC = () => {
                 return matchesAnySearchValue((candidate) =>
                   checkStringContains(row.tefapCert, candidate)
                 );
+              case "date":
+              case "famstartdate": {
+                return matchesAnySearchValue((candidate) => {
+                  const normalizedCandidateDate = deliveryDate.tryToDateTime(candidate);
+                  const normalizedRowDate = deliveryDate.tryToDateTime(row.famStartDate);
+
+                  if (!normalizedCandidateDate || !normalizedRowDate) {
+                    return false;
+                  }
+
+                  const candidateDisplay = deliveryDate.toDisplayString(normalizedCandidateDate);
+                  const rowDisplay = deliveryDate.toDisplayString(normalizedRowDate);
+                  const matches = checkStringEquals(rowDisplay, candidateDisplay);
+
+                  return matches;
+                });
+              }
               case "dob":
                 return matchesAnySearchValue((candidate) =>
                   checkValueOrInArray(row.dob, candidate, true)
@@ -3020,12 +3096,44 @@ const DeliverySpreadsheet: React.FC = () => {
             fontSize: "0.875rem",
             padding: "8px 16px",
           }}
-          onClick={handleResetClusters}
+          onClick={() => setIsResetClustersConfirmOpen(true)}
           startIcon={<RestartAltIcon />}
         >
           Reset Clusters
         </Button>
       </div>
+
+      {/* Reset Clusters confirmation dialog */}
+      <Dialog
+        open={isResetClustersConfirmOpen}
+        onClose={() => setIsResetClustersConfirmOpen(false)}
+        aria-labelledby="reset-clusters-confirm-title"
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle id="reset-clusters-confirm-title">Reset Clusters?</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2">
+            This will remove all route assignments and cluster groupings for this day. This action
+            cannot be undone.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setIsResetClustersConfirmOpen(false)} color="inherit">
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            color="error"
+            onClick={() => {
+              setIsResetClustersConfirmOpen(false);
+              handleResetClusters();
+            }}
+          >
+            Yes, Reset
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       {clusterDoc !== undefined && !isMainLoading && rows.length > 0 && unassignedRouteCount > 0 ? (
         <Alert severity="warning" sx={{ mb: 2 }}>
@@ -3936,7 +4044,7 @@ const DeliverySpreadsheet: React.FC = () => {
                             if (key === "address") label = "Address";
                             if (key === "adults") label = "Adults";
                             if (key === "children") label = "Children";
-                            if (key === "famStartDate") label = "FAM Start Date";
+                            if (key === "famStartDate") label = "Fam Start Date";
                             if (key === "deliveryFreq") label = "Delivery Freq";
                             if (key === "deliveryDetails.dietaryRestrictions")
                               label = "Dietary Restrictions";
@@ -4149,7 +4257,7 @@ const DeliverySpreadsheet: React.FC = () => {
                             if (key === "address") label = "Address";
                             if (key === "adults") label = "Adults";
                             if (key === "children") label = "Children";
-                            if (key === "famStartDate") label = "FAM Start Date";
+                            if (key === "famStartDate") label = "Fam Start Date";
                             if (key === "deliveryFreq") label = "Delivery Freq";
                             if (key === "deliveryDetails.dietaryRestrictions")
                               label = "Dietary Restrictions";

--- a/my-app/src/pages/Delivery/RouteExport.tsx
+++ b/my-app/src/pages/Delivery/RouteExport.tsx
@@ -232,6 +232,7 @@ const buildRouteCsvRow = (
     quadrant?: string;
     adults?: number;
     children?: number;
+    seniors?: number;
     total?: number;
   };
   const dietaryColumns = formatRouteDietaryColumns(row.deliveryDetails?.dietaryRestrictions);
@@ -246,7 +247,9 @@ const buildRouteCsvRow = (
     phone: row.phone || "",
     adults: rowData.adults ?? 0,
     children: rowData.children ?? 0,
-    total: rowData.total ?? (rowData.adults ?? 0) + (rowData.children ?? 0),
+    seniors: rowData.seniors ?? 0,
+    total:
+      rowData.total ?? (rowData.adults ?? 0) + (rowData.children ?? 0) + (rowData.seniors ?? 0),
     deliveryInstructions: row.deliveryDetails?.deliveryInstructions || "",
     dietaryRestrictions: dietaryColumns.dietaryRestrictions,
     dietaryPreferences: dietaryColumns.dietaryPreferences,

--- a/my-app/src/pages/Delivery/components/AssignDriverPopup.tsx
+++ b/my-app/src/pages/Delivery/components/AssignDriverPopup.tsx
@@ -1,32 +1,60 @@
-import { Autocomplete, DialogActions, Paper, TextField, Box, Typography } from "@mui/material";
+import {
+  Autocomplete,
+  DialogActions,
+  TextField,
+  Box,
+} from "@mui/material";
 import { useEffect, useState, useCallback } from "react";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import Button from "../../../components/common/Button";
 import DriverManagementModal from "../../../components/DriverManagementModal";
 import { Driver } from "../../../types/calendar-types";
 import DriverService from "../../../services/driver-service";
+import { TIME_SLOTS } from "../utils/timeSlots";
 
 interface AssignDriverPopupProps {
-  assignDriver: (driver: Driver | null) => Promise<boolean>;
+  assignDriverAndTime: (driver: Driver | null, time: string) => Promise<boolean>;
   setPopupMode: (mode: string) => void;
   onDriversUpdated?: () => void; // Optional callback when drivers are updated
 }
 
 export default function AssignDriverPopup({
-  assignDriver,
+  assignDriverAndTime,
   setPopupMode,
   onDriversUpdated,
 }: AssignDriverPopupProps) {
+  const MANAGE_DRIVERS_OPTION = { id: "__modal__", name: "Edit Driver List", phone: "" };
   const [driver, setDriver] = useState<Driver | null>(null);
-  const [drivers, setDrivers] = useState<Driver[]>([]);
+  const [time, setTime] = useState<string>("");
   const [driverSearchQuery, setDriverSearchQuery] = useState<string>("");
+  const [timeSearchQuery, setTimeSearchQuery] = useState<string>("");
+  const [drivers, setDrivers] = useState<Driver[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
   const [isDriverModalOpen, setIsDriverModalOpen] = useState<boolean>(false);
+  const isDriverError = error === "Please select a driver.";
+  const isTimeError = error === "Please select a time.";
+  const autocompleteSx = {
+    width: "100%",
+    minWidth: 0,
+    "& .MuiFormControl-root": {
+      width: "100%",
+    },
+    "& .MuiInputBase-root": {
+      width: "100%",
+    },
+    "& .MuiOutlinedInput-root": {
+      width: "100%",
+      paddingRight: "8px !important",
+    },
+  };
 
   const resetAndClose = () => {
     setDriver(null);
+    setTime("");
     setDriverSearchQuery("");
+    setTimeSearchQuery("");
     setError("");
     setPopupMode("");
   };
@@ -37,11 +65,16 @@ export default function AssignDriverPopup({
       return;
     }
 
+    if (!time) {
+      setError("Please select a time.");
+      return;
+    }
+
     setError("");
     setIsSaving(true);
 
     try {
-      const didSave = await assignDriver(driver);
+      const didSave = await assignDriverAndTime(driver, time);
       if (didSave) {
         resetAndClose();
       }
@@ -88,68 +121,42 @@ export default function AssignDriverPopup({
     <>
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2, p: 1 }}>
         <Autocomplete
-          options={[{ id: "__modal__", name: "Manage Drivers" }, ...drivers]}
-          getOptionLabel={(option) => option.name}
-          filterOptions={(options, state) => {
-            const specialOption = { id: "__modal__", name: "Manage Drivers" };
-
-            // Filter out the special option from the rest
-            const filteredDrivers = drivers.filter((driver) =>
-              driver.name.toLowerCase().includes(state.inputValue.toLowerCase())
-            );
-
-            return [specialOption, ...filteredDrivers];
-          }}
+          options={[MANAGE_DRIVERS_OPTION, ...drivers]}
           value={driver}
-          onChange={(event, newValue) => {
+          inputValue={driverSearchQuery}
+          onInputChange={(_, newInputValue) => {
+            setDriverSearchQuery(newInputValue);
+          }}
+          onChange={(_, newValue) => {
             if (!newValue) {
               setDriver(null);
-            } else if (newValue.id === "__modal__") {
+            } else if (newValue.id === MANAGE_DRIVERS_OPTION.id) {
               setIsDriverModalOpen(true);
+              return;
             } else {
               setDriver(newValue as Driver);
             }
             if (error) setError("");
           }}
-          inputValue={driverSearchQuery}
-          onInputChange={(event, newInputValue) => {
-            setDriverSearchQuery(newInputValue);
-          }}
+          getOptionLabel={(option) => option.name}
           isOptionEqualToValue={(option, value) => option.id === value.id}
+          filterOptions={(options, state) => {
+            const filteredDrivers = drivers.filter((candidateDriver) =>
+              candidateDriver.name.toLowerCase().includes(state.inputValue.toLowerCase())
+            );
+            return [MANAGE_DRIVERS_OPTION, ...filteredDrivers];
+          }}
           renderOption={(props, option) =>
-            option.id === "__modal__" ? (
+            option.id === MANAGE_DRIVERS_OPTION.id ? (
               <li {...props} key="manage-drivers-option">
-                <span
-                  style={{
-                    color: "var(--color-primary)",
-                    fontWeight: "bold",
-                    cursor: "pointer",
-                  }}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setIsDriverModalOpen(true);
-                  }}
-                >
-                  Edit Driver List
+                <span style={{ color: "var(--color-primary)", fontWeight: 700 }}>
+                  {MANAGE_DRIVERS_OPTION.name}
                 </span>
               </li>
             ) : (
               <li {...props} key={option.id}>
-                <span>
-                  <p
-                    style={{
-                      color: "var(--color-black)",
-                      fontWeight: "bold",
-                      display: "inline-block",
-                      marginRight: "10px",
-                    }}
-                  >
-                    {option.name}
-                  </p>
-                  <p style={{ color: "grey", display: "inline-block" }}>
-                    {"phone" in option && option.phone ? `(${option.phone})` : ""}
-                  </p>
-                </span>
+                {option.name}
+                {option.phone ? ` (${option.phone})` : ""}
               </li>
             )
           }
@@ -160,46 +167,73 @@ export default function AssignDriverPopup({
               variant="outlined"
               fullWidth
               size="small"
-              error={!!error}
+              error={isDriverError}
               helperText={
-                error ||
+                (isDriverError ? error : "") ||
                 (loading
                   ? "Loading drivers..."
                   : drivers.length === 0
                     ? "No drivers available"
                     : "")
               }
-              sx={{
-                ".MuiOutlinedInput-root": {
-                  height: "40px",
-                },
-                ".MuiOutlinedInput-input": {
-                  display: "flex",
-                  alignItems: "center",
-                },
-              }}
               InputProps={{
                 ...params.InputProps,
                 endAdornment: (
-                  <>
-                    {loading ? <Typography variant="caption">Loading...</Typography> : null}
-                    {params.InputProps.endAdornment}
-                  </>
+                  <ArrowDropDownIcon
+                    sx={{ color: "var(--color-text-medium-alt)", pointerEvents: "none" }}
+                  />
                 ),
               }}
             />
           )}
-          loading={loading}
-          noOptionsText="No matching drivers found"
           disabled={loading}
-          PaperComponent={({ children }) => <Paper elevation={3}>{children}</Paper>}
+          noOptionsText="No matching drivers found"
           forcePopupIcon={false}
-          sx={{
-            minWidth: "250px",
-            "& .MuiAutocomplete-clearIndicator": {
-              display: "none",
-            },
+          sx={autocompleteSx}
+        />
+
+        <Autocomplete
+          options={TIME_SLOTS}
+          value={TIME_SLOTS.find((slot) => slot.value === time) ?? null}
+          inputValue={timeSearchQuery}
+          onInputChange={(_, newInputValue) => {
+            setTimeSearchQuery(newInputValue);
           }}
+          onChange={(_, newValue) => {
+            setTime(newValue?.value ?? "");
+            if (newValue) {
+              setTimeSearchQuery(newValue.label);
+            }
+            if (error) setError("");
+          }}
+          getOptionLabel={(option) => option.label}
+          isOptionEqualToValue={(option, value) => option.value === value.value}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Select Time"
+              variant="outlined"
+              fullWidth
+              size="small"
+              error={isTimeError && !time}
+              helperText={
+                isTimeError && !time
+                  ? error
+                  : "Choose the route start time for selected deliveries."
+              }
+              InputProps={{
+                ...params.InputProps,
+                endAdornment: (
+                  <ArrowDropDownIcon
+                    sx={{ color: "var(--color-text-medium-alt)", pointerEvents: "none" }}
+                  />
+                ),
+              }}
+            />
+          )}
+          noOptionsText="No matching times found"
+          forcePopupIcon={false}
+          sx={autocompleteSx}
         />
 
         <DriverManagementModal
@@ -217,7 +251,7 @@ export default function AssignDriverPopup({
         <Button
           variant="primary"
           onClick={handleSave}
-          disabled={!driver || loading || isSaving}
+          disabled={!driver || !time || loading || isSaving}
           size="medium"
         >
           Save

--- a/my-app/src/pages/Delivery/components/AssignDriverPopup.tsx
+++ b/my-app/src/pages/Delivery/components/AssignDriverPopup.tsx
@@ -53,6 +53,13 @@ export default function AssignDriverPopup({
       width: "100%",
       paddingRight: "8px !important",
     },
+    "& .MuiOutlinedInput-notchedOutline": {
+      border: "1px solid var(--color-border-light) !important",
+    },
+    "& .MuiInputBase-input": {
+      border: "none !important",
+      boxShadow: "none !important",
+    },
   };
 
   const resetAndClose = () => {

--- a/my-app/src/pages/Delivery/components/AssignDriverPopup.tsx
+++ b/my-app/src/pages/Delivery/components/AssignDriverPopup.tsx
@@ -4,7 +4,7 @@ import {
   TextField,
   Box,
 } from "@mui/material";
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import Button from "../../../components/common/Button";
 import DriverManagementModal from "../../../components/DriverManagementModal";
@@ -15,12 +15,16 @@ import { TIME_SLOTS } from "../utils/timeSlots";
 interface AssignDriverPopupProps {
   assignDriverAndTime: (driver: Driver | null, time: string) => Promise<boolean>;
   setPopupMode: (mode: string) => void;
+  initialDriverName?: string;
+  initialTime?: string;
   onDriversUpdated?: () => void; // Optional callback when drivers are updated
 }
 
 export default function AssignDriverPopup({
   assignDriverAndTime,
   setPopupMode,
+  initialDriverName = "",
+  initialTime = "",
   onDriversUpdated,
 }: AssignDriverPopupProps) {
   const MANAGE_DRIVERS_OPTION = { id: "__modal__", name: "Edit Driver List", phone: "" };
@@ -33,6 +37,7 @@ export default function AssignDriverPopup({
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
   const [isDriverModalOpen, setIsDriverModalOpen] = useState<boolean>(false);
+  const didInitializeSelectionRef = useRef(false);
   const isDriverError = error === "Please select a driver.";
   const isTimeError = error === "Please select a time.";
   const autocompleteSx = {
@@ -104,6 +109,34 @@ export default function AssignDriverPopup({
   useEffect(() => {
     fetchDrivers();
   }, [fetchDrivers]);
+
+  useEffect(() => {
+    if (didInitializeSelectionRef.current || loading) {
+      return;
+    }
+
+    const normalizedInitialDriver = initialDriverName.trim();
+    const normalizedInitialTime = initialTime.trim();
+
+    if (normalizedInitialDriver) {
+      const matchedDriver =
+        drivers.find(
+          (candidateDriver) =>
+            candidateDriver.name.trim().toLowerCase() === normalizedInitialDriver.toLowerCase()
+        ) ?? null;
+
+      setDriver(matchedDriver);
+      setDriverSearchQuery(matchedDriver?.name ?? normalizedInitialDriver);
+    }
+
+    if (normalizedInitialTime) {
+      const matchedTimeSlot = TIME_SLOTS.find((slot) => slot.value === normalizedInitialTime);
+      setTime(normalizedInitialTime);
+      setTimeSearchQuery(matchedTimeSlot?.label ?? normalizedInitialTime);
+    }
+
+    didInitializeSelectionRef.current = true;
+  }, [drivers, initialDriverName, initialTime, loading]);
 
   // Handle drivers change from DriverManagementModal
   const handleDriversChange = useCallback(

--- a/my-app/src/pages/Delivery/components/RouteSearchSavedFilters.tsx
+++ b/my-app/src/pages/Delivery/components/RouteSearchSavedFilters.tsx
@@ -214,7 +214,7 @@ const RouteSearchSavedFilters: React.FC<RouteSearchSavedFiltersProps> = ({
         {savedSearches.length === 0 ? (
           <MenuItem disabled sx={{ whiteSpace: "normal", opacity: 1 }}>
             <Typography variant="body2" sx={{ color: "text.secondary" }}>
-              No saved searches yet
+              No saved filters yet
             </Typography>
           </MenuItem>
         ) : (

--- a/my-app/src/pages/Delivery/components/RouteSearchSavedFilters.tsx
+++ b/my-app/src/pages/Delivery/components/RouteSearchSavedFilters.tsx
@@ -1,0 +1,352 @@
+import React, { useState } from "react";
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  Menu,
+  MenuItem,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import BookmarkBorderIcon from "@mui/icons-material/BookmarkBorder";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import CloseIcon from "@mui/icons-material/Close";
+import type { SavedSearchItem } from "../utils/savedSearches";
+
+interface RouteSearchSavedFiltersProps {
+  currentQuery: string;
+  savedSearches: SavedSearchItem[];
+  onSaveCurrentSearch: (searchName?: string) => void;
+  onApplySavedSearch: (query: string) => void;
+  onOverwriteSavedSearch: (name: string, newQuery: string) => void;
+  onDeleteSavedSearch: (query: string) => void;
+}
+
+const RouteSearchSavedFilters: React.FC<RouteSearchSavedFiltersProps> = ({
+  currentQuery,
+  savedSearches,
+  onSaveCurrentSearch,
+  onApplySavedSearch,
+  onOverwriteSavedSearch,
+  onDeleteSavedSearch,
+}) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [isSaveDialogOpen, setIsSaveDialogOpen] = useState(false);
+  const [searchNameDraft, setSearchNameDraft] = useState("");
+  const [conflictMode, setConflictMode] = useState<"duplicate" | "mismatch" | null>(null);
+  const [conflictItem, setConflictItem] = useState<SavedSearchItem | null>(null);
+  const isOpen = Boolean(anchorEl);
+  const canSaveCurrent = currentQuery.trim().length > 0;
+
+  const nameTakenByItem = searchNameDraft.trim()
+    ? savedSearches.find(
+        (s) => s.name.trim().toLowerCase() === searchNameDraft.trim().toLowerCase()
+      ) ?? null
+    : null;
+
+  const handleOpenMenu = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleCloseMenu = () => {
+    setAnchorEl(null);
+  };
+
+  const handleSaveCurrent = () => {
+    if (!canSaveCurrent) {
+      return;
+    }
+    setSearchNameDraft(currentQuery.trim().slice(0, 40));
+    setIsSaveDialogOpen(true);
+  };
+
+  const handleCloseSaveDialog = () => {
+    setIsSaveDialogOpen(false);
+    setSearchNameDraft("");
+  };
+
+  const handleConfirmSave = () => {
+    const trimmedName = searchNameDraft.trim();
+    const existingWithSameName = savedSearches.find(
+      (s) => s.name.trim().toLowerCase() === trimmedName.toLowerCase()
+    );
+
+    if (existingWithSameName) {
+      const sameQuery =
+        existingWithSameName.query.trim().toLowerCase() ===
+        currentQuery.trim().toLowerCase();
+      setConflictItem(existingWithSameName);
+      setConflictMode(sameQuery ? "duplicate" : "mismatch");
+      return;
+    }
+
+    onSaveCurrentSearch(trimmedName || undefined);
+    handleCloseSaveDialog();
+    handleCloseMenu();
+  };
+
+  const handleOverwrite = () => {
+    if (conflictItem) {
+      onOverwriteSavedSearch(conflictItem.name, currentQuery);
+    }
+    setConflictMode(null);
+    setConflictItem(null);
+    handleCloseSaveDialog();
+    handleCloseMenu();
+  };
+
+  const handleConflictUseDifferentName = () => {
+    setConflictMode(null);
+    setConflictItem(null);
+    // Save dialog remains open so user can choose a different name
+  };
+
+  const handleConflictClose = () => {
+    setConflictMode(null);
+    setConflictItem(null);
+  };
+
+  const handleApplySaved = (query: string) => {
+    onApplySavedSearch(query);
+    handleCloseMenu();
+  };
+
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 1, flex: "0 0 auto" }}>
+      <Tooltip title="Save current search">
+        <span>
+          <IconButton
+            aria-label="Save current search"
+            onClick={handleSaveCurrent}
+            disabled={!canSaveCurrent}
+            sx={{
+              height: 42,
+              width: 42,
+              borderRadius: "6px",
+              color: "var(--color-white)",
+              backgroundColor: "var(--color-primary)",
+              "&:hover": {
+                backgroundColor: "var(--color-primary-darker)",
+              },
+              "&.Mui-disabled": {
+                color: "rgba(255,255,255,0.65)",
+                backgroundColor: "var(--color-text-medium)",
+              },
+            }}
+          >
+            <BookmarkBorderIcon fontSize="small" />
+          </IconButton>
+        </span>
+      </Tooltip>
+
+      <Button
+        variant="contained"
+        aria-haspopup="menu"
+        aria-expanded={isOpen ? "true" : undefined}
+        aria-controls={isOpen ? "saved-searches-menu" : undefined}
+        onClick={handleOpenMenu}
+        endIcon={<ArrowDropDownIcon />}
+        sx={{
+          height: 42,
+          width: "auto",
+          minWidth: 160,
+          maxWidth: 190,
+          px: 1.5,
+          flex: "0 0 auto",
+          borderRadius: "6px",
+          textTransform: "none",
+          whiteSpace: "nowrap",
+          backgroundColor: "var(--color-primary)",
+          "&:hover": {
+            backgroundColor: "var(--color-primary-darker)",
+          },
+        }}
+      >
+        Saved Filters
+      </Button>
+
+      <Menu
+        id="saved-searches-menu"
+        anchorEl={anchorEl}
+        open={isOpen}
+        onClose={handleCloseMenu}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+        transformOrigin={{ vertical: "top", horizontal: "right" }}
+        slotProps={{
+          paper: {
+            sx: {
+              mt: 0.5,
+              minWidth: 360,
+              maxWidth: 480,
+              borderRadius: "10px",
+              boxShadow: "0 8px 20px rgba(0, 0, 0, 0.12)",
+            },
+          },
+        }}
+      >
+        <Box sx={{ px: 2, pt: 1.25, pb: 1 }}>
+          <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+            Recent searches (Max: 5)
+          </Typography>
+        </Box>
+
+        <Divider sx={{ my: 0.5 }} />
+
+        {savedSearches.length === 0 ? (
+          <MenuItem disabled sx={{ whiteSpace: "normal", opacity: 1 }}>
+            <Typography variant="body2" sx={{ color: "text.secondary" }}>
+              No saved searches yet
+            </Typography>
+          </MenuItem>
+        ) : (
+          savedSearches.slice(0, 5).map((item) => (
+            <MenuItem
+              key={item.name}
+              onClick={() => handleApplySaved(item.query)}
+              sx={{
+                alignItems: "center",
+                py: 0.75,
+                pr: 0.5,
+              }}
+            >
+              <Tooltip title={item.query} placement="left" arrow>
+                <Typography
+                  variant="body2"
+                  sx={{
+                    flex: 1,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    fontWeight: 500,
+                    mr: 1,
+                  }}
+                >
+                  {item.name}
+                </Typography>
+              </Tooltip>
+              <Tooltip title="Delete" placement="right" arrow>
+                <IconButton
+                  aria-label={`Delete saved search "${item.name}"`}
+                  size="small"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDeleteSavedSearch(item.query);
+                  }}
+                  sx={{
+                    color: "error.main",
+                    ml: "auto",
+                    flexShrink: 0,
+                    "&:hover": { backgroundColor: "rgba(211,47,47,0.08)" },
+                  }}
+                >
+                  <CloseIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            </MenuItem>
+          ))
+        )}
+      </Menu>
+
+      <Dialog
+        open={isSaveDialogOpen}
+        onClose={handleCloseSaveDialog}
+        aria-labelledby="save-search-dialog-title"
+        fullWidth
+        maxWidth="xs"
+      >
+        <DialogTitle id="save-search-dialog-title">Save Search</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            fullWidth
+            margin="dense"
+            label="Search name"
+            placeholder="e.g. Ward 7 Friday"
+            value={searchNameDraft}
+            onChange={(event) => setSearchNameDraft(event.target.value)}
+            error={Boolean(nameTakenByItem)}
+            helperText={
+              nameTakenByItem
+                ? `"${nameTakenByItem.name}" is already saved — saving will prompt to overwrite`
+                : "Hover the saved name to preview the full query"
+            }
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                handleConfirmSave();
+              }
+            }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseSaveDialog} color="inherit">
+            Cancel
+          </Button>
+          <Button onClick={handleConfirmSave} variant="contained">
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Conflict dialog: same name already exists */}
+      <Dialog
+        open={conflictMode !== null}
+        onClose={handleConflictClose}
+        aria-labelledby="save-conflict-dialog-title"
+        fullWidth
+        maxWidth="xs"
+      >
+        {conflictMode === "duplicate" && (
+          <>
+            <DialogTitle id="save-conflict-dialog-title">Already Saved</DialogTitle>
+            <DialogContent>
+              <Typography variant="body2">
+                <strong>&quot;{conflictItem?.name}&quot;</strong> is already saved with this exact search.
+              </Typography>
+            </DialogContent>
+            <DialogActions>
+              <Button
+                variant="contained"
+                onClick={() => {
+                  handleConflictClose();
+                  handleCloseSaveDialog();
+                  handleCloseMenu();
+                }}
+              >
+                OK
+              </Button>
+            </DialogActions>
+          </>
+        )}
+        {conflictMode === "mismatch" && (
+          <>
+            <DialogTitle id="save-conflict-dialog-title">Name Already Exists</DialogTitle>
+            <DialogContent>
+              <Typography variant="body2">
+                A saved filter named <strong>&quot;{conflictItem?.name}&quot;</strong> already exists
+                with a different search. Would you like to overwrite it or use a different name?
+              </Typography>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={handleConflictUseDifferentName} color="inherit">
+                Use a Different Name
+              </Button>
+              <Button variant="contained" onClick={handleOverwrite}>
+                Overwrite
+              </Button>
+            </DialogActions>
+          </>
+        )}
+      </Dialog>
+    </Box>
+  );
+};
+
+export default RouteSearchSavedFilters;

--- a/my-app/src/pages/Delivery/components/RouteSearchSavedFilters.tsx
+++ b/my-app/src/pages/Delivery/components/RouteSearchSavedFilters.tsx
@@ -16,7 +16,6 @@ import {
 } from "@mui/material";
 import BookmarkBorderIcon from "@mui/icons-material/BookmarkBorder";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
-import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import CloseIcon from "@mui/icons-material/Close";
 import type { SavedSearchItem } from "../utils/savedSearches";
 
@@ -27,6 +26,7 @@ interface RouteSearchSavedFiltersProps {
   onApplySavedSearch: (query: string) => void;
   onOverwriteSavedSearch: (name: string, newQuery: string) => void;
   onDeleteSavedSearch: (query: string) => void;
+  hasDeliveries?: boolean;
 }
 
 const RouteSearchSavedFilters: React.FC<RouteSearchSavedFiltersProps> = ({
@@ -36,6 +36,7 @@ const RouteSearchSavedFilters: React.FC<RouteSearchSavedFiltersProps> = ({
   onApplySavedSearch,
   onOverwriteSavedSearch,
   onDeleteSavedSearch,
+  hasDeliveries = true,
 }) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [isSaveDialogOpen, setIsSaveDialogOpen] = useState(false);
@@ -43,7 +44,7 @@ const RouteSearchSavedFilters: React.FC<RouteSearchSavedFiltersProps> = ({
   const [conflictMode, setConflictMode] = useState<"duplicate" | "mismatch" | null>(null);
   const [conflictItem, setConflictItem] = useState<SavedSearchItem | null>(null);
   const isOpen = Boolean(anchorEl);
-  const canSaveCurrent = currentQuery.trim().length > 0;
+  const canSaveCurrent = currentQuery.trim().length > 0 && hasDeliveries;
 
   const nameTakenByItem = searchNameDraft.trim()
     ? savedSearches.find(
@@ -52,6 +53,9 @@ const RouteSearchSavedFilters: React.FC<RouteSearchSavedFiltersProps> = ({
     : null;
 
   const handleOpenMenu = (event: React.MouseEvent<HTMLElement>) => {
+    if (!hasDeliveries) {
+      return;
+    }
     setAnchorEl(event.currentTarget);
   };
 
@@ -114,6 +118,9 @@ const RouteSearchSavedFilters: React.FC<RouteSearchSavedFiltersProps> = ({
   };
 
   const handleApplySaved = (query: string) => {
+    if (!hasDeliveries) {
+      return;
+    }
     onApplySavedSearch(query);
     handleCloseMenu();
   };
@@ -152,6 +159,7 @@ const RouteSearchSavedFilters: React.FC<RouteSearchSavedFiltersProps> = ({
         aria-expanded={isOpen ? "true" : undefined}
         aria-controls={isOpen ? "saved-searches-menu" : undefined}
         onClick={handleOpenMenu}
+        disabled={!hasDeliveries}
         endIcon={<ArrowDropDownIcon />}
         sx={{
           height: 42,
@@ -166,6 +174,10 @@ const RouteSearchSavedFilters: React.FC<RouteSearchSavedFiltersProps> = ({
           backgroundColor: "var(--color-primary)",
           "&:hover": {
             backgroundColor: "var(--color-primary-darker)",
+          },
+          "&.Mui-disabled": {
+            color: "rgba(255,255,255,0.65)",
+            backgroundColor: "var(--color-text-medium)",
           },
         }}
       >
@@ -193,7 +205,7 @@ const RouteSearchSavedFilters: React.FC<RouteSearchSavedFiltersProps> = ({
       >
         <Box sx={{ px: 2, pt: 1.25, pb: 1 }}>
           <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
-            Recent searches (Max: 5)
+            Recent Filters (Max: 5)
           </Typography>
         </Box>
 
@@ -210,6 +222,7 @@ const RouteSearchSavedFilters: React.FC<RouteSearchSavedFiltersProps> = ({
             <MenuItem
               key={item.name}
               onClick={() => handleApplySaved(item.query)}
+              disabled={!hasDeliveries}
               sx={{
                 alignItems: "center",
                 py: 0.75,

--- a/my-app/src/pages/Delivery/utils/savedSearches.ts
+++ b/my-app/src/pages/Delivery/utils/savedSearches.ts
@@ -1,0 +1,161 @@
+export interface SavedSearchItem {
+  name: string;
+  query: string;
+  savedAt: string;
+}
+
+const MAX_SAVED_SEARCHES = 5;
+
+const getSafeUserKey = (userId?: string | null): string => {
+  const normalized = (userId || "").trim();
+  return normalized || "guest";
+};
+
+export const getSavedSearchesStorageKey = (userId?: string | null): string =>
+  `routes:savedSearches:${getSafeUserKey(userId)}`;
+
+const buildDefaultSearchName = (query: string): string => {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    return "Saved search";
+  }
+
+  if (trimmed.length <= 40) {
+    return trimmed;
+  }
+
+  return `${trimmed.slice(0, 37)}...`;
+};
+
+export const removeDuplicateAndLimitToFive = (searches: SavedSearchItem[]): SavedSearchItem[] => {
+  const seen = new Set<string>();
+  const deduped: SavedSearchItem[] = [];
+
+  for (const search of searches) {
+    const trimmedQuery = search.query.trim();
+    if (!trimmedQuery) {
+      continue;
+    }
+
+    const dedupeKey = trimmedQuery.toLowerCase();
+    if (seen.has(dedupeKey)) {
+      continue;
+    }
+
+    seen.add(dedupeKey);
+    deduped.push({
+      name: (search.name || "").trim() || buildDefaultSearchName(trimmedQuery),
+      query: trimmedQuery,
+      savedAt: search.savedAt,
+    });
+
+    if (deduped.length >= MAX_SAVED_SEARCHES) {
+      break;
+    }
+  }
+
+  return deduped;
+};
+
+export const getSavedSearches = (userId?: string | null): SavedSearchItem[] => {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  const storageKey = getSavedSearchesStorageKey(userId);
+  const raw = window.localStorage.getItem(storageKey);
+
+  if (!raw) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Array<Partial<SavedSearchItem>>;
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return removeDuplicateAndLimitToFive(
+      parsed.filter(
+        (item) =>
+          item && typeof item.query === "string" && typeof item.savedAt === "string"
+      ) as SavedSearchItem[]
+    );
+  } catch {
+    return [];
+  }
+};
+
+export const deleteSearch = (
+  userId: string | null | undefined,
+  query: string
+): SavedSearchItem[] => {
+  if (typeof window === "undefined") {
+    return getSavedSearches(userId);
+  }
+
+  const trimmedQuery = query.trim().toLowerCase();
+  const updated = getSavedSearches(userId).filter(
+    (s) => s.query.trim().toLowerCase() !== trimmedQuery
+  );
+
+  const storageKey = getSavedSearchesStorageKey(userId);
+  window.localStorage.setItem(storageKey, JSON.stringify(updated));
+  return updated;
+};
+
+export const findByName = (
+  searches: SavedSearchItem[],
+  name: string
+): SavedSearchItem | undefined => {
+  const normalized = name.trim().toLowerCase();
+  return searches.find((s) => s.name.trim().toLowerCase() === normalized);
+};
+
+export const replaceByName = (
+  userId: string | null | undefined,
+  name: string,
+  newQuery: string
+): SavedSearchItem[] => {
+  if (typeof window === "undefined") {
+    return getSavedSearches(userId);
+  }
+
+  const existing = getSavedSearches(userId);
+  const normalized = name.trim().toLowerCase();
+  const updated = existing.map((s) =>
+    s.name.trim().toLowerCase() === normalized
+      ? { ...s, query: newQuery.trim(), savedAt: new Date().toISOString() }
+      : s
+  );
+
+  const storageKey = getSavedSearchesStorageKey(userId);
+  window.localStorage.setItem(storageKey, JSON.stringify(updated));
+  return updated;
+};
+
+export const saveSearch = (
+  userId: string | null | undefined,
+  query: string,
+  name?: string
+): SavedSearchItem[] => {
+  const trimmedQuery = query.trim();
+  if (!trimmedQuery || typeof window === "undefined") {
+    return getSavedSearches(userId);
+  }
+
+  const trimmedName = (name || "").trim();
+
+  const storageKey = getSavedSearchesStorageKey(userId);
+  const next: SavedSearchItem[] = removeDuplicateAndLimitToFive([
+    {
+      name: trimmedName || buildDefaultSearchName(trimmedQuery),
+      query: trimmedQuery,
+      savedAt: new Date().toISOString(),
+    },
+    ...getSavedSearches(userId),
+  ]);
+
+  window.localStorage.setItem(storageKey, JSON.stringify(next));
+  return next;
+};

--- a/my-app/src/pages/Profile/Profile.tsx
+++ b/my-app/src/pages/Profile/Profile.tsx
@@ -2748,6 +2748,16 @@ const Profile = () => {
           return [normalizedStartDate];
         }
 
+        if (newDelivery.recurrence === "Monthly-Pattern") {
+          return Array.from(
+            new Set(
+              (newDelivery.customDates || [])
+                .map((date) => deliveryDate.tryToISODateString(date))
+                .filter((dateKey): dateKey is string => Boolean(dateKey))
+            )
+          ).sort();
+        }
+
         const recurrenceDates = Time.Recurrence.calculateRecurrenceDates(
           deliveryDate.toDateTime(normalizedStartDate),
           newDelivery.recurrence,

--- a/my-app/src/pages/Profile/Profile.tsx
+++ b/my-app/src/pages/Profile/Profile.tsx
@@ -1282,16 +1282,44 @@ const Profile = () => {
       }
       // --- Geocoding Optimization Start ---
       // Always force geocoding and coordinate update on every save
-      const { ward: fetchedWard, coordinates: fetchedCoordinates } = await getWardAndCoordinates(
-        clientProfile.address
-      );
-      const hasValidCoordinates =
-        Array.isArray(fetchedCoordinates) &&
-        fetchedCoordinates.length === 2 &&
-        (fetchedCoordinates[0] !== 0 || fetchedCoordinates[1] !== 0);
-      const coordinatesToSave: [number, number] | [] = hasValidCoordinates
-        ? [fetchedCoordinates[0], fetchedCoordinates[1]]
-        : [];
+      // Only geocode when address changed or existing coords/ward are missing/invalid
+      const addressChanged =
+        clientProfile.address !== prevClientProfile?.address ||
+        clientProfile.address2 !== prevClientProfile?.address2 ||
+        clientProfile.city !== prevClientProfile?.city ||
+        clientProfile.state !== prevClientProfile?.state ||
+        clientProfile.zipCode !== prevClientProfile?.zipCode;
+      const existingCoords = clientProfile.coordinates;
+      const hasExistingValidCoords =
+        Array.isArray(existingCoords) &&
+        existingCoords.length === 2 &&
+        (existingCoords[0] !== 0 || existingCoords[1] !== 0);
+      const hasValidWard =
+        !!clientProfile.ward &&
+        clientProfile.ward !== "No address" &&
+        clientProfile.ward !== "Error";
+      const needsGeocode = addressChanged || !hasExistingValidCoords || !hasValidWard;
+
+      let fetchedWard: string;
+      let coordinatesToSave: [number, number] | [];
+
+      if (needsGeocode) {
+        const { ward: geoWard, coordinates: fetchedCoordinates } = await getWardAndCoordinates(
+          clientProfile.address
+        );
+        const hasValidCoordinates =
+          Array.isArray(fetchedCoordinates) &&
+          fetchedCoordinates.length === 2 &&
+          (fetchedCoordinates[0] !== 0 || fetchedCoordinates[1] !== 0);
+        fetchedWard = geoWard;
+        coordinatesToSave = hasValidCoordinates
+          ? [fetchedCoordinates[0], fetchedCoordinates[1]]
+          : [];
+      } else {
+        // Address unchanged and existing coords/ward are valid — skip geocoding
+        fetchedWard = clientProfile.ward;
+        coordinatesToSave = existingCoords as [number, number];
+      }
       // Update the ward state
       clientProfile.ward = fetchedWard;
       setWard(fetchedWard);

--- a/my-app/src/pages/Profile/components/MiscellaneousForm.tsx
+++ b/my-app/src/pages/Profile/components/MiscellaneousForm.tsx
@@ -85,7 +85,7 @@ const MiscellaneousForm: React.FC<MiscellaneousFormProps> = ({
               pb: 0,
             }}
           >
-            FAM Start Date
+            Fam Start Date
           </Typography>
           {isEditing ? (
             <Box sx={{ minHeight: 120, width: "100%" }}>{renderField("famStartDate", "date")}</Box>

--- a/my-app/src/services/delivery-service.idShadowing.test.ts
+++ b/my-app/src/services/delivery-service.idShadowing.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+type MockDocData = Record<string, unknown>;
+type MockDocSnapshot = {
+  id: string;
+  data: () => MockDocData;
+};
+type MockGetDocsResult = {
+  docs: MockDocSnapshot[];
+};
+
+const mockGetDocs = jest.fn<Promise<MockGetDocsResult>, []>();
+const mockCollection = jest.fn(() => ({ mocked: "collection" }));
+const mockWhere = jest.fn((...args: unknown[]) => ({ mocked: "where", args }));
+const mockOrderBy = jest.fn((...args: unknown[]) => ({ mocked: "orderBy", args }));
+const mockQuery = jest.fn((...args: unknown[]) => ({ mocked: "query", args }));
+
+jest.mock("../auth/firebaseConfig", () => ({
+  db: {},
+}));
+
+jest.mock("firebase/firestore", () => ({
+  collection: () => mockCollection(),
+  doc: (..._args: unknown[]) => ({ id: "mock-doc-ref" }),
+  getDoc: () => Promise.resolve(undefined),
+  getDocs: () => mockGetDocs(),
+  setDoc: () => Promise.resolve(undefined),
+  updateDoc: () => Promise.resolve(undefined),
+  deleteDoc: () => Promise.resolve(undefined),
+  writeBatch: () => ({
+    delete: () => undefined,
+    update: () => undefined,
+    set: () => undefined,
+    commit: () => Promise.resolve(undefined),
+  }),
+  query: (...args: unknown[]) => mockQuery(...args),
+  where: (...args: unknown[]) => mockWhere(...args),
+  orderBy: (...args: unknown[]) => mockOrderBy(...args),
+  limit: () => ({}),
+  Timestamp: class MockTimestamp {
+    private readonly value: Date;
+
+    constructor(date: Date) {
+      this.value = date;
+    }
+
+    toDate(): Date {
+      return this.value;
+    }
+
+    static fromDate(date: Date): MockTimestamp {
+      return new MockTimestamp(date);
+    }
+  },
+}));
+
+import DeliveryService from "./delivery-service";
+
+const createDocSnapshot = (id: string, data: MockDocData): MockDocSnapshot => ({
+  id,
+  data: () => data,
+});
+
+describe("DeliveryService.getEventsByDateRange id source", () => {
+  beforeEach(() => {
+    mockGetDocs.mockReset();
+    mockCollection.mockClear();
+    mockWhere.mockClear();
+    mockOrderBy.mockClear();
+    mockQuery.mockClear();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // App coverage:
+  // - Day Calendar list rendering in `src/pages/Calendar/components/DayView.tsx` uses `key={event.id}`
+  // - If fetched events reuse payload ids instead of Firestore document ids, duplicate keys can hide cards
+  // Behavior contract: fetched event ids should come from Firestore document ids, not a stored payload `id` field.
+  it("prefers Firestore document ids over payload id fields", async () => {
+    const service = DeliveryService.getInstance();
+
+    // Two distinct docs that accidentally share a stale payload `id`.
+    // This reproduces the scenario where one card can disappear while counts stay correct.
+    mockGetDocs.mockResolvedValue({
+      docs: [
+        createDocSnapshot("doc-a", {
+          id: "legacy-shared-id",
+          clientId: "client-a",
+          deliveryDate: {
+            toDate: () => new Date("2026-04-24T12:00:00.000Z"),
+          },
+        }),
+        createDocSnapshot("doc-b", {
+          id: "legacy-shared-id",
+          clientId: "client-b",
+          deliveryDate: {
+            toDate: () => new Date("2026-04-24T13:00:00.000Z"),
+          },
+        }),
+      ],
+    });
+
+    const events = await service.getEventsByDateRange(
+      new Date("2026-04-24T00:00:00.000Z"),
+      new Date("2026-04-25T00:00:00.000Z")
+    );
+
+    expect(events).toHaveLength(2);
+    expect(events.map((event) => event.id)).toEqual(["doc-a", "doc-b"]);
+  });
+});

--- a/my-app/src/services/delivery-service.ts
+++ b/my-app/src/services/delivery-service.ts
@@ -252,6 +252,10 @@ class DeliveryService {
       Object.entries(event).map(([k, v]) => [k, v === undefined ? null : v])
     );
 
+    // Keep Firestore document id as the single source of truth.
+    // Persisting an `id` field in payloads can later shadow the document id on reads.
+    delete (cleanEvent as Partial<DeliveryEvent>).id;
+
     if (cleanEvent.deliveryDate) {
       cleanEvent.deliveryDate = deliveryDate.toJSDate(cleanEvent.deliveryDate as any);
     }
@@ -276,8 +280,8 @@ class DeliveryService {
     }
 
     const event = {
-      id: snapshot.id,
       ...raw,
+      id: snapshot.id,
       deliveryDate: deliveryDate.toJSDate(
         raw.deliveryDate as string | Date | Timestamp | null | undefined
       ),
@@ -669,7 +673,7 @@ class DeliveryService {
             const normalizedDate = deliveryDate.toJSDate(
               Time.Firebase.fromTimestamp(raw.deliveryDate).toJSDate()
             );
-            const data = { id: doc.id, ...raw, deliveryDate: normalizedDate };
+            const data = { ...raw, id: doc.id, deliveryDate: normalizedDate };
             return validateDeliveryEvent(data) ? data : undefined;
           })
           .filter((event) => event !== undefined) as DeliveryEvent[];
@@ -704,7 +708,7 @@ class DeliveryService {
             const normalizedDate = deliveryDate.toJSDate(
               Time.Firebase.fromTimestamp(raw.deliveryDate).toJSDate()
             );
-            const data = { id: doc.id, ...raw, deliveryDate: normalizedDate };
+            const data = { ...raw, id: doc.id, deliveryDate: normalizedDate };
             return validateDeliveryEvent(data) ? data : undefined;
           })
           .filter((event) => event !== undefined) as DeliveryEvent[];
@@ -1406,7 +1410,7 @@ class DeliveryService {
 
       querySnapshot.docs.forEach((docSnapshot) => {
         const eventData = docSnapshot.data() as Partial<DeliveryEvent>;
-        const cacheEvent = { id: docSnapshot.id, ...eventData };
+        const cacheEvent = { ...eventData, id: docSnapshot.id };
         const eventDateKey = eventData.deliveryDate
           ? deliveryDate.tryToISODateString(eventData.deliveryDate as any)
           : null;
@@ -1517,8 +1521,8 @@ class DeliveryService {
             }
             const deliveryDateValue = deliveryDate.toJSDate(data.deliveryDate);
             return {
-              id: doc.id,
               ...data,
+              id: doc.id,
               deliveryDate: deliveryDateValue,
             } as DeliveryEvent;
           })

--- a/my-app/src/services/delivery-service.ts
+++ b/my-app/src/services/delivery-service.ts
@@ -884,6 +884,16 @@ class DeliveryService {
       ).sort();
     }
 
+    if (newDelivery.recurrence === "Monthly-Pattern") {
+      return Array.from(
+        new Set(
+          (newDelivery.customDates || [])
+            .map((date) => deliveryDate.tryToISODateString(date))
+            .filter((dateKey): dateKey is string => Boolean(dateKey))
+        )
+      ).sort();
+    }
+
     const normalizedStartDate = deliveryDate.tryToISODateString(newDelivery.deliveryDate);
     if (!normalizedStartDate) {
       return [];

--- a/my-app/src/styles/form-field-global.css
+++ b/my-app/src/styles/form-field-global.css
@@ -115,17 +115,6 @@ textarea.error,
   border: none !important;
 }
 
-/* Autocomplete: use the fieldset border (not the inner input border) so the
-   arrow adornment sits inside the visible border, not outside it. */
-.MuiAutocomplete-root .MuiOutlinedInput-notchedOutline {
-  border: 1px solid var(--color-border-light) !important;
-}
-
-.MuiAutocomplete-root .MuiInputBase-input {
-  border: none !important;
-  box-shadow: none !important;
-}
-
 .MuiSelect-root,
 .MuiSelect-select,
 .MuiInputBase-root,

--- a/my-app/src/styles/form-field-global.css
+++ b/my-app/src/styles/form-field-global.css
@@ -115,6 +115,17 @@ textarea.error,
   border: none !important;
 }
 
+/* Autocomplete: use the fieldset border (not the inner input border) so the
+   arrow adornment sits inside the visible border, not outside it. */
+.MuiAutocomplete-root .MuiOutlinedInput-notchedOutline {
+  border: 1px solid var(--color-border-light) !important;
+}
+
+.MuiAutocomplete-root .MuiInputBase-input {
+  border: none !important;
+  box-shadow: none !important;
+}
+
 .MuiSelect-root,
 .MuiSelect-select,
 .MuiInputBase-root,

--- a/my-app/src/types/calendar-types.ts
+++ b/my-app/src/types/calendar-types.ts
@@ -17,7 +17,7 @@ export interface DateLimit {
 
 // Extending Delivery for calendar-specific fields
 export interface DeliveryEvent extends Delivery {
-  recurrence: "None" | "Weekly" | "2x-Monthly" | "Monthly" | "Custom";
+  recurrence: "None" | "Weekly" | "2x-Monthly" | "Monthly" | "Custom" | "Monthly-Pattern";
   customDates?: string[];
   recurrenceId?: string;
   seriesStartDate?: string; // The original start date of a recurring series
@@ -32,9 +32,11 @@ export interface NewDelivery {
   clientId: string;
   clientName: string;
   deliveryDate: string; // ISO string for the delivery date
-  recurrence: "None" | "Weekly" | "2x-Monthly" | "Monthly" | "Custom";
+  recurrence: "None" | "Weekly" | "2x-Monthly" | "Monthly" | "Custom" | "Monthly-Pattern";
   repeatsEndDate?: string;
   customDates?: string[];
+  monthlyPatternWeekPosition?: "first" | "second" | "third" | "fourth" | "last";
+  monthlyPatternDayOfWeek?: "monday" | "tuesday" | "wednesday" | "thursday" | "friday" | "saturday" | "sunday";
   // For validation error messages
   _deliveryDateError?: string;
   _repeatsEndDateError?: string;

--- a/my-app/src/types/delivery-types.ts
+++ b/my-app/src/types/delivery-types.ts
@@ -24,7 +24,7 @@ export interface Delivery {
   deliveryDate: string | Date | Timestamp; // Can be string, Date, or Firestore Timestamp
   time: string; // The time of the delivery;
   cluster: number;
-  recurrence: "None" | "Weekly" | "2x-Monthly" | "Monthly" | "Custom"; // Updated recurrence options
+  recurrence: "None" | "Weekly" | "2x-Monthly" | "Monthly" | "Custom" | "Monthly-Pattern"; // Updated recurrence options
   repeatsEndDate?: string; // Optional, end date for recurrence
   deliveryStatus?: "Scheduled" | "Missed";
   householdSnapshot?: HouseholdSnapshot | null;

--- a/my-app/src/utils/searchFilter.test.ts
+++ b/my-app/src/utils/searchFilter.test.ts
@@ -37,6 +37,12 @@ describe("searchFilter parsing", () => {
     expect(terms).toEqual(['name: "john smith"', "driver:maria"]);
   });
 
+  it("preserves key:value terms when value is unquoted and contains spaces", () => {
+    const terms = parseSearchTermsProgressively("assigned driver:sarah jones ward:7");
+
+    expect(terms).toEqual(["assigned driver:sarah jones", "ward:7"]);
+  });
+
   // App coverage:
   // - Routes page filter input for cluster IDs with or without a space after `:`
   // - ensures `cluster:12` and `cluster: 12` are both parsed as key:value filters
@@ -111,6 +117,23 @@ describe("searchFilter parsing", () => {
     expect(parsed).toEqual({
       keyword: "name",
       searchValue: "John Smith",
+      isKeyValue: true,
+    });
+  });
+
+  it("extracts key:value gracefully when keyword/value have one-sided quotes", () => {
+    const quotedKeyword = extractKeyValue('"assigned driver:Sarah');
+    const quotedValue = extractKeyValue('assigned driver:"Sarah Jones');
+
+    expect(quotedKeyword).toEqual({
+      keyword: "assigned driver",
+      searchValue: "Sarah",
+      isKeyValue: true,
+    });
+
+    expect(quotedValue).toEqual({
+      keyword: "assigned driver",
+      searchValue: "Sarah Jones",
       isKeyValue: true,
     });
   });

--- a/my-app/src/utils/searchFilter.test.ts
+++ b/my-app/src/utils/searchFilter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "@jest/globals";
 import {
   checkStringEquals,
+  checkStringContains,
   extractKeyValue,
   parseSearchTermsProgressively,
   splitFilterValues,
@@ -43,6 +44,18 @@ describe("searchFilter parsing", () => {
     expect(terms).toEqual(["assigned driver:sarah jones", "ward:7"]);
   });
 
+  it("splits when the next token is a recognized key like ward", () => {
+    const terms = parseSearchTermsProgressively("driver:sarah jones ward:7");
+
+    expect(terms).toEqual(["driver:sarah jones", "ward:7"]);
+  });
+
+  it("does not split on colon text inside a value when token is not a known key", () => {
+    const terms = parseSearchTermsProgressively("address:123 main st apt: 2 ward:7");
+
+    expect(terms).toEqual(["address:123 main st apt: 2", "ward:7"]);
+  });
+
   // App coverage:
   // - Routes page filter input for cluster IDs with or without a space after `:`
   // - ensures `cluster:12` and `cluster: 12` are both parsed as key:value filters
@@ -63,6 +76,14 @@ describe("searchFilter parsing", () => {
     const terms = parseSearchTermsProgressively("cluster: 1, 2 ward:7");
 
     expect(terms).toEqual(["cluster: 1, 2", "ward:7"]);
+  });
+
+  it("treats semicolon as an explicit separator between key:value filters", () => {
+    const terms = parseSearchTermsProgressively(
+      "language:english; delivery instructions:call before arriving"
+    );
+
+    expect(terms).toEqual(["language:english", "delivery instructions:call before arriving"]);
   });
 
   // App coverage:
@@ -105,6 +126,14 @@ describe("searchFilter parsing", () => {
     expect(checkStringEquals("10", "1")).toBe(false);
     expect(checkStringEquals("12", "2")).toBe(false);
     expect(checkStringEquals("Ward 12", "2")).toBe(false);
+  });
+
+  it("treats none as a match for missing or empty values", () => {
+    expect(checkStringContains(undefined, "none")).toBe(true);
+    expect(checkStringContains(null, "None")).toBe(true);
+    expect(checkStringContains("", "none")).toBe(true);
+    expect(checkStringEquals(undefined, "none")).toBe(true);
+    expect(checkStringEquals("", "none")).toBe(true);
   });
 
   // App coverage:

--- a/my-app/src/utils/searchFilter.test.ts
+++ b/my-app/src/utils/searchFilter.test.ts
@@ -103,6 +103,12 @@ describe("searchFilter parsing", () => {
       "dietary restrictions:vegan",
     ]);
     expect(parseSearchTermsProgressively("first name:john")).toEqual(["first name:john"]);
+    expect(parseSearchTermsProgressively("fam start date:01/01/2026")).toEqual([
+      "fam start date:01/01/2026",
+    ]);
+    expect(parseSearchTermsProgressively("fam start date: 01/01/2026")).toEqual([
+      "fam start date: 01/01/2026",
+    ]);
   });
 
   // App coverage:

--- a/my-app/src/utils/searchFilter.ts
+++ b/my-app/src/utils/searchFilter.ts
@@ -22,11 +22,61 @@ export const parseSearchTermsProgressively = (trimmedSearchQuery: string): strin
     "zip",
   ]);
 
-  const pushCurrentTerm = (stripTrailingComma = false): void => {
+  const knownFilterKeywords = new Set(
+    [
+      "name",
+      "client",
+      "first name",
+      "firstname",
+      "last name",
+      "lastname",
+      "address",
+      "phone",
+      "email",
+      "role",
+      "cluster",
+      "cluster id",
+      "clusterid",
+      "route",
+      "route id",
+      "routeid",
+      "tags",
+      "tag",
+      "zip",
+      "zip code",
+      "zipcode",
+      "ward",
+      "driver",
+      "assigned driver",
+      "time",
+      "assigned time",
+      "delivery instructions",
+      "instructions",
+      "dietary restrictions",
+      "dietary",
+      "adults",
+      "children",
+      "delivery freq",
+      "delivery frequency",
+      "ethnicity",
+      "gender",
+      "language",
+      "notes",
+      "referral entity",
+      "referral",
+      "tefap",
+      "tefap cert",
+      "tefapcert",
+      "dob",
+      "last delivery date",
+    ].map((keyword) => normalizeSearchKeyword(keyword))
+  );
+
+  const pushCurrentTerm = (stripTrailingDelimiter = false): void => {
     let normalizedTerm = currentTerm.trim();
 
-    if (stripTrailingComma) {
-      normalizedTerm = normalizedTerm.replace(/,\s*$/, "");
+    if (stripTrailingDelimiter) {
+      normalizedTerm = normalizedTerm.replace(/[;,]\s*$/, "");
     }
 
     if (normalizedTerm) {
@@ -39,7 +89,10 @@ export const parseSearchTermsProgressively = (trimmedSearchQuery: string): strin
   const upcomingTokenContainsColon = (startIndex: number): boolean => {
     let index = startIndex;
 
-    while (index < trimmedSearchQuery.length && trimmedSearchQuery[index] === " ") {
+    while (
+      index < trimmedSearchQuery.length &&
+      (trimmedSearchQuery[index] === " " || trimmedSearchQuery[index] === ",")
+    ) {
       index += 1;
     }
 
@@ -51,6 +104,39 @@ export const parseSearchTermsProgressively = (trimmedSearchQuery: string): strin
       if (trimmedSearchQuery[index] === ":") {
         return true;
       }
+      index += 1;
+    }
+
+    return false;
+  };
+
+  const upcomingTokenStartsKnownFilter = (startIndex: number): boolean => {
+    let index = startIndex;
+
+    while (
+      index < trimmedSearchQuery.length &&
+      (trimmedSearchQuery[index] === " " || trimmedSearchQuery[index] === ",")
+    ) {
+      index += 1;
+    }
+
+    const keyStart = index;
+
+    while (index < trimmedSearchQuery.length) {
+      const char = trimmedSearchQuery[index];
+      if (char === ":") {
+        const candidateKeyword = trimmedSearchQuery.slice(keyStart, index).trim();
+        if (!candidateKeyword) {
+          return false;
+        }
+
+        return knownFilterKeywords.has(normalizeSearchKeyword(candidateKeyword));
+      }
+
+      if (char === ",") {
+        return false;
+      }
+
       index += 1;
     }
 
@@ -69,12 +155,15 @@ export const parseSearchTermsProgressively = (trimmedSearchQuery: string): strin
       currentTerm += char;
       inQuote = false;
       quoteChar = "";
+    } else if (!inQuote && char === ";") {
+      pushCurrentTerm(true);
     } else if (!inQuote && char === ",") {
       const trimmedCurrentTerm = currentTerm.trim();
       const colonIndex = trimmedCurrentTerm.indexOf(":");
       const valueAfterColon =
         colonIndex === -1 ? "" : trimmedCurrentTerm.substring(colonIndex + 1).trim();
-      const nextTokenHasColon = upcomingTokenContainsColon(i + 1);
+      const nextTokenHasColon = upcomingTokenStartsKnownFilter(i + 1);
+      const nextTokenContainsColon = upcomingTokenContainsColon(i + 1);
 
       if (colonIndex !== -1 && valueAfterColon !== "" && nextTokenHasColon) {
         pushCurrentTerm(false);
@@ -86,7 +175,8 @@ export const parseSearchTermsProgressively = (trimmedSearchQuery: string): strin
       const colonIndex = trimmedCurrentTerm.indexOf(":");
       const valueAfterColon =
         colonIndex === -1 ? "" : trimmedCurrentTerm.substring(colonIndex + 1).trim();
-      const nextTokenHasColon = upcomingTokenContainsColon(i + 1);
+      const nextTokenHasColon = upcomingTokenStartsKnownFilter(i + 1);
+      const nextTokenContainsColon = upcomingTokenContainsColon(i + 1);
       const endsWithComma = trimmedCurrentTerm.endsWith(",");
       const endsWithQuote = trimmedCurrentTerm.endsWith('"') || trimmedCurrentTerm.endsWith("'");
       const normalizedTerm = normalizeSearchKeyword(trimmedCurrentTerm);
@@ -94,7 +184,7 @@ export const parseSearchTermsProgressively = (trimmedSearchQuery: string): strin
       if (
         colonIndex === -1 &&
         !endsWithQuote &&
-        nextTokenHasColon &&
+        nextTokenContainsColon &&
         multiWordFilterPrefixes.has(normalizedTerm)
       ) {
         currentTerm += char;
@@ -122,7 +212,34 @@ export const parseSearchTermsProgressively = (trimmedSearchQuery: string): strin
 
 const normalizeSearchValue = (value: any): string => String(value).trim().toLowerCase();
 
+export const isNoneSearchToken = (query: string): boolean =>
+  String(query)
+    .trim()
+    .toLowerCase()
+    .replace(/["']/g, "")
+    .replace(/[\s_]+/g, "") === "none";
+
+const isNoneLikeValue = (value: any): boolean => {
+  if (value === undefined || value === null) {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+
+  if (typeof value === "string") {
+    return value.trim() === "";
+  }
+
+  return false;
+};
+
 export const checkStringContains = (value: any, query: string): boolean => {
+  if (isNoneSearchToken(query)) {
+    return isNoneLikeValue(value);
+  }
+
   if (value === undefined || value === null) {
     return false;
   }
@@ -130,6 +247,10 @@ export const checkStringContains = (value: any, query: string): boolean => {
 };
 
 export const checkStringEquals = (value: any, query: string): boolean => {
+  if (isNoneSearchToken(query)) {
+    return isNoneLikeValue(value);
+  }
+
   if (value === undefined || value === null) {
     return false;
   }
@@ -192,13 +313,14 @@ const stripLooseWrappingQuotes = (value: string): string => {
 };
 
 export const splitFilterValues = (searchValue: string): string[] => {
+  const normalizedSearchValue = searchValue.replace(/;\s*$/, "");
   const values: string[] = [];
   let currentValue = "";
   let inQuote = false;
   let quoteChar = "";
 
-  for (let i = 0; i < searchValue.length; i++) {
-    const char = searchValue[i];
+  for (let i = 0; i < normalizedSearchValue.length; i++) {
+    const char = normalizedSearchValue[i];
 
     if (!inQuote && (char === '"' || char === "'")) {
       inQuote = true;

--- a/my-app/src/utils/searchFilter.ts
+++ b/my-app/src/utils/searchFilter.ts
@@ -98,13 +98,12 @@ export const parseSearchTermsProgressively = (trimmedSearchQuery: string): strin
         multiWordFilterPrefixes.has(normalizedTerm)
       ) {
         currentTerm += char;
-      } else if (
-        colonIndex !== -1 &&
-        (valueAfterColon === "" ||
-          (endsWithComma && !nextTokenHasColon) ||
-          nextChar === '"' ||
-          nextChar === "'")
-      ) {
+      } else if (colonIndex !== -1 && valueAfterColon === "") {
+        currentTerm += char;
+      } else if (colonIndex !== -1 && nextTokenHasColon) {
+        pushCurrentTerm(endsWithComma && nextTokenHasColon);
+      } else if (colonIndex !== -1) {
+        // Keep unquoted multi-word values together until a new key:value starts.
         currentTerm += char;
       } else if (trimmedCurrentTerm) {
         pushCurrentTerm(endsWithComma && nextTokenHasColon);
@@ -165,6 +164,33 @@ const stripWrappingQuotes = (value: string): string => {
   return trimmedValue;
 };
 
+const stripLooseWrappingQuotes = (value: string): string => {
+  const trimmedValue = value.trim();
+
+  if (!trimmedValue) {
+    return trimmedValue;
+  }
+
+  const startsWithDouble = trimmedValue.startsWith('"');
+  const endsWithDouble = trimmedValue.endsWith('"');
+  const startsWithSingle = trimmedValue.startsWith("'");
+  const endsWithSingle = trimmedValue.endsWith("'");
+
+  if ((startsWithDouble && endsWithDouble) || (startsWithSingle && endsWithSingle)) {
+    return stripWrappingQuotes(trimmedValue);
+  }
+
+  if (startsWithDouble || startsWithSingle) {
+    return trimmedValue.slice(1).trim();
+  }
+
+  if (endsWithDouble || endsWithSingle) {
+    return trimmedValue.slice(0, -1).trim();
+  }
+
+  return trimmedValue;
+};
+
 export const splitFilterValues = (searchValue: string): string[] => {
   const values: string[] = [];
   let currentValue = "";
@@ -183,7 +209,7 @@ export const splitFilterValues = (searchValue: string): string[] => {
       inQuote = false;
       quoteChar = "";
     } else if (!inQuote && char === ",") {
-      const normalizedValue = stripWrappingQuotes(currentValue);
+      const normalizedValue = stripLooseWrappingQuotes(currentValue);
       if (normalizedValue) {
         values.push(normalizedValue);
       }
@@ -193,7 +219,7 @@ export const splitFilterValues = (searchValue: string): string[] => {
     }
   }
 
-  const normalizedValue = stripWrappingQuotes(currentValue);
+  const normalizedValue = stripLooseWrappingQuotes(currentValue);
   if (normalizedValue) {
     values.push(normalizedValue);
   }
@@ -202,7 +228,7 @@ export const splitFilterValues = (searchValue: string): string[] => {
 };
 
 export const normalizeSearchKeyword = (value: string): string =>
-  value.toLowerCase().replace(/[\s_]+/g, "");
+  stripLooseWrappingQuotes(value).toLowerCase().replace(/["']/g, "").replace(/[\s_]+/g, "");
 
 export const isPartialFieldName = (term: string, fieldNames: string[]): boolean => {
   const lowerTerm = term.toLowerCase();
@@ -222,11 +248,11 @@ export const extractKeyValue = (
     let searchValue = term.substring(colonIndex + 1).trim();
 
     if (!searchValue.includes(",")) {
-      searchValue = stripWrappingQuotes(searchValue);
+      searchValue = stripLooseWrappingQuotes(searchValue);
     }
 
     return {
-      keyword: term.substring(0, colonIndex).trim().toLowerCase(),
+      keyword: stripLooseWrappingQuotes(term.substring(0, colonIndex)).toLowerCase(),
       searchValue: searchValue,
       isKeyValue: true,
     };

--- a/my-app/src/utils/searchFilter.ts
+++ b/my-app/src/utils/searchFilter.ts
@@ -11,6 +11,9 @@ export const parseSearchTermsProgressively = (trimmedSearchQuery: string): strin
 
   const multiWordFilterPrefixes = new Set([
     "assigned",
+    "fam",
+    "fam start",
+    "famstart",
     "cluster",
     "delivery",
     "dietary",
@@ -68,6 +71,7 @@ export const parseSearchTermsProgressively = (trimmedSearchQuery: string): strin
       "tefap cert",
       "tefapcert",
       "dob",
+      "fam start date",
       "last delivery date",
     ].map((keyword) => normalizeSearchKeyword(keyword))
   );
@@ -104,6 +108,46 @@ export const parseSearchTermsProgressively = (trimmedSearchQuery: string): strin
       if (trimmedSearchQuery[index] === ":") {
         return true;
       }
+      index += 1;
+    }
+
+    return false;
+  };
+
+  const upcomingPhraseCompletesKnownFilter = (
+    startIndex: number,
+    currentKeywordPrefix: string
+  ): boolean => {
+    const normalizedPrefix = normalizeSearchKeyword(currentKeywordPrefix);
+    if (!normalizedPrefix || !multiWordFilterPrefixes.has(normalizedPrefix)) {
+      return false;
+    }
+
+    let index = startIndex;
+
+    while (index < trimmedSearchQuery.length && trimmedSearchQuery[index] === " ") {
+      index += 1;
+    }
+
+    const phraseStart = index;
+
+    while (index < trimmedSearchQuery.length) {
+      const char = trimmedSearchQuery[index];
+
+      if (char === ":") {
+        const trailingKeywordPart = trimmedSearchQuery.slice(phraseStart, index).trim();
+        if (!trailingKeywordPart) {
+          return false;
+        }
+
+        const fullCandidateKeyword = `${currentKeywordPrefix.trim()} ${trailingKeywordPart}`.trim();
+        return knownFilterKeywords.has(normalizeSearchKeyword(fullCandidateKeyword));
+      }
+
+      if (char === ";" || char === ",") {
+        return false;
+      }
+
       index += 1;
     }
 
@@ -184,8 +228,9 @@ export const parseSearchTermsProgressively = (trimmedSearchQuery: string): strin
       if (
         colonIndex === -1 &&
         !endsWithQuote &&
-        nextTokenContainsColon &&
-        multiWordFilterPrefixes.has(normalizedTerm)
+        multiWordFilterPrefixes.has(normalizedTerm) &&
+        (nextTokenContainsColon ||
+          upcomingPhraseCompletesKnownFilter(i + 1, trimmedCurrentTerm))
       ) {
         currentTerm += char;
       } else if (colonIndex !== -1 && valueAfterColon === "") {


### PR DESCRIPTION
- Multiple rows are now highlighted when selecting more than one item on the map
- You can also select multiple rows and it opens up more than one item on the map
- You can deslect multipule rows from the spreadsheet and it deselects them from the map
- You can now bring the popup you select to the top of the layers if you click it
- The spreadsheet will now scroll to the last popup that was clicked, 
- Each search/filter will allow for two words to be either with or without quotes for both the key and value
- Each search/fitler allows for inline autocomplete on the keys, meaning if you begin to type it will give you a suggestion, each key value pair needs to be seperated by the semi-colon for additional key/value pairs to work 
- Fixed the Navigation issue on the Calendar page that for some reason when going back and forth the data would sometimes be consistant sometimes not
- Routes page, assign driver and time is now one modal and one button to open the modal, modal has two dropdowns.
- Routes page allows for selecting unassigned markers in mass by sorted items so you can mass assign unassigned markers to the cluster using the spreadsheet
- Optimized geocoding so that it only does geocodes if the addresses change 
- When the user uses the fiter on the routes page if they have items checked on the spreadhseet and they use the x button to clear the filter it will also clear the checkboxes

************************
5/4 additions
- We now have a save filter on the routes page, it allow 5 searches, you can save their names, if you save a name that already exists, it will ask you if you want to overwrite the existing filter. You can also delete an individual saved filter
- Day Calendar has a sticky header for the column names instead of repeating them on the cards
- Add Delivery Modal now has a new Monthly Recurrence Pattern that lets you assign deliveries on X position every Y day of the week (example: Every 3rd Monday)
- Senior column is added to the spreadsheets on the route page when they download totals remain consistent with it

*****************

5/9 addititons
- Reset clusters button has a yes/no diaglogue
- autocomplete uses fam start date, not familty start date
- If rows are highlighted and reassigned to new clusters they stay highlighted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-row map popups with multi-row highlights; inline key-based search autocomplete; saved-searches UI and saved-filters menu; combined “Assign Driver & Time” flow; new Monthly-Pattern recurrence option.

* **Bug Fixes & Improvements**
  * Improved popup stacking and targeted close behavior; stable calendar fetches against stale responses; delivery reads/writes use authoritative IDs; search treats “none” as matching empty/missing values and uses semicolon-separated filters; exports now include seniors in passenger totals.

* **Style**
  * Delivery card layout and typography refinements.

* **Tests**
  * Expanded autocomplete, parsing, calendar, recurrence, and delivery-service test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->