### PR TITLE
Fix search autocomplete segment boundary

### DIFF
--- a/my-app/src/hooks/useSearchKeyAutocomplete.test.tsx
+++ b/my-app/src/hooks/useSearchKeyAutocomplete.test.tsx
@@ -101,6 +101,39 @@ describe("useSearchKeyAutocomplete", () => {
     expect(input.value).not.toBe("cluster id");
   });
 
+  it("does not autocomplete a key-like suffix inside plain search text", () => {
+    render(<Harness />);
+    const input = screen.getByRole("textbox", { name: "search" }) as HTMLInputElement;
+
+    input.focus();
+    fireEvent.focus(input);
+
+    for (const value of ["t", "to", "tok", "toke", "token"]) {
+      fireEvent.change(input, {
+        target: { value, selectionStart: value.length, selectionEnd: value.length },
+      });
+    }
+
+    expect(input.value).toBe("token");
+    expect(input.selectionStart).toBe("token".length);
+    expect(input.selectionEnd).toBe("token".length);
+  });
+
+  it("still autocompletes a key after a semicolon following plain search text", () => {
+    render(<Harness />);
+    const input = screen.getByRole("textbox", { name: "search" }) as HTMLInputElement;
+
+    input.focus();
+    fireEvent.focus(input);
+
+    const query = "smith;n";
+    fireEvent.change(input, {
+      target: { value: query, selectionStart: query.length, selectionEnd: query.length },
+    });
+
+    expect(input.value).toBe("smith;name");
+  });
+
   it("does not start next key autocomplete after a value until a semicolon is typed", () => {
     render(<Harness />);
     const input = screen.getByRole("textbox", { name: "search" }) as HTMLInputElement;

--- a/my-app/src/hooks/useSearchKeyAutocomplete.ts
+++ b/my-app/src/hooks/useSearchKeyAutocomplete.ts
@@ -24,63 +24,20 @@ const getSegmentInfo = (
     return null;
   }
 
-  const findMatchingKeyStart = (text: string): number | null => {
-    // Prefer the straightforward segment-start key candidate first so both
-    // ";nextKey" and "; nextKey" behave the same.
-    const segmentLeadingWhitespace = (text.match(/^\s*/) ?? [""])[0].length;
-    const segmentStartCandidateRaw = text.slice(segmentLeadingWhitespace);
-    const normalizedSegmentStartCandidate = normalizeSearchKeyword(segmentStartCandidateRaw);
+  // A key can only begin the current semicolon-delimited segment. Searching
+  // arbitrary suffixes would turn plain text such as "token" into "tokename".
+  const leadingWhitespace = (preCursorSegment.match(/^\s*/) ?? [""])[0].length;
+  const keyCandidate = preCursorSegment.slice(leadingWhitespace);
+  const normalizedCandidate = normalizeSearchKeyword(keyCandidate);
+  const hasPrefixMatch = normalizedSuggestions.some((suggestion) =>
+    suggestion.normalized.startsWith(normalizedCandidate)
+  );
 
-    if (normalizedSegmentStartCandidate) {
-      const hasSegmentStartPrefixMatch = normalizedSuggestions.some((suggestion) =>
-        suggestion.normalized.startsWith(normalizedSegmentStartCandidate)
-      );
-
-      if (hasSegmentStartPrefixMatch) {
-        return segmentLeadingWhitespace;
-      }
-    }
-
-    let bestMatchStart: number | null = null;
-    let bestMatchLength = -1;
-
-    for (let start = 0; start < text.length; start += 1) {
-      const candidateRaw = text.slice(start);
-      if (candidateRaw.includes(":")) {
-        continue;
-      }
-
-      const leadingWhitespace = (candidateRaw.match(/^\s*/) ?? [""])[0];
-      const keyCandidate = candidateRaw.slice(leadingWhitespace.length);
-      if (!keyCandidate.trim()) {
-        continue;
-      }
-
-      const normalizedCandidate = normalizeSearchKeyword(keyCandidate);
-      if (!normalizedCandidate) {
-        continue;
-      }
-
-      const hasPrefixMatch = normalizedSuggestions.some((suggestion) =>
-        suggestion.normalized.startsWith(normalizedCandidate)
-      );
-
-      if (hasPrefixMatch && normalizedCandidate.length > bestMatchLength) {
-        bestMatchStart = start + leadingWhitespace.length;
-        bestMatchLength = normalizedCandidate.length;
-      }
-    }
-
-    return bestMatchStart;
-  };
-
-  const activeOffsetWithinSegment = findMatchingKeyStart(preCursorSegment);
-
-  if (activeOffsetWithinSegment === null) {
+  if (!normalizedCandidate || !hasPrefixMatch) {
     return null;
   }
 
-  const keyStart = baseStart + activeOffsetWithinSegment;
+  const keyStart = baseStart + leadingWhitespace;
 
   const nextSemicolonFromKey = value.indexOf(";", keyStart);
   const endBoundary = nextSemicolonFromKey === -1 ? value.length : nextSemicolonFromKey;


### PR DESCRIPTION
## What changed

- Restrict search-key autocomplete to the beginning of the current semicolon-delimited segment.
- Remove the arbitrary suffix scan that could rewrite plain client-name searches such as `belen` to `belename`.
- Add regressions for plain-text suffixes and autocomplete after a semicolon.

## Why

The shared autocomplete hook treated any suffix of ordinary search text as a possible key prefix. A final `n` could therefore be interpreted as the beginning of the `name` key and inserted into the controlled input.

This keeps matching, parsing, suggestion insertion, keyboard commits, and all three callers unchanged. Only the key-start boundary is corrected.

## Validation

- Focused autocomplete/search suites: 5 suites, 51 tests passed
- Full frontend suite: 26 suites, 147 tests passed
- ESLint: 0 errors (2 pre-existing Profile hook warnings)
- TypeScript: passed
- Production build: passed
- Frontend audit gate: passed
- Python dependency audit and compile gates: passed
- Local built-in Browser: verified Clients and Routes search behavior, including plain text, key insertion/selection, Tab commit, values after `:`, keys after `;`, and Backspace; no console errors
- Users browser route was unavailable to the local role; its dedicated autocomplete and search-filter tests passed