### PR TITLE
ETL updates

### DIFF
--- a/ETL/README.md
+++ b/ETL/README.md
@@ -134,17 +134,54 @@ python ETL/promote_temp_clients_and_referrals.py
 
 # Option 4: Full pipeline
 python ETL/run_full_etl_with_promotion.py
+
+# Add only selected new rows directly to production
+python ETL/add_client_rows.py --rows 120 125,130 140-142
 ```
 
 ### Quick Reference
 
 | Option | Command | Loads to Temp? | Promotes to Production? | Deletes Temp? | Cost (Geocoding + Firestore ops) |
 |--------|---------|----------------|------------------------|---------------|------|
+| **Add New Rows** | `add_client_rows.py --rows ...` | No | Creates selected production clients directly | No | Geocoding and Firestore writes for selected rows only |
 | **1. Single Batch** | `firebase_migration_v2.py` (with limit) | ✅ 250 records | ❌ | ❌ | ~ $1.25 geocoding + ~ $0.01 Firestore (total: ~ $1.26) |
 | **2. Full to Temp** | `firebase_migration_v2.py` (no limit) | ✅ All records | ❌ | ❌ | ~ $15.75 geocoding + ~ $0.03 Firestore (total: ~ $15.78) |
 | **3. Promote Only** | `promote_temp_clients_and_referrals.py` | ➖ (uses existing) | ✅ | ✅ | Firestore estimate: ~ $0.02 |
 | **4. Full Pipeline** | `run_full_etl_with_promotion.py` | ✅ All records | ✅ | ✅ | ~ $15.75 geocoding + Firestore ops (total: ~$15.80) |
 | **5. NPM Command** | `npm run etl` | ✅ All records | ✅ | ✅ | ~ $15.75 geocoding + Firestore ops (total: ~$15.80) |
+
+---
+
+### Add Only: Import Selected New Workbook Rows
+
+**Use when:** New clients were appended to an `FFA_CLIENT_DATABASE_[DATE].xlsx`
+workbook and only those Excel rows should be added to production.
+
+**This is add only.** The command refuses to run if any selected client ID
+already exists in `client-profile2`. Use the Food For All application to update
+existing client data. This command does not clear temp collections and does not
+run the promotion pipeline.
+
+From the repository root, pass one row, multiple rows, or inclusive ranges:
+
+```powershell
+# Uses the configured default workbook and Current Deliveries sheet
+python ETL\add_client_rows.py --rows 120 125,130 140-142
+
+# Use a differently dated workbook
+python ETL\add_client_rows.py --rows 350,355 --workbook ETL\FFA_CLIENT_DATABASE_AUGUST2026.xlsx
+```
+
+```sh
+python ETL/add_client_rows.py --rows 120 125,130 140-142
+python ETL/add_client_rows.py --rows 350,355 --workbook ETL/FFA_CLIENT_DATABASE_AUGUST2026.xlsx
+```
+
+The command validates all requested rows and client IDs before writing, lists
+the selected clients, and requires the exact confirmation phrase `ADD ONLY`.
+Client documents use create-only Firestore writes, so a concurrent insert also
+fails instead of overwriting production data. New referral and client documents
+are committed atomically in the same batch.
 
 ---
 

--- a/ETL/README.md
+++ b/ETL/README.md
@@ -198,20 +198,25 @@ already exists in `client-profile2`. Use the Food For All application to update
 existing client data. This command does not clear temp collections and does not
 run the promotion pipeline.
 
-From the repository root, pass one row, multiple rows, or inclusive ranges:
+From the repository root, run the command and enter one row, multiple
+comma-separated rows, or inclusive ranges when prompted:
 
 ```powershell
-# Uses the configured default workbook and Current Deliveries sheet
-python ETL\add_client_rows.py --rows 120 125,130 140-142
+# Uses the configured default workbook and Current Deliveries sheet, then asks for rows
+python ETL\add_client_rows.py
 
 # Use a differently dated workbook
-python ETL\add_client_rows.py --rows 350,355 --workbook ETL\FFA_CLIENT_DATABASE_AUGUST2026.xlsx
+python ETL\add_client_rows.py --workbook ETL\FFA_CLIENT_DATABASE_AUGUST2026.xlsx
 ```
 
 ```sh
-python ETL/add_client_rows.py --rows 120 125,130 140-142
-python ETL/add_client_rows.py --rows 350,355 --workbook ETL/FFA_CLIENT_DATABASE_AUGUST2026.xlsx
+python ETL/add_client_rows.py
+python ETL/add_client_rows.py --workbook ETL/FFA_CLIENT_DATABASE_AUGUST2026.xlsx
 ```
+
+The row prompt accepts values such as `120`, `120,125,130`, or `140-142`.
+For scripted use, bypass the row prompt with
+`--rows 120 125,130 140-142`.
 
 The command validates all requested rows and client IDs before writing, lists
 the selected clients, and requires the exact confirmation phrase `ADD ONLY`.

--- a/ETL/README.md
+++ b/ETL/README.md
@@ -116,6 +116,42 @@ The ETL script expects those names and locations.
 
 The ETL system uses a **staging workflow** with temporary collections (`temp-profile2` and `temp-referral`) that you can review before promoting to production (`client-profile2` and `referral`). Choose the option that fits your needs:
 
+### Full ETL Ownership Model: "Day One"
+
+The full ETL is a **Day One load**: it rebuilds the production data owned by
+the two source spreadsheets as though the application were being populated for
+the first time. The full load replaces `client-profile2` and `referral` from
+validated staging data, removing records in those collections that are not in
+the completed spreadsheet-derived load.
+
+Day One does **not** mean deleting the entire Firestore database. Collections
+created and maintained by the application that have no authoritative source in
+the spreadsheets are preserved. This includes drivers, users, tags, and
+delivery-limit settings. Historical route data is also preserved by default;
+`events` and `clusters` can be cleared together only through the separate,
+explicit full-ETL route-deletion confirmation.
+
+| Collection | Recommendation |
+|------------|----------------|
+| `temp-profile2` | Clear and rebuild as staging data from `Current Deliveries`. |
+| `temp-referral` | Clear and rebuild as staging referral/case-worker data. |
+| `client-profile2` | Replace from the completed `temp-profile2` Day One load. |
+| `referral` | Replace from the completed `temp-referral` Day One load. |
+| `events` | Preserve by default. Delete only when intentionally resetting all route history during a full ETL. |
+| `clusters` | Preserve by default. If route history is reset, delete with `events` so assignments cannot outlive their events. |
+| `Drivers2` | Preserve. Driver records are maintained in the app and cannot be rebuilt from the spreadsheet data used by ETL. |
+| `users` | Preserve. User accounts and roles are maintained by the app and authentication system. |
+| `tags` | Preserve. The master tag list is maintained by the app. |
+| `limits` | Preserve. Weekly delivery limits are app configuration. |
+| `dailyLimits` | Preserve. Date-specific delivery limits are app configuration. |
+| `clients` | Leave untouched. This appears to be a legacy collection and is not managed by the full ETL. |
+| `Drivers` | Leave untouched. This appears to be a legacy collection; the active app uses `Drivers2`. |
+
+The `Drivers` worksheet in the client workbook is not an ETL source and does
+not contain enough data to recreate `Drivers2`. Likewise, workbook tabs other
+than `Current Deliveries` and referral-form tabs other than `Form Responses 1`
+are not loaded unless the ETL mapping is deliberately expanded.
+
 ### Mac/Linux command equivalents (after activating venv)
 
 If you are using Mac (or Linux), use these equivalents:
@@ -248,9 +284,9 @@ Remove-Item Env:\MIGRATION_LIMIT_RECORDS -ErrorAction SilentlyContinue
 
 ---
 
-### Option 4: Full Pipeline (ETL → Clean → Promote)
+### Option 4: Full Pipeline / Day One Load (ETL → Clean → Promote)
 
-**Use when:** You want to run everything in one command without reviewing temp data
+**Use when:** You want to rebuild all spreadsheet-owned production data in one command without reviewing temp data
 
 **What it does:** Runs all 4 steps automatically:
 1. ETL into temp collections
@@ -264,8 +300,10 @@ Remove-Item Env:\MIGRATION_LIMIT_RECORDS -ErrorAction SilentlyContinue
 ```
 
 **Result:**
-- ⚠️  **DESTRUCTIVE:** Deletes ALL existing docs in `client-profile2` and `referral`
-- ✅ Fresh data in production collections
+- ⚠️  **REPLACES SPREADSHEET-OWNED DATA:** Rebuilds `client-profile2` and `referral` from the completed temp collections
+- ✅ Removes stale `client-profile2` and `referral` documents that are absent from the completed Day One load
+- ✅ Preserves app-owned collections such as `Drivers2`, `users`, `tags`, `limits`, and `dailyLimits`
+- ✅ Preserves `events` and `clusters` unless the operator enters the exact full-ETL route-deletion confirmation
 - ✅ Temp collections deleted
 - **Cost:** ~$15.75 for geocoding, plus Firestore operations from ETL + promotion
 
@@ -295,7 +333,8 @@ npm run etl
 | Already have validated temp data | Option 3 only |
 
 **Important Notes:**
-- Options 3, 4, and 5 are **DESTRUCTIVE** - they delete production data
+- Options 3, 4, and 5 replace spreadsheet-owned production data in `client-profile2` and `referral`; they do not clear unrelated app-owned collections
+- Deleting `events` and `clusters` is a separate full-ETL choice that requires the exact confirmation phrase `DELETE FULL ETL ROUTE DATA`
 - Always backup production collections before promoting
 - Review `temp-profile2` and `temp-referral` in Firestore console after Option 1/2
 - Environment variable `MIGRATION_LIMIT_RECORDS` persists for entire terminal session

--- a/ETL/add_client_rows.py
+++ b/ETL/add_client_rows.py
@@ -108,6 +108,19 @@ def find_existing_client_ids(db: firestore.Client, client_ids: Iterable[str]) ->
     return sorted(snapshot.id for snapshot in db.get_all(references) if snapshot.exists)
 
 
+def get_row_numbers(cli_values: list[str] | None) -> list[int]:
+    """Use CLI row values when supplied, otherwise ask the operator."""
+    if cli_values:
+        return parse_row_numbers(cli_values)
+
+    print("\nADD ONLY: Select Excel rows containing new clients.")
+    print("Existing client IDs will be rejected; use the app to update existing data.")
+    response = input(
+        "Excel rows to add (examples: 120 or 120,125 or 140-142): "
+    ).strip()
+    return parse_row_numbers([response])
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
@@ -118,10 +131,9 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--rows",
         nargs="+",
-        required=True,
         help=(
             "Excel row numbers, comma-separated values, or ranges "
-            "(for example: 120 125,130 140-142)."
+            "(for example: 120 125,130 140-142). If omitted, the command prompts for rows."
         ),
     )
     parser.add_argument(
@@ -141,7 +153,7 @@ def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
 
     try:
-        row_numbers = parse_row_numbers(args.rows)
+        row_numbers = get_row_numbers(args.rows)
     except ValueError as error:
         print(f"ERROR: {error}")
         return 2

--- a/ETL/add_client_rows.py
+++ b/ETL/add_client_rows.py
@@ -1,0 +1,234 @@
+"""Add selected workbook rows to production without updating existing clients.
+
+This command is intentionally add-only. Existing client document IDs cause the
+entire run to abort. Use the application to update existing client data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+from pathlib import Path
+from typing import Iterable
+
+import firebase_admin
+import pandas as pd
+from firebase_admin import credentials, firestore
+
+
+SERVICE_ACCOUNT_PATH = os.path.join(
+    "ETL", "food-for-all-dc-caf23-firebase-adminsdk-fbsvc-4e77c7873e.json"
+)
+PROJECT_ID = "food-for-all-dc-caf23"
+DEFAULT_WORKBOOK = os.path.join("ETL", "FFA_CLIENT_DATABASE_JULY2026.xlsx")
+DEFAULT_SHEET = "Current Deliveries"
+PRODUCTION_CLIENTS_COLLECTION = "client-profile2"
+PRODUCTION_REFERRALS_COLLECTION = "referral"
+CONFIRMATION_PHRASE = "ADD ONLY"
+
+
+def parse_row_numbers(values: Iterable[str]) -> list[int]:
+    """Parse comma/space-separated Excel row numbers and inclusive ranges."""
+    row_numbers: list[int] = []
+    seen: set[int] = set()
+
+    for token in re.split(r"[\s,]+", " ".join(values).strip()):
+        if not token:
+            continue
+        if re.fullmatch(r"\d+-\d+", token):
+            start, end = (int(value) for value in token.split("-", 1))
+            if start > end:
+                raise ValueError(f"Row range must be ascending: {token}")
+            candidates = range(start, end + 1)
+        elif token.isdigit():
+            candidates = (int(token),)
+        else:
+            raise ValueError(f"Invalid row number or range: {token}")
+
+        for row_number in candidates:
+            if row_number < 2:
+                raise ValueError("Excel row numbers must be 2 or greater; row 1 contains headers.")
+            if row_number not in seen:
+                seen.add(row_number)
+                row_numbers.append(row_number)
+
+    if not row_numbers:
+        raise ValueError("At least one Excel row number is required.")
+    return row_numbers
+
+
+def select_rows(dataframe: pd.DataFrame, row_numbers: list[int]) -> list[dict]:
+    """Return normalized workbook records in the requested row order."""
+    if "_excel_row_num" not in dataframe.columns:
+        raise ValueError("Workbook data is missing Excel row-number metadata.")
+    if "ID" not in dataframe.columns:
+        raise ValueError("Workbook sheet does not contain an ID column.")
+
+    records_by_row = {
+        int(record["_excel_row_num"]): record
+        for record in dataframe.to_dict(orient="records")
+    }
+    missing_rows = [row_number for row_number in row_numbers if row_number not in records_by_row]
+    if missing_rows:
+        raise ValueError(f"Workbook rows not found: {', '.join(map(str, missing_rows))}")
+
+    records = [records_by_row[row_number] for row_number in row_numbers]
+    invalid_rows = []
+    client_ids = []
+    for record in records:
+        raw_id = record.get("ID")
+        if pd.isna(raw_id):
+            client_id = ""
+        elif isinstance(raw_id, float) and raw_id.is_integer():
+            client_id = str(int(raw_id))
+        else:
+            client_id = str(raw_id).strip()
+        if client_id.lower() in {"", "nan", "none", "null"}:
+            invalid_rows.append(int(record["_excel_row_num"]))
+        record["ID"] = client_id
+        client_ids.append(client_id)
+    if invalid_rows:
+        raise ValueError(f"Selected rows have no stable ID: {', '.join(map(str, invalid_rows))}")
+
+    duplicate_ids = sorted(
+        client_id for client_id in set(client_ids) if client_ids.count(client_id) > 1
+    )
+    if duplicate_ids:
+        raise ValueError(f"Selected rows contain duplicate IDs: {', '.join(duplicate_ids)}")
+    return records
+
+
+def find_existing_client_ids(db: firestore.Client, client_ids: Iterable[str]) -> list[str]:
+    """Return selected IDs that already exist in production."""
+    references = [
+        db.collection(PRODUCTION_CLIENTS_COLLECTION).document(client_id)
+        for client_id in client_ids
+    ]
+    return sorted(snapshot.id for snapshot in db.get_all(references) if snapshot.exists)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Add new FFA client workbook rows to production. ADD ONLY: use the app "
+            "to update clients that already exist."
+        )
+    )
+    parser.add_argument(
+        "--rows",
+        nargs="+",
+        required=True,
+        help=(
+            "Excel row numbers, comma-separated values, or ranges "
+            "(for example: 120 125,130 140-142)."
+        ),
+    )
+    parser.add_argument(
+        "--workbook",
+        default=DEFAULT_WORKBOOK,
+        help="Path to FFA_CLIENT_DATABASE_[DATE].xlsx.",
+    )
+    parser.add_argument(
+        "--sheet",
+        default=DEFAULT_SHEET,
+        help="Workbook sheet containing client rows.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    try:
+        row_numbers = parse_row_numbers(args.rows)
+    except ValueError as error:
+        print(f"ERROR: {error}")
+        return 2
+
+    workbook = Path(args.workbook)
+    if not workbook.exists():
+        print(f"ERROR: Workbook not found: {workbook}")
+        return 2
+
+    import firebase_migration_v2 as migration_module
+
+    try:
+        dataframe = pd.read_excel(workbook, sheet_name=args.sheet, dtype=object)
+        dataframe = migration_module.normalize_client_database_dataframe(dataframe)
+        records = select_rows(dataframe, row_numbers)
+    except Exception as error:
+        print(f"ERROR: Unable to load selected workbook rows: {error}")
+        return 2
+
+    api_key = os.getenv("REACT_APP_GOOGLE_MAPS_API_KEY") or os.getenv(
+        "GOOGLE_MAPS_API_KEY", ""
+    )
+    if not api_key:
+        print(
+            "ERROR: Set REACT_APP_GOOGLE_MAPS_API_KEY or GOOGLE_MAPS_API_KEY "
+            "before running add-only ETL."
+        )
+        return 2
+
+    if not firebase_admin._apps:
+        firebase_admin.initialize_app(
+            credentials.Certificate(SERVICE_ACCOUNT_PATH),
+            {"projectId": PROJECT_ID},
+        )
+    db = firestore.client()
+
+    client_ids = [record["ID"] for record in records]
+    existing_ids = find_existing_client_ids(db, client_ids)
+    if existing_ids:
+        print("ERROR: Add-only ETL cannot overwrite existing clients:")
+        for client_id in existing_ids:
+            print(f"  - {client_id}")
+        print("Use the Food For All application to update existing client data.")
+        return 1
+
+    print("\nADD-ONLY PRODUCTION IMPORT")
+    print("This command creates new clients only. It never updates existing client documents.")
+    print("Use the Food For All application for updates to existing clients.\n")
+    print("Existing events and clusters will be kept; route-data deletion is disabled.\n")
+    for record in records:
+        first_name = record.get("FIRST_database") or record.get("FIRST", "")
+        last_name = record.get("LAST_database") or record.get("LAST", "")
+        name = f"{first_name} {last_name}".strip()
+        print(f"  Excel row {int(record['_excel_row_num'])}: {record['ID']} - {name}")
+
+    confirmation = input(
+        f"\nType {CONFIRMATION_PHRASE} to create these clients: "
+    ).strip()
+    if confirmation != CONFIRMATION_PHRASE:
+        print("Cancelled. No client data was written.")
+        return 1
+
+    migration = migration_module.FirestoreMigration(
+        service_account_path=SERVICE_ACCOUNT_PATH,
+        project_id=PROJECT_ID,
+        collection_name=PRODUCTION_CLIENTS_COLLECTION,
+        referral_collection_name=PRODUCTION_REFERRALS_COLLECTION,
+        create_only=True,
+    )
+    stats = migration.migrate_data(
+        file_path=None,
+        batch_size=min(250, len(records)),
+        max_workers=1,
+        use_threading=False,
+        records_override=records,
+    )
+
+    if stats.failed_imports or stats.successful_imports != len(records):
+        print(
+            f"ERROR: Add-only import created {stats.successful_imports}/{len(records)} clients "
+            f"with {stats.failed_imports} failure(s). Review ETL error logs."
+        )
+        return 1
+
+    print(f"Successfully added {stats.successful_imports} new production client(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ETL/firebase_migration_v2.py
+++ b/ETL/firebase_migration_v2.py
@@ -1,5 +1,7 @@
 CLIENT_COLLECTION_NAME = "temp-profile2"
 REFERRAL_COLLECTION_NAME = "temp-referral"
+PRODUCTION_CLIENT_COLLECTION_NAME = "client-profile2"
+PRODUCTION_REFERRAL_COLLECTION_NAME = "referral"
 
 import json
 import os
@@ -961,7 +963,7 @@ class FirestoreMigration:
 					is_internet = str(referral.get("organization", "")).strip().lower() == "internet search"
 					if is_internet:
 						# Try to find existing 'Internet Search' referral
-						ref_coll = self.db.collection(REFERRAL_COLLECTION_NAME)
+						ref_coll = self.db.collection(self.referral_collection_name)
 						internet_filter = FieldFilter("organization", "==", "Internet Search")
 						query = ref_coll.where(filter=internet_filter)
 						existing = list(query.limit(1).stream())
@@ -979,8 +981,11 @@ class FirestoreMigration:
 								"phone": ""
 							}
 							try:
-								ref_ref = self.db.collection(REFERRAL_COLLECTION_NAME).document()
-								ref_ref.set(referral_doc)
+								ref_ref = self.db.collection(self.referral_collection_name).document()
+								if self.create_only:
+									batch.create(ref_ref, referral_doc)
+								else:
+									ref_ref.set(referral_doc)
 								referral_doc_id = ref_ref.id
 								logger.debug(f"Inserted new 'Internet Search' referral with id {referral_doc_id}")
 								if "referralEntity" in transformed and transformed["referralEntity"] is not None:
@@ -1006,7 +1011,7 @@ class FirestoreMigration:
 						else:
 							# Check Firestore for existing referral with same or swapped fields
 							found_existing = False
-							ref_coll = self.db.collection(REFERRAL_COLLECTION_NAME)
+							ref_coll = self.db.collection(self.referral_collection_name)
 							if referral.get("email"):
 								email_filter = FieldFilter("email", "==", referral["email"])
 								query = ref_coll.where(filter=email_filter)
@@ -1064,14 +1069,17 @@ class FirestoreMigration:
 										break
 								# Insert into referral collection and get the doc ID
 								try:
-									ref_ref = self.db.collection(REFERRAL_COLLECTION_NAME).document()
-									ref_ref.set(referral_doc)
+									ref_ref = self.db.collection(self.referral_collection_name).document()
+									if self.create_only:
+										batch.create(ref_ref, referral_doc)
+									else:
+										ref_ref.set(referral_doc)
 									referral_doc_id = ref_ref.id
 									ref_name = str(referral_doc.get("name", "")).strip() or "<no name>"
 									ref_org = str(referral_doc.get("organization", "")).strip() or "<no org>"
 									# Quiet per-record console output: keep details only in debug logs
 									logger.debug(
-										f"[REF] Inserted referral into {REFERRAL_COLLECTION_NAME}: "
+										f"[REF] Inserted referral into {self.referral_collection_name}: "
 										f"{ref_name} - {ref_org} (id {referral_doc_id})"
 									)
 									# Set the referralEntity.id in the client profile
@@ -1082,7 +1090,7 @@ class FirestoreMigration:
 									ref_name = str(referral_doc.get("name", "")).strip() or "<no name>"
 									ref_org = str(referral_doc.get("organization", "")).strip() or "<no org>"
 									logger.error(
-										f"[ERROR] Failed to insert referral into {REFERRAL_COLLECTION_NAME} | "
+										f"[ERROR] Failed to insert referral into {self.referral_collection_name} | "
 										f"Name: {ref_name} | "
 										f"Organization: {ref_org} | "
 										f"Error: {str(e)}"
@@ -1108,7 +1116,10 @@ class FirestoreMigration:
 				transformed.pop("_referralContactPhone", None)
 				transformed.pop("_referralContactEmail", None)
 				doc_ref = self.db.collection(self.collection_name).document(doc_id)
-				batch.set(doc_ref, transformed)
+				if self.create_only:
+					batch.create(doc_ref, transformed)
+				else:
+					batch.set(doc_ref, transformed)
 				successful += 1
 				# Update the on-screen current-record line for a successful insert
 				name_preview = f"{transformed.get('firstName', '')} {transformed.get('lastName', '')}".strip() or display_name
@@ -1384,9 +1395,18 @@ class FirestoreMigration:
 		except Exception as e:
 			logger.error(f"[ERROR] Error loading file {file_path}: {str(e)}")
 			return []
-	def __init__(self, service_account_path: str, project_id: str, collection_name: str = "clients"):
+	def __init__(
+		self,
+		service_account_path: str,
+		project_id: str,
+		collection_name: str = "clients",
+		referral_collection_name: str = REFERRAL_COLLECTION_NAME,
+		create_only: bool = False,
+	):
 		self.project_id = project_id
 		self.collection_name = collection_name
+		self.referral_collection_name = referral_collection_name
+		self.create_only = create_only
 		self.stats = MigrationStats()
 		self.processed_names = set()
 		self.case_workers = {}

--- a/ETL/firebase_migration_v2.py
+++ b/ETL/firebase_migration_v2.py
@@ -956,6 +956,20 @@ class FirestoreMigration:
 						"email": str(transformed.get("_referralContactEmail", "")),
 						"phone": normalize_phone_for_save(transformed.get("_referralContactPhone", "")),
 					}
+				# Full ETL prunes contactless referrals before promotion. Mirror that
+				# cleanup when create-only imports write directly to production.
+				if (
+					self.create_only
+					and referral
+					and not str(referral.get("email") or "").strip()
+					and not str(referral.get("phone") or "").strip()
+				):
+					transformed["referralEntity"] = {
+						"id": "",
+						"name": "",
+						"organization": "None",
+					}
+					referral = None
 				# Only insert if we have at least a name or organization
 				if referral and (referral.get("name") or referral.get("organization")):
 					referral_insert_failed = False

--- a/ETL/run_full_etl_with_promotion.py
+++ b/ETL/run_full_etl_with_promotion.py
@@ -17,12 +17,17 @@ Pipeline steps (in order):
    - Copy all docs from "temp-profile2" -> "client-profile2" and
      from "temp-referral" -> "referral" using the same IDs.
    - Delete all docs from the sandbox collections.
+5. If route-data deletion was selected before the pipeline started,
+   delete all documents from both "events" and "clusters" so saved
+   cluster assignments cannot outlive their source delivery events.
 
 **WARNING: FINAL STEP IS DESTRUCTIVE**
 
 - The last step permanently deletes all existing documents in
   "client-profile2" and "referral" and replaces them with the sandbox
   data.
+- If route-data deletion is selected, the final cleanup also permanently
+  deletes all documents in both "events" and "clusters".
 - Use this only after you have validated the sandbox output of
   firebase_migration_v2 and are ready to refresh production.
 
@@ -48,17 +53,40 @@ import promote_temp_clients_and_referrals
 
 
 ROUTE_EVENTS_COLLECTION = "events"
+ROUTE_CLUSTERS_COLLECTION = "clusters"
+ROUTE_DATA_COLLECTIONS = (ROUTE_CLUSTERS_COLLECTION, ROUTE_EVENTS_COLLECTION)
+ROUTE_DELETE_CONFIRMATION = "DELETE FULL ETL ROUTE DATA"
 
 
-def _prompt_delete_routes(console: Console) -> bool:
-  """Ask whether to delete production route events after promotion."""
+def _prompt_delete_routes(console: Console, *, add_only: bool = False) -> bool:
+  """Ask about route deletion only for a full replacement ETL run."""
+  if add_only:
+    console.print(
+      "\n[bold green]Add-only mode:[/bold green] Existing production data in "
+      f"[bold]{ROUTE_EVENTS_COLLECTION}[/bold] and "
+      f"[bold]{ROUTE_CLUSTERS_COLLECTION}[/bold] will be kept. "
+      "Route-data deletion is disabled."
+    )
+    return False
+
   console.print(
-    "\n[yellow]Optional:[/yellow] Delete all production route events "
-    f"in [bold]{ROUTE_EVENTS_COLLECTION}[/bold]?"
+    "\n[bold red]FULL ETL ONLY:[/bold red] Optionally delete all production route data in "
+    f"[bold]{ROUTE_EVENTS_COLLECTION}[/bold] and "
+    f"[bold]{ROUTE_CLUSTERS_COLLECTION}[/bold]?"
   )
-  console.print("[dim]Type 'yes' to delete routes, or press Enter / type 'no' to keep them.[/dim]")
-  response = input("Delete route events? [yes/no] (default: no): ").strip().lower()
-  return response in {"y", "yes"}
+  console.print(
+    "[yellow]Do not delete this data when adding selected new workbook rows. "
+    "Exit this full ETL and use add_client_rows.py for add-only imports.[/yellow]"
+  )
+  console.print(
+    "[dim]For a full replacement ETL only, type "
+    f"'[bold]{ROUTE_DELETE_CONFIRMATION}[/bold]' exactly. "
+    "Any other response keeps route events and clusters.[/dim]"
+  )
+  response = input(
+    "FULL ETL route-data deletion confirmation (default: keep): "
+  ).strip()
+  return response == ROUTE_DELETE_CONFIRMATION
 
 
 def _delete_collection_documents(collection_name: str, console: Console) -> int:
@@ -76,6 +104,14 @@ def _delete_collection_documents(collection_name: str, console: Console) -> int:
   return deleted
 
 
+def _delete_route_data(console: Console) -> dict[str, int]:
+  """Delete route events and their corresponding cluster assignments."""
+  return {
+    collection_name: _delete_collection_documents(collection_name, console)
+    for collection_name in ROUTE_DATA_COLLECTIONS
+  }
+
+
 def main() -> None:
   console = Console()
 
@@ -84,13 +120,16 @@ def main() -> None:
   delete_routes_after_promotion = _prompt_delete_routes(console)
   if delete_routes_after_promotion:
     rprint(
-      "[yellow]ℹ️ Route events will be deleted as the final step "
-      f"after successful promotion from [bold]{ROUTE_EVENTS_COLLECTION}[/bold].[/yellow]\n"
+      "[yellow]ℹ️ Route events and clusters will be deleted as the final step "
+      "after successful promotion from "
+      f"[bold]{ROUTE_EVENTS_COLLECTION}[/bold] and "
+      f"[bold]{ROUTE_CLUSTERS_COLLECTION}[/bold].[/yellow]\n"
     )
   else:
     rprint(
-      "[cyan]ℹ️ Route events will be kept. "
-      f"No changes will be made to [bold]{ROUTE_EVENTS_COLLECTION}[/bold].[/cyan]\n"
+      "[cyan]ℹ️ Route events and clusters will be kept. "
+      f"No changes will be made to [bold]{ROUTE_EVENTS_COLLECTION}[/bold] or "
+      f"[bold]{ROUTE_CLUSTERS_COLLECTION}[/bold].[/cyan]\n"
     )
 
   rprint("[cyan]Step 1/4[/cyan] ▶️ ETL into [bold]temp-profile2[/bold] / [bold]temp-referral[/bold]...")
@@ -128,12 +167,17 @@ def main() -> None:
 
   if delete_routes_after_promotion:
     rprint(
-      "[yellow]🗑️ Deleting production route events collection "
-      f"[bold]{ROUTE_EVENTS_COLLECTION}[/bold]...[/yellow]"
+      "[yellow]🗑️ Deleting production route data from "
+      f"[bold]{ROUTE_EVENTS_COLLECTION}[/bold] and "
+      f"[bold]{ROUTE_CLUSTERS_COLLECTION}[/bold]...[/yellow]"
     )
-    _delete_collection_documents(ROUTE_EVENTS_COLLECTION, console)
+    _delete_route_data(console)
   else:
-    rprint(f"[cyan]ℹ️ Final step: kept [bold]{ROUTE_EVENTS_COLLECTION}[/bold].[/cyan]")
+    rprint(
+      "[cyan]ℹ️ Final step: kept "
+      f"[bold]{ROUTE_EVENTS_COLLECTION}[/bold] and "
+      f"[bold]{ROUTE_CLUSTERS_COLLECTION}[/bold].[/cyan]"
+    )
 
   rprint("[bold green]🎉 Full ETL + cleanup + promotion pipeline completed.[/bold green]")
 

--- a/ETL/test_add_client_rows.py
+++ b/ETL/test_add_client_rows.py
@@ -1,9 +1,14 @@
 from unittest import TestCase
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 
-from add_client_rows import find_existing_client_ids, parse_row_numbers, select_rows
+from add_client_rows import (
+    find_existing_client_ids,
+    get_row_numbers,
+    parse_row_numbers,
+    select_rows,
+)
 
 
 class ParseRowNumbersTests(TestCase):
@@ -23,6 +28,20 @@ class ParseRowNumbersTests(TestCase):
     def test_rejects_descending_range(self) -> None:
         with self.assertRaisesRegex(ValueError, "must be ascending"):
             parse_row_numbers(["12-10"])
+
+    def test_prompts_for_rows_when_cli_option_is_omitted(self) -> None:
+        with patch("builtins.input", return_value="12,15-16") as prompt:
+            result = get_row_numbers(None)
+
+        self.assertEqual(result, [12, 15, 16])
+        prompt.assert_called_once()
+
+    def test_cli_rows_bypass_interactive_prompt(self) -> None:
+        with patch("builtins.input") as prompt:
+            result = get_row_numbers(["12", "15-16"])
+
+        self.assertEqual(result, [12, 15, 16])
+        prompt.assert_not_called()
 
 
 class SelectRowsTests(TestCase):

--- a/ETL/test_add_client_rows.py
+++ b/ETL/test_add_client_rows.py
@@ -9,6 +9,7 @@ from add_client_rows import (
     parse_row_numbers,
     select_rows,
 )
+from firebase_migration_v2 import FirestoreMigration, MigrationStats
 
 
 class ParseRowNumbersTests(TestCase):
@@ -100,3 +101,109 @@ class ExistingClientTests(TestCase):
         self.assertEqual(result, ["ID-8"])
         collection = database.collection
         collection.assert_any_call("client-profile2")
+
+
+class CreateOnlyReferralTests(TestCase):
+    def _build_migration(self, transformed_records: list[dict]) -> FirestoreMigration:
+        migration = FirestoreMigration.__new__(FirestoreMigration)
+        migration.db = MagicMock()
+        migration.collection_name = "client-profile2"
+        migration.referral_collection_name = "referral"
+        migration.create_only = True
+        migration.stats = MigrationStats()
+        migration.processed_names = set()
+        migration.failed_geocoding_clients = []
+        migration.load_referral_form = MagicMock(return_value=[])
+        migration.check_recent_deliveries = MagicMock(return_value=False)
+        migration._advance_progress = MagicMock()
+        migration.transform_record = MagicMock(side_effect=transformed_records)
+        return migration
+
+    def test_contactless_referral_is_not_created_in_production(self) -> None:
+        migration = self._build_migration(
+            [
+                {
+                    "firstName": "No",
+                    "lastName": "Referral",
+                    "referralEntity": {"id": "", "name": "None", "organization": "None"},
+                    "_referralContactEmail": "",
+                    "_referralContactPhone": "",
+                }
+            ]
+        )
+
+        successful, failed = migration.import_batch(
+            [{"ID": "NEW-1", "FIRST": "No", "LAST": "Referral", "Active": "Yes"}]
+        )
+
+        self.assertEqual((successful, failed), (1, 0))
+        batch = migration.db.batch.return_value
+        batch.create.assert_called_once()
+        self.assertEqual(
+            batch.create.call_args.args[1]["referralEntity"],
+            {"id": "", "name": "", "organization": "None"},
+        )
+        self.assertEqual(
+            [call.args[0] for call in migration.db.collection.call_args_list],
+            ["client-profile2"],
+        )
+
+    def test_contactless_internet_search_rows_do_not_create_duplicate_referrals(self) -> None:
+        migration = self._build_migration(
+            [
+                {
+                    "firstName": first_name,
+                    "lastName": "Client",
+                    "referralEntity": {
+                        "id": "",
+                        "name": "",
+                        "organization": "Internet Search",
+                    },
+                    "_referralContactEmail": "",
+                    "_referralContactPhone": "",
+                }
+                for first_name in ("One", "Two")
+            ]
+        )
+
+        successful, failed = migration.import_batch(
+            [
+                {"ID": "NEW-1", "FIRST": "One", "LAST": "Client", "Active": "Yes"},
+                {"ID": "NEW-2", "FIRST": "Two", "LAST": "Client", "Active": "Yes"},
+            ]
+        )
+
+        self.assertEqual((successful, failed), (2, 0))
+        batch = migration.db.batch.return_value
+        self.assertEqual(batch.create.call_count, 2)
+        self.assertEqual(
+            [call.args[0] for call in migration.db.collection.call_args_list],
+            ["client-profile2", "client-profile2"],
+        )
+
+    def test_contactful_referral_is_created_with_its_client(self) -> None:
+        migration = self._build_migration(
+            [
+                {
+                    "firstName": "Has",
+                    "lastName": "Referral",
+                    "referralEntity": {
+                        "id": "",
+                        "name": "Case Worker",
+                        "organization": "Community Center",
+                    },
+                    "_referralContactEmail": "worker@example.org",
+                    "_referralContactPhone": "",
+                }
+            ]
+        )
+
+        successful, failed = migration.import_batch(
+            [{"ID": "NEW-1", "FIRST": "Has", "LAST": "Referral", "Active": "Yes"}]
+        )
+
+        self.assertEqual((successful, failed), (1, 0))
+        writes = [call.args[1] for call in migration.db.batch.return_value.create.call_args_list]
+        self.assertEqual(len(writes), 2)
+        self.assertEqual(writes[0]["email"], "worker@example.org")
+        self.assertEqual(writes[1]["referralEntity"]["organization"], "Community Center")

--- a/ETL/test_add_client_rows.py
+++ b/ETL/test_add_client_rows.py
@@ -1,0 +1,83 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+from add_client_rows import find_existing_client_ids, parse_row_numbers, select_rows
+
+
+class ParseRowNumbersTests(TestCase):
+    def test_accepts_numbers_commas_and_ranges(self) -> None:
+        self.assertEqual(
+            parse_row_numbers(["12", "15,18", "20-22"]),
+            [12, 15, 18, 20, 21, 22],
+        )
+
+    def test_removes_duplicate_rows_without_reordering(self) -> None:
+        self.assertEqual(parse_row_numbers(["12,12", "11-12"]), [12, 11])
+
+    def test_rejects_header_row(self) -> None:
+        with self.assertRaisesRegex(ValueError, "row 1 contains headers"):
+            parse_row_numbers(["1"])
+
+    def test_rejects_descending_range(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must be ascending"):
+            parse_row_numbers(["12-10"])
+
+
+class SelectRowsTests(TestCase):
+    def test_preserves_requested_excel_row_order(self) -> None:
+        dataframe = pd.DataFrame(
+            [
+                {"_excel_row_num": 8, "ID": "ID-8", "FIRST": "Eight"},
+                {"_excel_row_num": 12, "ID": "ID-12", "FIRST": "Twelve"},
+            ]
+        )
+
+        records = select_rows(dataframe, [12, 8])
+
+        self.assertEqual([record["ID"] for record in records], ["ID-12", "ID-8"])
+
+    def test_rejects_missing_rows(self) -> None:
+        dataframe = pd.DataFrame([{"_excel_row_num": 8, "ID": "ID-8"}])
+
+        with self.assertRaisesRegex(ValueError, "Workbook rows not found: 9"):
+            select_rows(dataframe, [9])
+
+    def test_rejects_rows_without_stable_ids(self) -> None:
+        dataframe = pd.DataFrame([{"_excel_row_num": 8, "ID": None}])
+
+        with self.assertRaisesRegex(ValueError, "Selected rows have no stable ID: 8"):
+            select_rows(dataframe, [8])
+
+    def test_normalizes_integral_excel_ids(self) -> None:
+        dataframe = pd.DataFrame([{"_excel_row_num": 8, "ID": 2056.0}])
+
+        records = select_rows(dataframe, [8])
+
+        self.assertEqual(records[0]["ID"], "2056")
+
+    def test_rejects_duplicate_client_ids(self) -> None:
+        dataframe = pd.DataFrame(
+            [
+                {"_excel_row_num": 8, "ID": "ID-8"},
+                {"_excel_row_num": 9, "ID": "ID-8"},
+            ]
+        )
+
+        with self.assertRaisesRegex(ValueError, "duplicate IDs: ID-8"):
+            select_rows(dataframe, [8, 9])
+
+
+class ExistingClientTests(TestCase):
+    def test_returns_only_existing_production_ids(self) -> None:
+        database = MagicMock()
+        existing = MagicMock(id="ID-8", exists=True)
+        missing = MagicMock(id="ID-9", exists=False)
+        database.get_all.return_value = [missing, existing]
+
+        result = find_existing_client_ids(database, ["ID-8", "ID-9"])
+
+        self.assertEqual(result, ["ID-8"])
+        collection = database.collection
+        collection.assert_any_call("client-profile2")

--- a/ETL/test_run_full_etl_with_promotion.py
+++ b/ETL/test_run_full_etl_with_promotion.py
@@ -1,0 +1,77 @@
+import sys
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import Mock, call, patch
+
+for module_name in (
+  "firebase_migration_v2",
+  "prune_temp_referrals_no_contact",
+  "cleanup_temp_referrals_name_from_org",
+  "promote_temp_clients_and_referrals",
+):
+  sys.modules.setdefault(module_name, Mock())
+
+import run_full_etl_with_promotion as pipeline
+
+
+class DeleteRouteDataTests(TestCase):
+  def test_add_only_mode_disables_route_deletion_without_prompting(self) -> None:
+    console = Mock()
+
+    with patch("builtins.input") as prompt:
+      result = pipeline._prompt_delete_routes(console, add_only=True)
+
+    self.assertFalse(result)
+    prompt.assert_not_called()
+    self.assertIn("Route-data deletion is disabled", console.print.call_args.args[0])
+
+  def test_plain_yes_does_not_enable_full_etl_route_deletion(self) -> None:
+    with patch("builtins.input", return_value="yes"):
+      result = pipeline._prompt_delete_routes(Mock())
+
+    self.assertFalse(result)
+
+  def test_exact_full_etl_phrase_enables_route_deletion(self) -> None:
+    with patch("builtins.input", return_value=pipeline.ROUTE_DELETE_CONFIRMATION):
+      result = pipeline._prompt_delete_routes(Mock())
+
+    self.assertTrue(result)
+
+  def test_deletes_events_and_clusters(self) -> None:
+    console = Mock()
+
+    with patch.object(
+      pipeline,
+      "_delete_collection_documents",
+      side_effect=[4, 12],
+    ) as delete_collection:
+      result = pipeline._delete_route_data(console)
+
+    self.assertEqual(result, {"events": 12, "clusters": 4})
+    self.assertEqual(
+      delete_collection.call_args_list,
+      [call("clusters", console), call("events", console)],
+    )
+
+  def test_main_deletes_route_data_after_successful_promotion(self) -> None:
+    migration_stats = SimpleNamespace(
+      total_records=10,
+      skipped_inactive=1,
+      skipped_duplicates=1,
+      failed_imports=0,
+      successful_imports=8,
+    )
+
+    with (
+      patch.dict("os.environ", {"MIGRATION_LIMIT_RECORDS": ""}),
+      patch.object(pipeline, "_prompt_delete_routes", return_value=True),
+      patch.object(pipeline.firebase_migration_v2, "main", return_value=migration_stats),
+      patch.object(pipeline.prune_temp_referrals_no_contact, "main"),
+      patch.object(pipeline.cleanup_temp_referrals_name_from_org, "main"),
+      patch.object(pipeline.promote_temp_clients_and_referrals, "main"),
+      patch.object(pipeline, "_delete_route_data") as delete_route_data,
+      patch.object(pipeline, "rprint"),
+    ):
+      pipeline.main()
+
+    delete_route_data.assert_called_once()


### PR DESCRIPTION
## Summary

Adds/Updates two explicit ETL workflows:

- **Day One (Full ETL)**
  - Rebuilds spreadsheet-owned client and referral data.
  - Preserves app-owned collections by default.
  - Optionally clears `events` and `clusters` together using an explicit confirmation phrase.

- **Add Only**
  - Imports selected Excel rows directly into production.
  - Supports individual rows, lists, and ranges.
  - Rejects existing client IDs instead of updating them.
  - Uses create-only, atomic Firestore writes.
  - Directs users to the app for existing-client updates.

## Additional Changes

- Added safeguards around destructive route-data deletion.
- Documented collection ownership and preservation behavior.
- Added tests for row parsing, validation, create-only imports, and deletion guards.

## Testing

- 15 ETL unit tests passing.
- Python compilation and diff validation passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an add-only workflow to import selected spreadsheet rows into production with validation and duplicate protection.
  * Full rebuilds now preserve app-owned and route-history data by default.
  * Added optional deletion of route events and clusters with exact confirmation.
  * Added safeguards for create-only client and referral imports.

* **Documentation**
  * Clarified rebuild, promotion, import, and route-deletion workflows.

* **Tests**
  * Added coverage for row selection, duplicate handling, validation, create-only referrals, and route-data deletion safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->