### PR TITLE
Fix route cluster dates across browser time zones

### DIFF
--- a/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
+++ b/my-app/src/pages/Delivery/DeliverySpreadsheet.tsx
@@ -1318,34 +1318,13 @@ const DeliverySpreadsheet: React.FC = () => {
       const requestId = ++clustersRequestIdRef.current;
 
       try {
-        // account for timezone issues
-        const startDate = new Date(
-          Date.UTC(
-            dateForFetch.getFullYear(),
-            dateForFetch.getMonth(),
-            dateForFetch.getDate(),
-            0,
-            0,
-            0
-          )
-        );
-
-        const endDate = new Date(
-          Date.UTC(
-            dateForFetch.getFullYear(),
-            dateForFetch.getMonth(),
-            dateForFetch.getDate(),
-            23,
-            59,
-            59
-          )
-        );
+        const { start, endExclusive } = deliveryDate.getUTCDateBounds(dateForFetch);
 
         const clustersCollectionRef = collection(db, dataSources.firebase.clustersCollection);
         const q = query(
           clustersCollectionRef,
-          where("date", ">=", Timestamp.fromDate(startDate)),
-          where("date", "<=", Timestamp.fromDate(endDate)),
+          where("date", ">=", Timestamp.fromDate(start)),
+          where("date", "<", Timestamp.fromDate(endExclusive)),
           orderBy("date", "asc")
         );
 
@@ -1790,18 +1769,7 @@ const DeliverySpreadsheet: React.FC = () => {
     const docRef = doc(collection(db, dataSources.firebase.clustersCollection));
     const normalizedClusters = normalizeClusters(newClusters);
 
-    // Use selectedDate to ensure consistency with fetched data
-    const clusterDate = new Date(
-      Date.UTC(
-        selectedDate.getFullYear(),
-        selectedDate.getMonth(),
-        selectedDate.getDate(),
-        0,
-        0,
-        0,
-        0
-      )
-    );
+    const clusterDate = deliveryDate.getUTCDateBounds(selectedDateKey).start;
 
     const newClusterDoc = {
       clusters: normalizedClusters,

--- a/my-app/src/services/delivery-service.ts
+++ b/my-app/src/services/delivery-service.ts
@@ -120,7 +120,7 @@ class DeliveryService {
     const eventQuery = query(
       collection(this.db, this.eventsCollection),
       where("deliveryDate", ">=", range.start),
-      where("deliveryDate", "<=", range.end),
+      where("deliveryDate", "<", range.endExclusive),
       orderBy("deliveryDate", "asc")
     );
     const snapshot = await getDocs(eventQuery);
@@ -718,23 +718,17 @@ class DeliveryService {
     return DeliveryService.instance;
   }
 
-  private getClusterDateRange(dateKey: string): { start: Timestamp; end: Timestamp } | null {
+  private getClusterDateRange(dateKey: string): { start: Timestamp; endExclusive: Timestamp } | null {
     const normalizedDateKey = deliveryDate.tryToISODateString(dateKey);
     if (!normalizedDateKey) {
       return null;
     }
 
-    const jsDate = deliveryDate.toJSDate(normalizedDateKey);
-    const startDate = new Date(
-      Date.UTC(jsDate.getFullYear(), jsDate.getMonth(), jsDate.getDate(), 0, 0, 0, 0)
-    );
-    const endDate = new Date(
-      Date.UTC(jsDate.getFullYear(), jsDate.getMonth(), jsDate.getDate(), 23, 59, 59, 999)
-    );
+    const { start, endExclusive } = deliveryDate.getUTCDateBounds(normalizedDateKey);
 
     return {
-      start: Timestamp.fromDate(startDate),
-      end: Timestamp.fromDate(endDate),
+      start: Timestamp.fromDate(start),
+      endExclusive: Timestamp.fromDate(endExclusive),
     };
   }
 
@@ -884,7 +878,7 @@ class DeliveryService {
               const clusterQuery = query(
                 collection(this.db, this.clustersCollection),
                 where("date", ">=", range.start),
-                where("date", "<=", range.end),
+                where("date", "<", range.endExclusive),
                 orderBy("date", "asc")
               );
 

--- a/my-app/src/utils/deliveryDate.test.ts
+++ b/my-app/src/utils/deliveryDate.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "@jest/globals";
+import { deliveryDate } from "./deliveryDate";
+
+describe("deliveryDate.getUTCDateBounds", () => {
+  it("uses the logical Eastern date instead of browser-local date getters", () => {
+    class UTCPlusNineDate extends Date {
+      getFullYear() {
+        return 2026;
+      }
+
+      getMonth() {
+        return 6;
+      }
+
+      getDate() {
+        return 31;
+      }
+    }
+
+    const july30EasternMidday = new UTCPlusNineDate("2026-07-30T16:00:00.000Z");
+
+    expect(july30EasternMidday.getDate()).toBe(31);
+
+    const bounds = deliveryDate.getUTCDateBounds(july30EasternMidday);
+
+    expect(bounds.start.toISOString()).toBe("2026-07-30T00:00:00.000Z");
+    expect(bounds.endExclusive.toISOString()).toBe("2026-07-31T00:00:00.000Z");
+  });
+
+  it("returns an exclusive next-day boundary", () => {
+    const bounds = deliveryDate.getUTCDateBounds("2026-11-01");
+
+    expect(bounds.start.toISOString()).toBe("2026-11-01T00:00:00.000Z");
+    expect(bounds.endExclusive.toISOString()).toBe("2026-11-02T00:00:00.000Z");
+  });
+});

--- a/my-app/src/utils/deliveryDate.ts
+++ b/my-app/src/utils/deliveryDate.ts
@@ -132,6 +132,16 @@ export const deliveryDate = {
       endExclusive: start.plus({ days: 1 }),
     };
   },
+  getUTCDateBounds(input: DeliveryDateInput): { start: Date; endExclusive: Date } {
+    const dateKey = deliveryDate.toISODateString(input);
+    const [year, month, day] = dateKey.split("-").map(Number);
+    const start = new Date(Date.UTC(year, month - 1, day));
+
+    return {
+      start,
+      endExclusive: new Date(Date.UTC(year, month - 1, day + 1)),
+    };
+  },
 };
 
 export type { DeliveryDateInput };


### PR DESCRIPTION
## Summary

- derive cluster UTC storage/query bounds from the app's logical Eastern delivery date
- use the same bounds for route creation, route lookup, and post-schedule reconciliation
- use an exclusive next-day bound for Firestore range queries
- add a regression test that simulates UTC+9 browser-local date getters

## Root cause

The route code converted an Eastern delivery `Date` into a UTC cluster timestamp using browser-local `getFullYear()`, `getMonth()`, and `getDate()`. In UTC+8 and later, July 30 at Eastern midday is already July 31 locally, so a July 30 route assignment could be stored and queried as July 31.

The Firestore timestamp itself is still the correct storage type and is retained. The fix derives UTC midnight from the normalized `YYYY-MM-DD` delivery key instead of browser-local getters.

A read-only production audit supported this diagnosis:

- July 30 had 78 delivery clients and 79 saved route clients, so the stale-assignment banner correctly detected one obsolete assignment.
- The July 31 cluster document contained exactly July 30's 78 delivery clients and none of July 31's 84 delivery clients.

## Impact

Route assignments no longer shift to the following day based on the user's browser time zone. Lookup and reconciliation now share the same date-boundary contract as route creation.

## Validation

- `TZ=Asia/Tokyo CI=true npm test -- --watchAll=false --runTestsByPath src/utils/deliveryDate.test.ts src/pages/Delivery/DeliverySpreadsheet.dateNavigation.test.tsx`
- `CI=true npm run test:ci` — 32 suites, 178 tests passed
- `npx tsc --noEmit`
- `npm run lint` — no errors; three pre-existing hook warnings
- `CI=false npm run build` — successful; existing dependency/lint warnings remain