### PR TITLE
July 26 fixes

### DIFF
--- a/ETL/README.md
+++ b/ETL/README.md
@@ -303,7 +303,7 @@ Below is the current mapping used by `ETL/firebase_migration_v2.py` for the new 
 | `StartDate_database` or `StartDate_referral` or `Start Date` | `startDate` |
 | `EndDate` or `End Date` (defaulted/validated by ETL) | `endDate` |
 | `TEFAP_FY25` / `TEFAP FY25` / `TEFAP FY26` | `tefapCertDate` (`03/15/2026` when true, blank when false), legacy `tefapCert`, and `tags` (`TEFAPOnFile`) |
-| `Active` and date-window logic | `activeStatus` and `tags` (`Active`) |
+| `Active` and date-window logic | `activeStatus` |
 
 ### Client Referral Form v.3_20_24 (Responses).xlsx (sheet: `Form Responses 1`) -> `referral`
 

--- a/ETL/firebase_migration_v2.py
+++ b/ETL/firebase_migration_v2.py
@@ -1648,8 +1648,10 @@ class FirestoreMigration:
 			excel_row_num_int = None
 		if excel_row_num_int is not None and SATURDAY_DELIVERY_ROW_START <= excel_row_num_int <= SATURDAY_DELIVERY_ROW_END:
 			tags.append("Saturday Delivery")
-		if str(active_status).lower() in ['yes', 'true', '1', 'active', 'y']:
-			tags.append("Active")
+		# Old requirement: we used to keep the source Active value as a visible tag.
+		# We are not keeping that tag anymore; activeStatus remains the status field.
+		# if str(active_status).lower() in ['yes', 'true', '1', 'active', 'y']:
+		# 	tags.append("Active")
 		delivery_freq = self.parse_frequency(row.get("Frequency", ""))
 		# Household composition: support Adults_database/kids or Excel '# Adults'/'# kids'
 		adults_raw = row.get("Adults_database") if row.get("Adults_database") is not None else row.get("# Adults")

--- a/ETL/firebase_migration_v2.py
+++ b/ETL/firebase_migration_v2.py
@@ -96,6 +96,21 @@ def normalize_tefap_cert_date(value):
 	return TEFAP_FY26_CERT_DATE if normalize_tefap_cert_value(value) else ""
 
 
+def normalize_phone_for_save(value: Any) -> str:
+	"""Normalize US phone numbers to (XXX) XXX-XXXX when possible."""
+	if value is None:
+		return ""
+	trimmed_value = str(value).strip()
+	if not trimmed_value:
+		return ""
+
+	digits = re.sub(r"\D", "", trimmed_value)
+	national_digits = digits[1:] if len(digits) == 11 and digits.startswith("1") else digits
+	match = re.match(r"^(\d{3})(\d{3})(\d{4})$", national_digits)
+
+	return f"({match.group(1)}) {match.group(2)}-{match.group(3)}" if match else trimmed_value
+
+
 class _InfoOnlyFilter(logging.Filter):
 	"""Filter that lets only INFO-and-below records through.
 
@@ -937,7 +952,7 @@ class FirestoreMigration:
 						"name": str(base_ref.get("name", "")),
 						"organization": str(base_ref.get("organization", "")),
 						"email": str(transformed.get("_referralContactEmail", "")),
-						"phone": str(transformed.get("_referralContactPhone", "")),
+						"phone": normalize_phone_for_save(transformed.get("_referralContactPhone", "")),
 					}
 				# Only insert if we have at least a name or organization
 				if referral and (referral.get("name") or referral.get("organization")):
@@ -1029,7 +1044,7 @@ class FirestoreMigration:
 									found_existing = True
 							if not found_existing:
 								# Build referral doc
-								phone_from_referral = str(referral.get("phone", "") or "").strip()
+								phone_from_referral = normalize_phone_for_save(referral.get("phone", ""))
 								referral_doc = {
 									"name": str(referral.get("name", "")),
 									"organization": str(referral.get("organization", "")),
@@ -1045,7 +1060,7 @@ class FirestoreMigration:
 								]
 								for pf in phone_fields:
 									if not referral_doc["phone"] and pf and str(pf).strip():
-										referral_doc["phone"] = str(pf).strip()
+										referral_doc["phone"] = normalize_phone_for_save(pf)
 										break
 								# Insert into referral collection and get the doc ID
 								try:
@@ -1580,6 +1595,49 @@ class FirestoreMigration:
 			if not text or text.lower() == "nan":
 				return ""
 			return text
+
+		def _extract_quadrant_abbreviation(value: Any) -> str:
+			"""Return normalized DC quadrant token (NW/NE/SW/SE) or empty string."""
+			cleaned = _clean_name(value)
+			if not cleaned:
+				return ""
+			standardized = re.sub(
+				r"\b(northwest|northeast|southwest|southeast)\b",
+				lambda m: {
+					"northwest": "NW",
+					"northeast": "NE",
+					"southwest": "SW",
+					"southeast": "SE",
+				}.get(m.group(1).lower(), m.group(0)),
+				cleaned,
+				flags=re.IGNORECASE,
+			)
+			match = re.search(r"\b(NE|NW|SE|SW)\b", standardized, flags=re.IGNORECASE)
+			return match.group(1).upper() if match else ""
+
+		def _normalize_address_directions(value: Any) -> str:
+			"""Normalize spelled-out DC directions in address text to NW/NE/SW/SE."""
+			cleaned = _clean_name(value)
+			if not cleaned:
+				return ""
+			return re.sub(
+				r"\b(northwest|northeast|southwest|southeast)\b",
+				lambda m: {
+					"northwest": "NW",
+					"northeast": "NE",
+					"southwest": "SW",
+					"southeast": "SE",
+				}.get(m.group(1).lower(), m.group(0)),
+				cleaned,
+				flags=re.IGNORECASE,
+			)
+
+		def _is_street_style_address(value: Any) -> bool:
+			"""Heuristic: real street addresses usually include at least one digit."""
+			cleaned = _clean_name(value)
+			if not cleaned:
+				return False
+			return bool(re.search(r"\d", cleaned))
 		first_name_raw = row.get("FIRST_database") or row.get("FIRST", "")
 		last_name_raw = row.get("LAST_database") or row.get("LAST", "")
 		first_name = _clean_name(first_name_raw)
@@ -1600,7 +1658,7 @@ class FirestoreMigration:
 			if '@' in phone_str:
 				email = phone_str
 			else:
-				phone = phone_str
+				phone = normalize_phone_for_save(phone_str)
 
 		# Dietary restrictions and vulnerability fields: handle both JSON and Excel headers
 		restrictions = self.parse_dietary_restrictions(
@@ -1618,12 +1676,12 @@ class FirestoreMigration:
 		mental_health_conditions = self.parse_mental_health_conditions(main_vulnerability, eligibility_database, unnamed_29, further_information)
 		life_challenges = self.parse_life_challenges(main_vulnerability, eligibility_database, unnamed_29, further_information)
 		referral_entity = self.parse_referral_entity(row, referral_form_records=referral_form_records)
-		referral_phone = referral_entity.get("phone", "") if referral_entity else ""
+		referral_phone = normalize_phone_for_save(referral_entity.get("phone", "")) if referral_entity else ""
 		referral_email = referral_entity.get("email", "") if referral_entity else ""
 		notes_raw = row.get("Notes", "")
 		notes = "" if pd.isna(notes_raw) else str(notes_raw)
 		if not phone and referral_entity and referral_entity.get("phone"):
-			phone = referral_entity["phone"]
+			phone = normalize_phone_for_save(referral_entity["phone"])
 			if notes:
 				notes += " | Phone number is from Referral Entity."
 			else:
@@ -1687,12 +1745,13 @@ class FirestoreMigration:
 
 		# --- Address handling: use main address up to quadrant for geocoding,
 		# and capture apartment/unit suffix into address2 when possible. ---
-		raw_address = _clean_name(row.get("ADDRESS"))
+		raw_address = _normalize_address_directions(row.get("ADDRESS"))
 		apt_from_col = _clean_name(row.get("APT")) or _clean_name(row.get("APT #"))
 		apt_from_address = ""
-		quadrant_value = _clean_name(row.get("Quadrant_database")) or _clean_name(row.get("Quadrant"))
+		quadrant_value = _extract_quadrant_abbreviation(row.get("Quadrant_database")) or _extract_quadrant_abbreviation(row.get("Quadrant"))
 		quadrant_match = re.search(r"\b(NE|NW|SE|SW)\b", raw_address)
 		if quadrant_match:
+			quadrant_value = quadrant_match.group(1).upper()
 			end_idx = quadrant_match.end()
 			address_for_coords = raw_address[:end_idx].strip()
 			# Anything after the quadrant may contain apartment/unit info
@@ -1710,6 +1769,15 @@ class FirestoreMigration:
 				label = m.group(1)
 				rest = m.group(2).strip()
 				apt_from_address = f"{label} {rest}".strip() if rest else label
+		# Spreadsheet often stores quadrant in a separate column; append it when the
+		# address string is missing a quadrant token so downstream UIs/exports are consistent.
+		# Skip status/non-address text rows (e.g., "DECEASED", "MOVED").
+		if (
+			quadrant_value
+			and _is_street_style_address(address_for_coords)
+			and not re.search(r"\b(NE|NW|SE|SW)\b", address_for_coords, flags=re.IGNORECASE)
+		):
+			address_for_coords = f"{address_for_coords} {quadrant_value}".strip()
 		address = address_for_coords
 		city = _clean_name(row.get("City"))
 		state = _clean_name(row.get("State"))

--- a/my-app/src/components/DriverManagementModal.sorting.test.tsx
+++ b/my-app/src/components/DriverManagementModal.sorting.test.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, jest } from "@jest/globals";
+import DriverManagementModal from "./DriverManagementModal";
+
+jest.mock("firebase/firestore", () => ({
+  doc: () => undefined,
+  updateDoc: async () => undefined,
+  addDoc: async () => ({ id: "mock-driver" }),
+  deleteDoc: async () => undefined,
+  collection: () => undefined,
+}));
+
+jest.mock("../auth/firebaseConfig", () => ({
+  db: {},
+}));
+
+jest.mock("./ConfirmationModal", () => () => null);
+
+describe("DriverManagementModal sorting", () => {
+  const baseDrivers = [
+    {
+      id: "driver-10",
+      name: "Saturday Driver 10",
+      phone: "2021112222",
+      email: "saturday@foodforalldc.org",
+    },
+    {
+      id: "driver-2",
+      name: "Saturday Driver 2",
+      phone: "2021112222",
+      email: "saturday@foodforalldc.org",
+    },
+    {
+      id: "driver-1",
+      name: "Saturday Driver 1",
+      phone: "2021112222",
+      email: "saturday@foodforalldc.org",
+    },
+    {
+      id: "driver-11",
+      name: "Saturday Driver 11",
+      phone: "2021112222",
+      email: "saturday@foodforalldc.org",
+    },
+  ];
+
+  const renderModal = () => {
+    render(
+      <DriverManagementModal
+        open={true}
+        onClose={jest.fn()}
+        drivers={baseDrivers}
+        onDriversChange={jest.fn()}
+      />
+    );
+  };
+
+  it("sorts driver names using natural numeric order in ascending mode", () => {
+    renderModal();
+
+    const driverNames = screen.getAllByText(/Saturday Driver \d+/).map((node) => node.textContent);
+
+    expect(driverNames).toEqual([
+      "Saturday Driver 1",
+      "Saturday Driver 2",
+      "Saturday Driver 10",
+      "Saturday Driver 11",
+    ]);
+  });
+
+  it("sorts driver names using natural numeric order in descending mode", () => {
+    renderModal();
+
+    fireEvent.click(screen.getByText("Driver"));
+
+    const driverNames = screen.getAllByText(/Saturday Driver \d+/).map((node) => node.textContent);
+
+    expect(driverNames).toEqual([
+      "Saturday Driver 11",
+      "Saturday Driver 10",
+      "Saturday Driver 2",
+      "Saturday Driver 1",
+    ]);
+  });
+});

--- a/my-app/src/components/DriverManagementModal.tsx
+++ b/my-app/src/components/DriverManagementModal.tsx
@@ -138,11 +138,20 @@ const DriverManagementModal: React.FC<DriverManagementModalProps> = ({
   // Sorted drivers
   const sortedDrivers = React.useMemo(() => {
     const sorted = [...drivers].sort((a, b) => {
-      const aValue = (a[sortConfig.key] || "").toString().toLowerCase();
-      const bValue = (b[sortConfig.key] || "").toString().toLowerCase();
-      if (aValue < bValue) return sortConfig.direction === "asc" ? -1 : 1;
-      if (aValue > bValue) return sortConfig.direction === "asc" ? 1 : -1;
-      return 0;
+      const aRawValue = (a[sortConfig.key] || "").toString();
+      const bRawValue = (b[sortConfig.key] || "").toString();
+
+      const aComparable =
+        sortConfig.key === "phone" ? aRawValue.replace(/\D/g, "") : aRawValue.trim();
+      const bComparable =
+        sortConfig.key === "phone" ? bRawValue.replace(/\D/g, "") : bRawValue.trim();
+
+      const comparison = aComparable.localeCompare(bComparable, undefined, {
+        sensitivity: "base",
+        numeric: true,
+      });
+
+      return sortConfig.direction === "asc" ? comparison : -comparison;
     });
     return sorted;
   }, [drivers, sortConfig]);

--- a/my-app/src/components/Spreadsheet/Spreadsheet.tsx
+++ b/my-app/src/components/Spreadsheet/Spreadsheet.tsx
@@ -86,6 +86,7 @@ import { useNotifications } from "../NotificationProvider";
 import { CsvExportError } from "../../utils/csvExport";
 import { getClientStatusPresentation } from "../../utils/clientStatus";
 import type { ClientDeliverySummary } from "../../utils/lastDeliveryDate";
+import { formatAddressWithQuadrantAndUnit } from "../../utils/addressFormat";
 
 const addablePropertyKeyLabelMap: Record<string, string> = {
   address: "Address",
@@ -608,6 +609,7 @@ const Spreadsheet: React.FC = () => {
               tefapCertDate: client.tefapCertDate || "",
               dob: client.dob || "",
               ward: client.ward || "",
+              quadrant: client.quadrant || "",
               zipCode: client.zipCode || "",
               tags: client.tags || [],
               referralEntity: client.referralEntity
@@ -773,14 +775,8 @@ const Spreadsheet: React.FC = () => {
         key: "address",
         label: "Address",
         type: "text",
-        compute: (data: RowData) => {
-          // Append address2 (apartment/unit) if present
-          const address2 = typeof data.address2 === "string" ? data.address2 : "";
-          if (address2.trim() !== "") {
-            return `${data.address} ${address2}`.trim();
-          }
-          return data.address;
-        },
+        compute: (data: RowData) =>
+          formatAddressWithQuadrantAndUnit(data.address, data.quadrant, data.address2),
       },
       { key: "phone", label: "Phone", type: "text" },
       {

--- a/my-app/src/components/Spreadsheet/export.tsx
+++ b/my-app/src/components/Spreadsheet/export.tsx
@@ -2,7 +2,6 @@ import { CsvRow, downloadCsv } from "../../utils/csvExport";
 import { getNestedValue } from "../../utils/misc";
 import { formatDietaryRestrictionsForExport } from "../../utils/exportFormatters";
 import { deliveryDate } from "../../utils/deliveryDate";
-import { formatAddressWithQuadrant } from "../../utils/addressFormat";
 
 export interface RowData {
   id: string;
@@ -15,7 +14,6 @@ export interface RowData {
   houseNumber?: number;
   address: string;
   address2?: string;
-  quadrant?: string;
   deliveryDetails: {
     deliveryInstructions: string;
     dietaryRestrictions: {
@@ -131,10 +129,6 @@ const normalizeDateValue = (value: unknown): string => {
 };
 
 const resolveSpreadsheetExportValue = (row: RowData, propertyKey: string): string => {
-  if (propertyKey === "address") {
-    return formatAddressWithQuadrant(row.address, row.quadrant);
-  }
-
   if (propertyKey === "deliveryDetails.dietaryRestrictions") {
     return formatDietaryRestrictionsForExport(row.deliveryDetails?.dietaryRestrictions);
   }
@@ -193,7 +187,7 @@ export const exportQueryResults = (
     // Start with the base columns that are always visible
     const baseData: CsvRow = {
       Name: `${row.lastName}, ${row.firstName}`,
-      Address: formatAddressWithQuadrant(row.address, row.quadrant),
+      Address: row.address,
       "Address 2": row.address2 || "",
       Phone: row.phone ?? "",
       "Delivery Instructions": row.deliveryDetails?.deliveryInstructions || "None",
@@ -227,7 +221,7 @@ export const exportAllClients = (rows: RowData[]) => {
       UID: row.uid,
       Name: `${row.lastName}, ${row.firstName}`,
       Phone: row.phone ?? "",
-      Address: formatAddressWithQuadrant(row.address, row.quadrant),
+      Address: row.address,
       "Address 2": row.address2 || "",
       "House Number": row.houseNumber ?? "",
       "Street Name": row.streetName ?? "",

--- a/my-app/src/components/Spreadsheet/export.tsx
+++ b/my-app/src/components/Spreadsheet/export.tsx
@@ -2,6 +2,7 @@ import { CsvRow, downloadCsv } from "../../utils/csvExport";
 import { getNestedValue } from "../../utils/misc";
 import { formatDietaryRestrictionsForExport } from "../../utils/exportFormatters";
 import { deliveryDate } from "../../utils/deliveryDate";
+import { formatAddressWithQuadrant } from "../../utils/addressFormat";
 
 export interface RowData {
   id: string;
@@ -14,6 +15,7 @@ export interface RowData {
   houseNumber?: number;
   address: string;
   address2?: string;
+  quadrant?: string;
   deliveryDetails: {
     deliveryInstructions: string;
     dietaryRestrictions: {
@@ -129,6 +131,10 @@ const normalizeDateValue = (value: unknown): string => {
 };
 
 const resolveSpreadsheetExportValue = (row: RowData, propertyKey: string): string => {
+  if (propertyKey === "address") {
+    return formatAddressWithQuadrant(row.address, row.quadrant);
+  }
+
   if (propertyKey === "deliveryDetails.dietaryRestrictions") {
     return formatDietaryRestrictionsForExport(row.deliveryDetails?.dietaryRestrictions);
   }
@@ -187,7 +193,7 @@ export const exportQueryResults = (
     // Start with the base columns that are always visible
     const baseData: CsvRow = {
       Name: `${row.lastName}, ${row.firstName}`,
-      Address: row.address,
+      Address: formatAddressWithQuadrant(row.address, row.quadrant),
       "Address 2": row.address2 || "",
       Phone: row.phone ?? "",
       "Delivery Instructions": row.deliveryDetails?.deliveryInstructions || "None",
@@ -221,7 +227,7 @@ export const exportAllClients = (rows: RowData[]) => {
       UID: row.uid,
       Name: `${row.lastName}, ${row.firstName}`,
       Phone: row.phone ?? "",
-      Address: row.address,
+      Address: formatAddressWithQuadrant(row.address, row.quadrant),
       "Address 2": row.address2 || "",
       "House Number": row.houseNumber ?? "",
       "Street Name": row.streetName ?? "",

--- a/my-app/src/pages/Delivery/ClusterMap.tsx
+++ b/my-app/src/pages/Delivery/ClusterMap.tsx
@@ -234,6 +234,8 @@ const clusterColors = [
   "#4169E1",
 ];
 
+const POPUP_VIEWPORT_MARGIN_PX = 16;
+
 const ClusterMap: React.FC<ClusterMapProps> = ({
   allRows,
   visibleRows,
@@ -302,6 +304,47 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
 
     callback(map);
   }, []);
+
+  const repositionPopupIntoViewport = useCallback((popupElement: HTMLElement) => {
+    if (!popupElement.isConnected) {
+      return;
+    }
+
+    withLiveMap((map) => {
+      map.stop();
+      const popupRect = popupElement.getBoundingClientRect();
+      const mapRect = map.getContainer().getBoundingClientRect();
+
+      const minLeft = mapRect.left + POPUP_VIEWPORT_MARGIN_PX;
+      const maxRight = mapRect.right - POPUP_VIEWPORT_MARGIN_PX;
+      const minTop = mapRect.top + POPUP_VIEWPORT_MARGIN_PX;
+      const maxBottom = mapRect.bottom - POPUP_VIEWPORT_MARGIN_PX;
+
+      let dx = 0;
+      let dy = 0;
+
+      if (popupRect.left < minLeft) {
+        dx = popupRect.left - minLeft;
+      } else if (popupRect.right > maxRight) {
+        dx = popupRect.right - maxRight;
+      }
+
+      if (popupRect.top < minTop) {
+        dy = popupRect.top - minTop;
+      } else if (popupRect.bottom > maxBottom) {
+        dy = popupRect.bottom - maxBottom;
+      }
+
+      // Only pan when popup would render outside the map viewport.
+      if (dx !== 0 || dy !== 0) {
+        map.panBy([dx, dy], {
+          animate: true,
+          duration: 0.25,
+          easeLinearity: 0.25,
+        });
+      }
+    });
+  }, [withLiveMap]);
 
   const destroyMap = useCallback(() => {
     if (!mapRef.current && !markerGroupRef.current && !wardLayerGroupRef.current) {
@@ -851,6 +894,9 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
 
         const marker = markersMapRef.current.get(clientId);
         if (marker) {
+          withLiveMap((map) => {
+            map.stop();
+          });
           marker.openPopup();
         }
 
@@ -1175,14 +1221,8 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
               return;
             }
 
-            withLiveMap((map) => {
-              const latlng = marker.getLatLng();
-              const popupRect = modeElement.getBoundingClientRect();
-              const markerPoint = map.latLngToContainerPoint(latlng);
-              const targetPoint = markerPoint.subtract([0, popupRect.height / 2]);
-              const targetLatLng = map.containerPointToLatLng(targetPoint);
-              map.panTo(targetLatLng, { animate: true });
-            });
+            const popupRoot = modeElement.closest(".leaflet-popup") as HTMLElement | null;
+            repositionPopupIntoViewport(popupRoot ?? modeElement);
           }, 100);
         };
 
@@ -1405,13 +1445,17 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
       //add popup and marker to group
       marker
         .bindPopup(popupContent, {
-          autoPan: true,
-          keepInView: true,
+          // Avoid Leaflet popup auto-pan loops during map transitions.
+          autoPan: false,
+          keepInView: false,
           closeOnClick: false,
           autoClose: false,
         })
         .on("click", () => {
           isPopupOpening.current = true;
+          withLiveMap((map) => {
+            map.stop();
+          });
           marker.openPopup();
           // Row highlight is triggered from popupopen to guarantee popup ↔ row sync
         })
@@ -1423,6 +1467,14 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
           // Bring this popup to the front when clicked
           const popupWrapper = (e as L.PopupEvent).popup.getElement();
           if (popupWrapper) {
+            // Reposition view-mode popup if it opens partially outside the viewport.
+            scheduleClusterMapTimeout(() => {
+              if (!popupWrapper.isConnected) {
+                return;
+              }
+              repositionPopupIntoViewport(popupWrapper);
+            }, 100);
+
             topPopupZIndexRef.current += 1;
             popupWrapper.style.zIndex = String(topPopupZIndexRef.current);
 
@@ -1508,6 +1560,9 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
     if (clientIdsToReopen.length > 0) {
       suppressedPopupClientIdsRef.current = new Set(clientIdsToReopen);
       isOpeningFromTableRef.current = true;
+      withLiveMap((map) => {
+        map.stop();
+      });
       clientIdsToReopen.forEach((id) => {
         const markerToReopen = markersMapRef.current.get(id);
         if (markerToReopen) {
@@ -1539,19 +1594,39 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
     visibleRows.length === 0 && dayTotalDeliveries > 0;
 
   const centerMap = () => {
-    // Avoid keepInView popup auto-pan fighting explicit recenter actions.
+    // Preserve currently open popups while recentering.
+    const popupClientIdsToRestore: string[] = [];
+    markersMapRef.current.forEach((marker, clientId) => {
+      if (marker.isPopupOpen()) {
+        popupClientIdsToRestore.push(clientId);
+      }
+    });
+
     isPopupOpening.current = true;
-    suppressedPopupClientIdsRef.current.clear();
+    suppressedPopupClientIdsRef.current = new Set(popupClientIdsToRestore);
+    isOpeningFromTableRef.current = popupClientIdsToRestore.length > 0;
 
     withLiveMap((map) => {
       map.stop();
-      map.closePopup();
       map.setView(ffaCoordinates, 11, { animate: false });
       map.invalidateSize(false);
     });
 
+    if (popupClientIdsToRestore.length > 0) {
+      scheduleClusterMapTimeout(() => {
+        popupClientIdsToRestore.forEach((clientId) => {
+          const marker = markersMapRef.current.get(clientId);
+          if (marker && !marker.isPopupOpen()) {
+            marker.openPopup();
+          }
+        });
+      }, 50);
+    }
+
     scheduleClusterMapTimeout(() => {
       isPopupOpening.current = false;
+      isOpeningFromTableRef.current = false;
+      suppressedPopupClientIdsRef.current.clear();
     }, 250);
   };
 

--- a/my-app/src/pages/Delivery/ClusterMap.tsx
+++ b/my-app/src/pages/Delivery/ClusterMap.tsx
@@ -712,47 +712,32 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
     wardLayerGroupRef.current.clearLayers();
 
     boundaries.features.forEach((feature: any) => {
-      const wardName = feature.properties.NAME || `Ward ${feature.properties.WARD}`;
-      const safeWardName = escapeHtml(wardName);
-      const wardColor = wardColors[wardName] || "#999999"; // Default color if ward not found
+      try {
+        const wardName = feature.properties.NAME || `Ward ${feature.properties.WARD}`;
+        const wardColor = wardColors[wardName] || "#999999"; // Default color if ward not found
 
-      // Create polygon layer with translucent fill
-      const polygon = L.geoJSON(feature, {
-        style: {
-          fillColor: wardColor,
-          fillOpacity: 0.2, // Translucent
-          color: wardColor,
-          weight: 2,
-          opacity: 0.8,
-        },
-        onEachFeature: (feature, layer) => {
-          // Add popup with ward information
-          layer.bindPopup(`
-            <div style="font-family: Arial, sans-serif; font-weight: bold;">
-              ${safeWardName}
-            </div>
-          `);
+        // Create polygon layer with translucent fill.
+        // smoothFactor: 0 avoids deep recursive simplification in Leaflet on complex shapes.
+        // Keep ward overlays non-interactive so they cannot trigger popup/pan feedback loops.
+        const polygon = L.geoJSON(feature, {
+          smoothFactor: 0,
+          interactive: false,
+          bubblingMouseEvents: false,
+          style: {
+            fillColor: wardColor,
+            fillOpacity: 0.2, // Translucent
+            color: wardColor,
+            weight: 2,
+            opacity: 0.8,
+          },
+        } as any);
 
-          // Add hover effects
-          layer.on({
-            mouseover: (e) => {
-              const layer = e.target;
-              layer.setStyle({
-                fillOpacity: 0.4,
-              });
-            },
-            mouseout: (e) => {
-              const layer = e.target;
-              layer.setStyle({
-                fillOpacity: 0.2,
-              });
-            },
-          });
-        },
-      });
-
-      if (wardLayerGroupRef.current) {
-        polygon.addTo(wardLayerGroupRef.current);
+        if (wardLayerGroupRef.current) {
+          polygon.addTo(wardLayerGroupRef.current);
+        }
+      } catch (error) {
+        // Skip malformed ward geometry instead of breaking the map interaction loop.
+        console.warn("Skipping ward feature due to geometry render error:", error);
       }
     });
   }, [fetchWardBoundaries, wardData]);
@@ -1554,10 +1539,20 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
     visibleRows.length === 0 && dayTotalDeliveries > 0;
 
   const centerMap = () => {
+    // Avoid keepInView popup auto-pan fighting explicit recenter actions.
+    isPopupOpening.current = true;
+    suppressedPopupClientIdsRef.current.clear();
+
     withLiveMap((map) => {
       map.stop();
+      map.closePopup();
       map.setView(ffaCoordinates, 11, { animate: false });
+      map.invalidateSize(false);
     });
+
+    scheduleClusterMapTimeout(() => {
+      isPopupOpening.current = false;
+    }, 250);
   };
 
   const handleInvalidBadgeClick = (event: React.MouseEvent<HTMLElement>) => {

--- a/my-app/src/pages/Delivery/ClusterMap.tsx
+++ b/my-app/src/pages/Delivery/ClusterMap.tsx
@@ -114,6 +114,7 @@ const wardColors: { [key: string]: string } = {
 };
 
 const ffaCoordinates: L.LatLngExpression = [38.91433, -77.036942];
+const dcWardCenterCoordinates: L.LatLngExpression = [38.895, -77.036942];
 
 const isValidCoordinate = isRenderableCoordinate;
 
@@ -273,6 +274,7 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
   const onClusterUpdateRef = useRef(onClusterUpdate);
   const markersMapRef = useRef<Map<string, L.Marker>>(new Map()); // Store markers by client ID
   const previousVisibleRowsKeyRef = useRef<string>("");
+  const hasCompletedInitialMapLoadRef = useRef<boolean>(false);
   const isPopupOpening = useRef<boolean>(false); // Prevent close handler from firing during opening
   const isOpeningFromTableRef = useRef<boolean>(false); // True when popup is opened via table row click
   const suppressedPopupClientIdsRef = useRef<Set<string>>(new Set());
@@ -357,6 +359,7 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
       clearScheduledMapWork();
       markersMapRef.current.clear();
       previousVisibleRowsKeyRef.current = "";
+      hasCompletedInitialMapLoadRef.current = false;
       return;
     }
 
@@ -389,6 +392,7 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
 
     markersMapRef.current.clear();
     previousVisibleRowsKeyRef.current = "";
+    hasCompletedInitialMapLoadRef.current = false;
 
     if (map) {
       map.remove();
@@ -829,7 +833,7 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
       try {
         mapRef.current = L.map(mapContainerRef.current, {
           closePopupOnClick: false,
-        }).setView(ffaCoordinates, 11, {
+        }).setView(dcWardCenterCoordinates, 11, {
           animate: false,
         });
         isMapAliveRef.current = true;
@@ -1550,7 +1554,8 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
       .map((row) => row.id)
       .sort()
       .join("|");
-    const shouldAutoFit = visibleRowsKey !== previousVisibleRowsKeyRef.current;
+    const shouldAutoFit =
+      hasCompletedInitialMapLoadRef.current && visibleRowsKey !== previousVisibleRowsKeyRef.current;
 
     if (markerGroupRef.current!.getLayers().length > 0 && shouldAutoFit) {
       withLiveMap((map) => {
@@ -1559,8 +1564,9 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
           animate: false,
         });
       });
-      previousVisibleRowsKeyRef.current = visibleRowsKey;
     }
+    previousVisibleRowsKeyRef.current = visibleRowsKey;
+    hasCompletedInitialMapLoadRef.current = true;
 
     // Re-open the popup that was open before the rebuild (if any).
     // Set isOpeningFromTableRef so popupopen doesn't double-add the highlight.
@@ -1618,7 +1624,7 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
 
     withLiveMap((map) => {
       map.stop();
-      map.setView(ffaCoordinates, 11, { animate: false });
+      map.setView(dcWardCenterCoordinates, 11, { animate: false });
       map.invalidateSize(false);
     });
 

--- a/my-app/src/pages/Delivery/ClusterMap.tsx
+++ b/my-app/src/pages/Delivery/ClusterMap.tsx
@@ -276,6 +276,7 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
   const isPopupOpening = useRef<boolean>(false); // Prevent close handler from firing during opening
   const isOpeningFromTableRef = useRef<boolean>(false); // True when popup is opened via table row click
   const suppressedPopupClientIdsRef = useRef<Set<string>>(new Set());
+  const suppressPopupViewportRepositionRef = useRef<boolean>(false);
   const topPopupZIndexRef = useRef<number>(700); // Base Leaflet popup z-index is ~700
   const clustersRef = useRef<Cluster[]>(clusters);
 
@@ -307,6 +308,10 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
 
   const repositionPopupIntoViewport = useCallback((popupElement: HTMLElement) => {
     if (!popupElement.isConnected) {
+      return;
+    }
+
+    if (suppressPopupViewportRepositionRef.current) {
       return;
     }
 
@@ -1217,6 +1222,10 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
               return;
             }
 
+            if (suppressPopupViewportRepositionRef.current) {
+              return;
+            }
+
             if (!markerGroupRef.current?.hasLayer(marker)) {
               return;
             }
@@ -1605,6 +1614,7 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
     isPopupOpening.current = true;
     suppressedPopupClientIdsRef.current = new Set(popupClientIdsToRestore);
     isOpeningFromTableRef.current = popupClientIdsToRestore.length > 0;
+    suppressPopupViewportRepositionRef.current = popupClientIdsToRestore.length > 0;
 
     withLiveMap((map) => {
       map.stop();
@@ -1614,6 +1624,7 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
 
     if (popupClientIdsToRestore.length > 0) {
       scheduleClusterMapTimeout(() => {
+        suppressPopupViewportRepositionRef.current = false;
         popupClientIdsToRestore.forEach((clientId) => {
           const marker = markersMapRef.current.get(clientId);
           if (marker && !marker.isPopupOpen()) {
@@ -1627,6 +1638,7 @@ const ClusterMap: React.FC<ClusterMapProps> = ({
       isPopupOpening.current = false;
       isOpeningFromTableRef.current = false;
       suppressedPopupClientIdsRef.current.clear();
+      suppressPopupViewportRepositionRef.current = false;
     }, 250);
   };
 

--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -99,6 +99,7 @@ import DietaryRestrictionsLegend from "../../components/DietaryRestrictionsLegen
 import { deliveryDate } from "../../utils/deliveryDate";
 import { deliveryEventEmitter } from "../../utils/deliveryEventEmitter";
 import { useNotifications } from "../../components/NotificationProvider";
+import { formatAddressWithQuadrantAndUnit } from "../../utils/addressFormat";
 import {
   ClientOverride,
   normalizeAssignmentValue,
@@ -3889,7 +3890,7 @@ const DeliverySpreadsheet: React.FC = () => {
                       >
                         {col.propertyKey !== "none"
                           ? col.propertyKey === "address"
-                            ? `${row.address || ""}${row.address2 ? " " + row.address2 : ""}${row.zipCode ? " " + row.zipCode : ""}`.trim()
+                            ? `${formatAddressWithQuadrantAndUnit(row.address, row.quadrant, row.address2)}${row.zipCode ? " " + row.zipCode : ""}`.trim()
                             : col.propertyKey === "deliveryDetails.dietaryRestrictions"
                               ? (() => {
                                   const dr = row.deliveryDetails?.dietaryRestrictions;

--- a/my-app/src/pages/Delivery/RouteExport.tsx
+++ b/my-app/src/pages/Delivery/RouteExport.tsx
@@ -4,6 +4,7 @@ import { Cluster } from "./DeliverySpreadsheet";
 import { RowData } from "./types/deliveryTypes";
 import { getExportConfig } from "../../config/exportConfig";
 import { normalizeCsvRows, sanitizeFilename } from "../../utils/csvExport";
+import { formatAddressWithQuadrant, formatAddressWithQuadrantAndUnit } from "../../utils/addressFormat";
 import {
   ClientOverride,
   normalizeAssignmentValue,
@@ -151,7 +152,8 @@ const formatAssignedTime = (time?: string, fallback = "No time assigned"): strin
 const truncateExportText = (value: string | undefined, maxLength: number): string =>
   (value || "").trim().slice(0, maxLength);
 
-const buildDoorDashStreetAddress = (row: RowData): string => (row.address || "").trim();
+const buildDoorDashStreetAddress = (row: RowData): string =>
+  formatAddressWithQuadrant(row.address, row.quadrant);
 
 const recordSkippedReason = (
   skippedReasonCounts: Map<string, number>,
@@ -240,7 +242,7 @@ const buildRouteCsvRow = (
   return {
     firstName: row.firstName || "",
     lastName: row.lastName || "",
-    address: row.address ? `${row.address}${row.address2 ? ` ${row.address2}` : ""}` : "",
+    address: formatAddressWithQuadrantAndUnit(row.address, rowData.quadrant, row.address2),
     zip: row.zipCode || "",
     quadrant: rowData.quadrant || "",
     ward: row.ward || "",

--- a/my-app/src/pages/Profile/Profile.addressAutocomplete.test.tsx
+++ b/my-app/src/pages/Profile/Profile.addressAutocomplete.test.tsx
@@ -342,6 +342,36 @@ describe("Profile address autocomplete lifecycle", () => {
     });
   });
 
+  it("rejects unsupported international phone prefixes before saving", async () => {
+    const alertSpy = jest.spyOn(window, "alert").mockImplementation(() => undefined);
+
+    render(
+      <MemoryRouter
+        initialEntries={["/profile/client-1"]}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <Routes>
+          <Route path="/profile/:clientId" element={<Profile />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByText("100 Main Street NW");
+
+    fireEvent.click(screen.getAllByTestId("EditIcon")[0].closest("button")!);
+    fireEvent.change(await screen.findByRole("textbox", { name: "phone" }), {
+      target: { name: "phone", value: "+91 202-555-0101" },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: "save" })[0]);
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining("invalid format"));
+    });
+    expect(mockSetDoc).not.toHaveBeenCalled();
+
+    alertSpy.mockRestore();
+  });
+
   it("standardizes Google Places dropdown direction words to DC quadrant abbreviations", async () => {
     render(
       <MemoryRouter

--- a/my-app/src/pages/Profile/Profile.addressAutocomplete.test.tsx
+++ b/my-app/src/pages/Profile/Profile.addressAutocomplete.test.tsx
@@ -377,4 +377,149 @@ describe("Profile address autocomplete lifecycle", () => {
 
     document.body.removeChild(container);
   });
+
+  it("stores quadrant abbreviation when neighborhood includes non-quadrant text", async () => {
+    render(
+      <MemoryRouter
+        initialEntries={["/profile/client-1"]}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <Routes>
+          <Route path="/profile/:clientId" element={<Profile />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByText("100 Main Street NW");
+
+    fireEvent.click(screen.getAllByTestId("EditIcon")[0].closest("button")!);
+    await screen.findByRole("textbox", { name: "address" });
+    await waitFor(() => expect(autocompleteInstances).toHaveLength(1));
+
+    autocompleteInstances[0].place = {
+      formatted_address: "1738 Massachusetts Avenue Southeast, Washington, DC 20003, USA",
+      address_components: [
+        { long_name: "1738", short_name: "1738", types: ["street_number"] },
+        {
+          long_name: "Massachusetts Avenue Southeast",
+          short_name: "Massachusetts Ave SE",
+          types: ["route"],
+        },
+        {
+          long_name: "Barney Circle Southeast",
+          short_name: "Barney Circle Southeast",
+          types: ["neighborhood"],
+        },
+        { long_name: "Washington", short_name: "Washington", types: ["locality"] },
+        {
+          long_name: "District of Columbia",
+          short_name: "DC",
+          types: ["administrative_area_level_1"],
+        },
+        { long_name: "20003", short_name: "20003", types: ["postal_code"] },
+      ],
+    } as google.maps.places.PlaceResult;
+
+    await act(async () => {
+      await autocompleteInstances[0].placeChanged?.();
+    });
+
+    expect(screen.getByTestId("address-fields").textContent).toBe(
+      "1738 Massachusetts Avenue SE|Washington|DC|20003|SE|Ward 2"
+    );
+  });
+
+  it("normalizes autocomplete quadrants to NW/NE/SW/SE across direction variants", async () => {
+    render(
+      <MemoryRouter
+        initialEntries={["/profile/client-1"]}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <Routes>
+          <Route path="/profile/:clientId" element={<Profile />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByText("100 Main Street NW");
+
+    fireEvent.click(screen.getAllByTestId("EditIcon")[0].closest("button")!);
+    await screen.findByRole("textbox", { name: "address" });
+    await waitFor(() => expect(autocompleteInstances).toHaveLength(1));
+
+    const cases = [
+      {
+        streetNumber: "1",
+        zip: "20001",
+        route: "First Street Northwest",
+        neighborhood: "Barney Circle Northwest",
+        formattedAddress: "1 First Street Northwest, Washington, DC 20001, USA",
+        expectedAddress: "1 First Street NW|Washington|DC|20001|NW|Ward 2",
+      },
+      {
+        streetNumber: "2",
+        zip: "20002",
+        route: "Second Street Northeast",
+        neighborhood: "Barney Circle Northeast",
+        formattedAddress: "2 Second Street Northeast, Washington, DC 20002, USA",
+        expectedAddress: "2 Second Street NE|Washington|DC|20002|NE|Ward 2",
+      },
+      {
+        streetNumber: "3",
+        zip: "20024",
+        route: "Third Street Southwest",
+        neighborhood: "Barney Circle Southwest",
+        formattedAddress: "3 Third Street Southwest, Washington, DC 20024, USA",
+        expectedAddress: "3 Third Street SW|Washington|DC|20024|SW|Ward 2",
+      },
+      {
+        streetNumber: "1738",
+        zip: "20003",
+        route: "Massachusetts Avenue Southeast",
+        neighborhood: "Barney Circle Southeast",
+        formattedAddress: "1738 Massachusetts Avenue Southeast, Washington, DC 20003, USA",
+        expectedAddress: "1738 Massachusetts Avenue SE|Washington|DC|20003|SE|Ward 2",
+      },
+    ];
+
+    for (const entry of cases) {
+      autocompleteInstances[0].place = {
+        formatted_address: entry.formattedAddress,
+        address_components: [
+          {
+            long_name: entry.streetNumber,
+            short_name: entry.streetNumber,
+            types: ["street_number"],
+          },
+          {
+            long_name: entry.route,
+            short_name: entry.route,
+            types: ["route"],
+          },
+          {
+            long_name: entry.neighborhood,
+            short_name: entry.neighborhood,
+            types: ["neighborhood"],
+          },
+          { long_name: "Washington", short_name: "Washington", types: ["locality"] },
+          {
+            long_name: "District of Columbia",
+            short_name: "DC",
+            types: ["administrative_area_level_1"],
+          },
+          {
+            long_name: entry.zip,
+            short_name: entry.zip,
+            types: ["postal_code"],
+          },
+        ],
+      } as google.maps.places.PlaceResult;
+
+      await act(async () => {
+        await autocompleteInstances[0].placeChanged?.();
+      });
+
+      expect(screen.getByTestId("address-fields").textContent).toBe(entry.expectedAddress);
+    }
+  });
 });

--- a/my-app/src/pages/Profile/Profile.addressAutocomplete.test.tsx
+++ b/my-app/src/pages/Profile/Profile.addressAutocomplete.test.tsx
@@ -160,6 +160,8 @@ jest.mock("./components/BasicInfoForm", () => ({
   default: ({ clientProfile, renderField, addressInputRef }: any) => (
     <div>
       {renderField("address", "text", addressInputRef)}
+      {renderField("phone", "text")}
+      {renderField("alternativePhone", "text")}
       <output data-testid="address-fields">
         {[
           clientProfile.address,
@@ -169,6 +171,9 @@ jest.mock("./components/BasicInfoForm", () => ({
           clientProfile.quadrant,
           clientProfile.ward,
         ].join("|")}
+      </output>
+      <output data-testid="phone-fields">
+        {[clientProfile.phone, clientProfile.alternativePhone].join("|")}
       </output>
     </div>
   ),
@@ -278,7 +283,7 @@ describe("Profile address autocomplete lifecycle", () => {
       address_components: [
         { long_name: "1600", short_name: "1600", types: ["street_number"] },
         {
-          long_name: "Pennsylvania Avenue NW",
+          long_name: "Pennsylvania Avenue Northwest",
           short_name: "Pennsylvania Ave NW",
           types: ["route"],
         },
@@ -299,5 +304,77 @@ describe("Profile address autocomplete lifecycle", () => {
     expect(screen.getByTestId("address-fields").textContent).toBe(
       "1600 Pennsylvania Avenue NW|Washington|DC|20006|NW|Ward 2"
     );
+  });
+
+  it("formats profile phone numbers when saving while accepting allowed input formats", async () => {
+    render(
+      <MemoryRouter
+        initialEntries={["/profile/client-1"]}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <Routes>
+          <Route path="/profile/:clientId" element={<Profile />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByText("100 Main Street NW");
+
+    fireEvent.click(screen.getAllByTestId("EditIcon")[0].closest("button")!);
+    fireEvent.change(await screen.findByRole("textbox", { name: "phone" }), {
+      target: { name: "phone", value: "202.555.0101" },
+    });
+    fireEvent.change(screen.getByRole("textbox", { name: "alternativePhone" }), {
+      target: { name: "alternativePhone", value: "+1 202-555-0102" },
+    });
+
+    fireEvent.click(screen.getAllByRole("button", { name: "save" })[0]);
+
+    await waitFor(() => {
+      expect(mockSetDoc).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          phone: "(202) 555-0101",
+          alternativePhone: "(202) 555-0102",
+        }),
+        { merge: true }
+      );
+    });
+  });
+
+  it("standardizes Google Places dropdown direction words to DC quadrant abbreviations", async () => {
+    render(
+      <MemoryRouter
+        initialEntries={["/profile/client-1"]}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <Routes>
+          <Route path="/profile/:clientId" element={<Profile />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByText("100 Main Street NW");
+
+    fireEvent.click(screen.getAllByTestId("EditIcon")[0].closest("button")!);
+    await screen.findByRole("textbox", { name: "address" });
+    await waitFor(() => expect(autocompleteInstances).toHaveLength(1));
+
+    const container = document.createElement("div");
+    container.className = "pac-container";
+    const item = document.createElement("div");
+    item.className = "pac-item";
+    item.textContent = "1600 Pennsylvania Avenue Northwest, Washington, DC";
+    container.appendChild(item);
+
+    await act(async () => {
+      document.body.appendChild(container);
+    });
+
+    await waitFor(() => {
+      expect(item.textContent).toBe("1600 Pennsylvania Avenue NW, Washington, DC");
+    });
+
+    document.body.removeChild(container);
   });
 });

--- a/my-app/src/pages/Profile/Profile.tsx
+++ b/my-app/src/pages/Profile/Profile.tsx
@@ -905,7 +905,7 @@ const Profile = () => {
 
         const countDigits = (str: string) => (str.match(/\d/g) || []).length;
         const isValidPhoneFormat = (phone: string) => {
-          return /^(\+\d{1,2}\s?)?((\(\d{3}\))|\d{3})[\s.-]?\d{3}[\s.-]?\d{4}$/.test(phone);
+          return /^(\+1\s?)?((\(\d{3}\))|\d{3})[\s.-]?\d{3}[\s.-]?\d{4}$/.test(phone);
         };
         const newErrors = { ...errors };
 
@@ -1022,7 +1022,7 @@ const Profile = () => {
     const countDigits = (str: string) => (str.match(/\d/g) || []).length;
     const isValidPhoneFormat = (phone: string) => {
       // Allowed formats: (123) 456-7890, 123-456-7890, 123.456.7890, 123 456 7890, 1234567890, +1 123-456-7890
-      return /^(\+\d{1,2}\s?)?((\(\d{3}\))|\d{3})[\s.-]?\d{3}[\s.-]?\d{4}$/.test(phone);
+      return /^(\+1\s?)?((\(\d{3}\))|\d{3})[\s.-]?\d{3}[\s.-]?\d{4}$/.test(phone);
     };
 
     if (!clientProfile.phone?.trim()) {

--- a/my-app/src/pages/Profile/Profile.tsx
+++ b/my-app/src/pages/Profile/Profile.tsx
@@ -88,6 +88,12 @@ const standardizeAddressDirections = (value: string): string =>
     ADDRESS_DIRECTION_ABBREVIATIONS[match.toLowerCase()] ?? match
   );
 
+const extractQuadrantAbbreviation = (value: string): string => {
+  const standardizedValue = standardizeAddressDirections(value);
+  const match = standardizedValue.match(/\b(NW|NE|SW|SE)\b/i);
+  return match?.[1]?.toUpperCase() ?? "";
+};
+
 const formatProfilePhoneForSave = (value: unknown): string => {
   if (typeof value !== "string") return "";
   const trimmedValue = value.trim();
@@ -2721,18 +2727,18 @@ const Profile = () => {
             street += " " + comp.long_name;
           } else if (comp.types.includes("neighborhood")) {
             // Optionally use for quadrant if DC
-            if (!quadrant && comp.long_name.match(/(NW|NE|SW|SE)/i)) {
-              quadrant = comp.long_name;
+            if (!quadrant) {
+              quadrant = extractQuadrantAbbreviation(comp.long_name);
             }
           }
         }
         // If DC, try to extract quadrant from formatted address if not found
-        if (
-          !quadrant &&
-          place.formatted_address &&
-          place.formatted_address.match(/(NW|NE|SW|SE)/i)
-        ) {
-          quadrant = place.formatted_address.match(/(NW|NE|SW|SE)/i)?.[0] || "";
+        if (!quadrant && place.formatted_address) {
+          quadrant = extractQuadrantAbbreviation(place.formatted_address);
+        }
+        // Fallback to extracted street text if formatted address doesn't include a quadrant token.
+        if (!quadrant && street) {
+          quadrant = extractQuadrantAbbreviation(street);
         }
 
         // Get ward for the selected address

--- a/my-app/src/pages/Profile/Profile.tsx
+++ b/my-app/src/pages/Profile/Profile.tsx
@@ -76,6 +76,30 @@ import { deliveryDate } from "../../utils/deliveryDate";
 import { computeClientActiveStatus } from "../../utils/clientStatus";
 import { toJSDate } from "../../utils/timestamp";
 
+const ADDRESS_DIRECTION_ABBREVIATIONS: Record<string, string> = {
+  northeast: "NE",
+  northwest: "NW",
+  southeast: "SE",
+  southwest: "SW",
+};
+
+const standardizeAddressDirections = (value: string): string =>
+  value.replace(/\b(northwest|northeast|southwest|southeast)\b/gi, (match) =>
+    ADDRESS_DIRECTION_ABBREVIATIONS[match.toLowerCase()] ?? match
+  );
+
+const formatProfilePhoneForSave = (value: unknown): string => {
+  if (typeof value !== "string") return "";
+  const trimmedValue = value.trim();
+  if (!trimmedValue) return "";
+
+  const digits = trimmedValue.replace(/\D/g, "");
+  const nationalDigits = digits.length === 11 && digits.startsWith("1") ? digits.slice(1) : digits;
+  const match = nationalDigits.match(/^(\d{3})(\d{3})(\d{4})$/);
+
+  return match ? `(${match[1]}) ${match[2]}-${match[3]}` : trimmedValue;
+};
+
 const fieldStyles = {
   backgroundColor: "var(--color-white)",
   width: "60%",
@@ -1470,6 +1494,8 @@ const Profile = () => {
       const normalizedStartDate = convertDateForSave(cleanedProfile.startDate);
       const normalizedEndDate = convertDateForSave(cleanedProfile.endDate);
         const normalizedTefapCertDate = convertDateForSave(cleanedProfile.tefapCertDate);
+      const normalizedPhone = formatProfilePhoneForSave(cleanedProfile.phone);
+      const normalizedAlternativePhone = formatProfilePhoneForSave(cleanedProfile.alternativePhone);
       const normalizedStartDateISO = deliveryDate.tryToISODateString(normalizedStartDate);
       const normalizedEndDateISO = deliveryDate.tryToISODateString(normalizedEndDate);
       const nextActiveStatus = computeClientActiveStatus(
@@ -1488,6 +1514,8 @@ const Profile = () => {
         dob: convertDateForSave(cleanedProfile.dob),
         tefapCert: Boolean(normalizedTefapCertDate.trim()),
         tefapCertDate: normalizedTefapCertDate,
+        phone: normalizedPhone,
+        alternativePhone: normalizedAlternativePhone,
         famStartDate: convertDateForSave(cleanedProfile.famStartDate),
         startDate: normalizedStartDate,
         endDate: normalizedEndDate,
@@ -2627,6 +2655,30 @@ const Profile = () => {
     loadGoogleMapsScript(googleMapsApiKey, () => setIsGoogleApiLoaded(true));
   }, []);
 
+  useEffect(() => {
+    if (!isGoogleApiLoaded) return;
+
+    const normalizePlacesDropdown = () => {
+      document.querySelectorAll(".pac-container .pac-item").forEach((item) => {
+        const walker = document.createTreeWalker(item, NodeFilter.SHOW_TEXT);
+        let textNode = walker.nextNode();
+        while (textNode) {
+          const normalizedText = standardizeAddressDirections(textNode.textContent || "");
+          if (textNode.textContent !== normalizedText) {
+            textNode.textContent = normalizedText;
+          }
+          textNode = walker.nextNode();
+        }
+      });
+    };
+
+    const observer = new MutationObserver(normalizePlacesDropdown);
+    observer.observe(document.body, { childList: true, subtree: true, characterData: true });
+    normalizePlacesDropdown();
+
+    return () => observer.disconnect();
+  }, [isGoogleApiLoaded]);
+
   // Initialize Google Places Autocomplete when input and API are ready
   useEffect(() => {
     if (
@@ -2658,7 +2710,7 @@ const Profile = () => {
           if (comp.types.includes("street_number")) {
             street = comp.long_name + " " + street;
           } else if (comp.types.includes("route")) {
-            street += comp.long_name;
+            street += standardizeAddressDirections(comp.long_name);
           } else if (comp.types.includes("locality")) {
             city = comp.long_name;
           } else if (comp.types.includes("administrative_area_level_1")) {

--- a/my-app/src/tests/pages/Delivery/ClusterMap.test.ts
+++ b/my-app/src/tests/pages/Delivery/ClusterMap.test.ts
@@ -62,6 +62,21 @@ describe("ClusterMap popup regression guards", () => {
     expect(source).toContain("closePopupOnClick: false");
   });
 
+  it("disables ward geometry smoothing to avoid Leaflet simplify recursion", () => {
+    expect(source).toContain("smoothFactor: 0");
+    expect(source).toContain("interactive: false");
+    expect(source).toContain("bubblingMouseEvents: false");
+    expect(source).toContain("Skipping ward feature due to geometry render error");
+  });
+
+  // Recenter should close open popups first, otherwise keepInView can auto-pan
+  // the map back to popup markers and make recenter look frozen.
+  it("closes popups before recentering to Food For All", () => {
+    expect(source).toContain("const centerMap = () => {");
+    expect(source).toContain("map.closePopup();");
+    expect(source).toContain("map.setView(ffaCoordinates, 11, { animate: false });");
+  });
+
   // Ensures both interaction entry points (direct marker click and table-driven openMapPopup)
   // explicitly open the marker popup.
   it("opens marker popup directly on marker click", () => {

--- a/my-app/src/tests/pages/Delivery/ClusterMap.test.ts
+++ b/my-app/src/tests/pages/Delivery/ClusterMap.test.ts
@@ -60,6 +60,8 @@ describe("ClusterMap popup regression guards", () => {
     expect(source).toContain("closeOnClick: false");
     expect(source).toContain("autoClose: false");
     expect(source).toContain("closePopupOnClick: false");
+    expect(source).toContain("autoPan: false");
+    expect(source).toContain("keepInView: false");
   });
 
   it("disables ward geometry smoothing to avoid Leaflet simplify recursion", () => {
@@ -69,11 +71,13 @@ describe("ClusterMap popup regression guards", () => {
     expect(source).toContain("Skipping ward feature due to geometry render error");
   });
 
-  // Recenter should close open popups first, otherwise keepInView can auto-pan
-  // the map back to popup markers and make recenter look frozen.
-  it("closes popups before recentering to Food For All", () => {
+  // Recenter should preserve open popups while zooming back out.
+  it("preserves open popups while recentering to Food For All", () => {
     expect(source).toContain("const centerMap = () => {");
-    expect(source).toContain("map.closePopup();");
+    expect(source).toContain("popupClientIdsToRestore");
+    expect(source).toContain("suppressedPopupClientIdsRef.current = new Set(popupClientIdsToRestore);");
+    expect(source).toContain("if (marker && !marker.isPopupOpen()) {");
+    expect(source).toContain("marker.openPopup();");
     expect(source).toContain("map.setView(ffaCoordinates, 11, { animate: false });");
   });
 
@@ -82,6 +86,16 @@ describe("ClusterMap popup regression guards", () => {
   it("opens marker popup directly on marker click", () => {
     expect(source).toMatch(/\.on\("click",\s*\(\)\s*=>\s*\{[\s\S]*?marker\.openPopup\(\)/m);
     expect(source).toMatch(/openMapPopup\s*=\s*\(clientId:\s*string\)\s*=>\s*\{[\s\S]*?marker\.openPopup\(\)/m);
+  });
+
+  it("stops map motion before programmatic popup and pan operations", () => {
+    expect(source).toContain("map.stop();");
+    expect(source).toContain("POPUP_VIEWPORT_MARGIN_PX");
+    expect(source).toContain("schedulePopupReposition(viewMode);");
+    expect(source).toContain("repositionPopupIntoViewport(popupWrapper);");
+    expect(source).toContain("map.panBy([dx, dy], {");
+    expect(source).toContain("animate: true");
+    expect(source).toContain("if (dx !== 0 || dy !== 0)");
   });
 
   it("lets the cluster summary overlay toggle sorting by number of deliveries", () => {

--- a/my-app/src/tests/pages/Delivery/ClusterMap.test.ts
+++ b/my-app/src/tests/pages/Delivery/ClusterMap.test.ts
@@ -93,6 +93,7 @@ describe("ClusterMap popup regression guards", () => {
     expect(source).toContain("POPUP_VIEWPORT_MARGIN_PX");
     expect(source).toContain("schedulePopupReposition(viewMode);");
     expect(source).toContain("repositionPopupIntoViewport(popupWrapper);");
+    expect(source).toContain("suppressPopupViewportRepositionRef");
     expect(source).toContain("map.panBy([dx, dy], {");
     expect(source).toContain("animate: true");
     expect(source).toContain("if (dx !== 0 || dy !== 0)");

--- a/my-app/src/tests/pages/Delivery/ClusterMap.test.ts
+++ b/my-app/src/tests/pages/Delivery/ClusterMap.test.ts
@@ -74,11 +74,14 @@ describe("ClusterMap popup regression guards", () => {
   // Recenter should preserve open popups while zooming back out.
   it("preserves open popups while recentering to Food For All", () => {
     expect(source).toContain("const centerMap = () => {");
+    expect(source).toContain("const dcWardCenterCoordinates: L.LatLngExpression = [38.895, -77.036942];");
+    expect(source).toContain("}).setView(dcWardCenterCoordinates, 11, {");
+    expect(source).toContain("hasCompletedInitialMapLoadRef.current && visibleRowsKey !== previousVisibleRowsKeyRef.current");
     expect(source).toContain("popupClientIdsToRestore");
     expect(source).toContain("suppressedPopupClientIdsRef.current = new Set(popupClientIdsToRestore);");
     expect(source).toContain("if (marker && !marker.isPopupOpen()) {");
     expect(source).toContain("marker.openPopup();");
-    expect(source).toContain("map.setView(ffaCoordinates, 11, { animate: false });");
+    expect(source).toContain("map.setView(dcWardCenterCoordinates, 11, { animate: false });");
   });
 
   // Ensures both interaction entry points (direct marker click and table-driven openMapPopup)

--- a/my-app/src/utils/addressFormat.test.ts
+++ b/my-app/src/utils/addressFormat.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  formatAddressWithQuadrant,
+  formatAddressWithQuadrantAndUnit,
+  normalizeQuadrantToken,
+} from "./addressFormat";
+
+describe("addressFormat", () => {
+  it("normalizes full-word quadrant tokens", () => {
+    expect(normalizeQuadrantToken("Southeast")).toBe("SE");
+    expect(normalizeQuadrantToken("northwest")).toBe("NW");
+  });
+
+  it("appends normalized quadrant when base address lacks one", () => {
+    expect(formatAddressWithQuadrant("1738 Massachusetts Avenue", "Southeast")).toBe(
+      "1738 Massachusetts Avenue SE"
+    );
+  });
+
+  it("does not duplicate quadrant when already present", () => {
+    expect(formatAddressWithQuadrant("1738 Massachusetts Avenue SE", "SE")).toBe(
+      "1738 Massachusetts Avenue SE"
+    );
+  });
+
+  it("standardizes full-word directions already in address", () => {
+    expect(formatAddressWithQuadrant("1738 Massachusetts Avenue Southeast", "SE")).toBe(
+      "1738 Massachusetts Avenue SE"
+    );
+  });
+
+  it("keeps apartment/unit text when formatting full address", () => {
+    expect(
+      formatAddressWithQuadrantAndUnit(
+        "1738 Massachusetts Avenue",
+        "Southeast",
+        "Apartment 4B"
+      )
+    ).toBe("1738 Massachusetts Avenue SE Apartment 4B");
+  });
+});

--- a/my-app/src/utils/addressFormat.ts
+++ b/my-app/src/utils/addressFormat.ts
@@ -1,0 +1,57 @@
+const DIRECTION_TO_ABBREVIATION: Record<string, string> = {
+  northeast: "NE",
+  northwest: "NW",
+  southeast: "SE",
+  southwest: "SW",
+};
+
+const QUADRANT_TOKEN_REGEX = /\b(NE|NW|SE|SW)\b/i;
+
+export const standardizeAddressDirections = (value: string): string =>
+  value.replace(/\b(northwest|northeast|southwest|southeast)\b/gi, (match) =>
+    DIRECTION_TO_ABBREVIATION[match.toLowerCase()] ?? match
+  );
+
+export const normalizeQuadrantToken = (value: unknown): string => {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  const standardized = standardizeAddressDirections(value).trim();
+  const match = standardized.match(QUADRANT_TOKEN_REGEX);
+  return match?.[1]?.toUpperCase() ?? "";
+};
+
+export const formatAddressWithQuadrant = (address: unknown, quadrant: unknown): string => {
+  const baseAddress = typeof address === "string" ? standardizeAddressDirections(address).trim() : "";
+  const normalizedQuadrant = normalizeQuadrantToken(quadrant);
+
+  if (!baseAddress) {
+    return "";
+  }
+
+  if (!normalizedQuadrant || QUADRANT_TOKEN_REGEX.test(baseAddress)) {
+    return baseAddress;
+  }
+
+  return `${baseAddress} ${normalizedQuadrant}`.trim();
+};
+
+export const formatAddressWithQuadrantAndUnit = (
+  address: unknown,
+  quadrant: unknown,
+  address2: unknown
+): string => {
+  const street = formatAddressWithQuadrant(address, quadrant);
+  const unit = typeof address2 === "string" ? address2.trim() : "";
+
+  if (!street) {
+    return unit;
+  }
+
+  if (!unit) {
+    return street;
+  }
+
+  return `${street} ${unit}`.trim();
+};


### PR DESCRIPTION
- Removed active tag, updated ETL to not use that anymore, 
- Google autocomplete shortens the quadrant now (eg: Northwest when you type shows NW instead)
- phone number saves in (XXX) XXX-XXXX format

From 7/29
- Fixed ETL to append quadrant to the addresses for saturday deliveres
- Annie dolores Edwards-Parker had something going one with how her address was formatted that google wasnt assigning quadrant properly even though her address was right
- Drivers were not sorting properly if they had numbers in their name so 10 was before 2 as an example
- Users were hitting a stack overflow in Leaflet while panning/opening popups with ward overlays enabled, which could freeze or break map usage. This change prioritizes map stability while preserving ward visualization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Phone numbers are now consistently normalized when saving profiles and referral records.
  * Addresses display standardized DC quadrant abbreviations and preserve unit details across profiles, spreadsheets, deliveries, and route exports (including improved Google Places direction/quadrant handling).
  * Driver lists sort naturally (including numeric values).
  * Map popups remain stable and visible during recentering and editing, with additional safeguards for popup behavior and ward rendering.
* **Data Updates**
  * Active status is mapped/stored without automatically adding an “Active” tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->