### PR TITLE
Remove admin login text

### DIFF
--- a/my-app/src/pages/Login/Login.tsx
+++ b/my-app/src/pages/Login/Login.tsx
@@ -151,8 +151,6 @@ function Login() {
           <h1 className={styles.heading}>Welcome!</h1>
           <p className={styles.subheading}>Please enter your details</p>
 
-          <p className={styles.label}>Admin Login</p>
-
           <TextField
             label="Email"
             variant="outlined"


### PR DESCRIPTION
## What changed

Removed the “Admin Login” label from the login page.

## Why

The login page should not display that admin-specific text.

## Impact

No authentication behavior changes; this is a presentation-only update.

## Validation

- `npm run lint`
- `npx tsc --noEmit`
- `CI=true npm run test:ci` with the workflow’s placeholder environment (26 suites, 145 tests)
- `npm run build`