### PR TITLE
Add Start Date to Export All Clients

### DIFF
--- a/my-app/src/components/Spreadsheet/export.tsx
+++ b/my-app/src/components/Spreadsheet/export.tsx
@@ -48,6 +48,7 @@ export interface RowData {
   tefapCert?: boolean;
   tefapCertDate?: string;
   famStartDate?: string;
+  startDate?: string;
   lastDeliveryDate?: string;
   missedStrikeCount?: number;
   activeStatus?: boolean;
@@ -214,8 +215,8 @@ export const exportQueryResults = (
  * Export all data as a CSV file with formatted, readable output.
  * @param rows - The data to export.
  */
-export const exportAllClients = (rows: RowData[]) => {
-  const formattedData: CsvRow[] = rows.map((row) => {
+export const buildAllClientsExportRows = (rows: RowData[]): CsvRow[] =>
+  rows.map((row) => {
     // Format the data in a readable way
     return {
       UID: row.uid,
@@ -244,10 +245,11 @@ export const exportAllClients = (rows: RowData[]) => {
         ? [row.referralEntity.name, row.referralEntity.organization].filter(Boolean).join(", ")
         : "",
       "TEFAP Cert": normalizeDateValue(row.tefapCertDate),
+      "Start Date": normalizeDateValue(row.startDate),
       Tags: row.tags?.join(", ") || "",
       "Date of Birth": row.dob ?? "",
     };
   });
 
-  return downloadCsv(formattedData, "all_clients.csv");
-};
+export const exportAllClients = (rows: RowData[]) =>
+  downloadCsv(buildAllClientsExportRows(rows), "all_clients.csv");

--- a/my-app/src/services/client-service.ts
+++ b/my-app/src/services/client-service.ts
@@ -78,7 +78,7 @@ const deriveClientActiveStatus = (raw: {
     typeof raw.autoInactiveReason === "string" ? raw.autoInactiveReason : null
   );
 
-const mapClientDocToSpreadsheetBaseRow = (docId: string, raw: any): RowData => {
+export const mapClientDocToSpreadsheetBaseRow = (docId: string, raw: any): RowData => {
   const normalizedFamStartDate = normalizeFirestoreDateValue(raw.famStartDate);
   const famStartDate =
     deliveryDate.tryToISODateString(
@@ -124,6 +124,7 @@ const mapClientDocToSpreadsheetBaseRow = (docId: string, raw: any): RowData => {
     language: raw.language ?? "",
     notes: raw.notes ?? "",
     famStartDate,
+    startDate: normalizeDateStringField(raw.startDate),
     tefapCert: normalizeBooleanField(raw.tefapCert),
     tefapCertDate: normalizeDateStringField(raw.tefapCertDate),
     dob: raw.dob ?? "",

--- a/my-app/src/tests/components/Spreadsheet/export.test.ts
+++ b/my-app/src/tests/components/Spreadsheet/export.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { buildAllClientsExportRows } from "../../../components/Spreadsheet/export";
+import { mapClientDocToSpreadsheetBaseRow } from "../../../services/client-service";
+
+jest.mock("../../../auth/firebaseConfig", () => ({ db: {} }));
+
+describe("client spreadsheet exports", () => {
+  // App coverage:
+  // - Export All Clients receives Firestore client documents through the spreadsheet row mapper
+  // - startDate is the required delivery-eligibility date shown as Start Date in client exports
+  // Behavior contract: the canonical client startDate reaches the downloaded CSV under Start Date.
+  it("includes the canonical client start date in Export All Clients", () => {
+    const row = mapClientDocToSpreadsheetBaseRow("client-1", {
+      firstName: "Ada",
+      lastName: "Lovelace",
+      startDate: "2026-07-04",
+    });
+
+    const [exportedRow] = buildAllClientsExportRows([row]);
+
+    expect(exportedRow).toEqual(expect.objectContaining({ "Start Date": "2026-07-04" }));
+  });
+});


### PR DESCRIPTION
## Summary

- carry the canonical client `startDate` through the spreadsheet row mapper
- add a `Start Date` column to the formatted Export All Clients CSV
- add a focused raw-client-to-export-row regression test

## Cause

`exportAllClients` uses a fixed formatted column whitelist, while `mapClientDocToSpreadsheetBaseRow` discarded `startDate` after using it to derive active status. As a result, the required client delivery-eligibility date could not reach `all_clients.csv`.

This is distinct from `famStartDate`: the requested `Start Date` is the canonical profile field already used by active-status and delivery-date validation.

## Proof

- reproduced on current `main` (`2a6bd112`): the mapper/export path had no `Start Date` output
- regression test proves `startDate: 2026-07-04` reaches the export row as `"Start Date": "2026-07-04"`
- 32 test suites / 177 tests passed
- TypeScript passed
- ESLint passed with 3 pre-existing hook warnings
- production build passed with existing warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Start Date** column to the “Export All Clients” spreadsheet.
  * Client start dates are now preserved and formatted consistently in exported data.
* **Tests**
  * Added coverage verifying that canonical client start dates appear correctly in exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->