### PR TITLE
Fixes to date and wrapping issues

### DIFF
--- a/my-app/src/pages/Profile/Profile.tsx
+++ b/my-app/src/pages/Profile/Profile.tsx
@@ -840,6 +840,10 @@ const Profile = () => {
       return new Date(obj.getTime()) as T;
     }
 
+    if (typeof (obj as { toDate?: unknown }).toDate === "function") {
+      return obj;
+    }
+
     if (Array.isArray(obj)) {
       return obj.map((item) => deepCopy(item)) as unknown as T;
     }

--- a/my-app/src/pages/Profile/components/DeliveryInfoForm.tsx
+++ b/my-app/src/pages/Profile/components/DeliveryInfoForm.tsx
@@ -5,6 +5,7 @@ import { ClientProfileKey, InputType } from "../types";
 import { styled, Select } from "@mui/material";
 import TagManager from "../Tags/TagManager";
 import { validateDateRange } from "../../../utils/dateValidation";
+import { formatLastEditedTimestamp } from "../../../utils/dates";
 
 interface DeliveryInfoFormProps {
   clientProfile: ClientProfile;
@@ -63,6 +64,11 @@ const DeliveryInfoForm: React.FC<DeliveryInfoFormProps> = ({
 }) => {
   const [startDateError, setStartDateError] = useState<string>("");
   const [endDateError, setEndDateError] = useState<string>("");
+
+  const deliveryInstructionsLastEdited = formatLastEditedTimestamp(
+    clientProfile.deliveryInstructionsTimestamp?.timestamp
+  );
+  const notesLastEdited = formatLastEditedTimestamp(clientProfile.notesTimestamp?.timestamp);
 
   // Validate date range whenever start or end date changes
   useEffect(() => {
@@ -183,21 +189,10 @@ const DeliveryInfoForm: React.FC<DeliveryInfoFormProps> = ({
             DELIVERY INSTRUCTIONS
           </Typography>
           {renderField("deliveryDetails.deliveryInstructions", "textarea")}
-          {clientProfile.deliveryDetails?.deliveryInstructions?.trim() !== "" && (
-            <p id="timestamp">
-              Last edited:{" "}
-              {clientProfile.deliveryInstructionsTimestamp &&
-                clientProfile.deliveryInstructionsTimestamp.timestamp &&
-                new Date(
-                  typeof clientProfile.deliveryInstructionsTimestamp.timestamp === "object" &&
-                  clientProfile.deliveryInstructionsTimestamp.timestamp !== null &&
-                  "toDate" in clientProfile.deliveryInstructionsTimestamp.timestamp &&
-                  typeof clientProfile.deliveryInstructionsTimestamp.timestamp.toDate === "function"
-                    ? clientProfile.deliveryInstructionsTimestamp.timestamp.toDate()
-                    : clientProfile.deliveryInstructionsTimestamp.timestamp
-                ).toLocaleString()}
-            </p>
-          )}
+          {clientProfile.deliveryDetails?.deliveryInstructions?.trim() !== "" &&
+            deliveryInstructionsLastEdited && (
+              <p id="timestamp">Last edited: {deliveryInstructionsLastEdited}</p>
+            )}
         </Box>
 
         {/* Notes */}
@@ -212,20 +207,8 @@ const DeliveryInfoForm: React.FC<DeliveryInfoFormProps> = ({
             ADMIN NOTES
           </Typography>
           {renderField("notes", "textarea")}
-          {clientProfile.notes?.trim() !== "" && (
-            <p id="timestamp">
-              Last edited:{" "}
-              {clientProfile.notesTimestamp &&
-                clientProfile.notesTimestamp.timestamp &&
-                new Date(
-                  typeof clientProfile.notesTimestamp.timestamp === "object" &&
-                  clientProfile.notesTimestamp.timestamp !== null &&
-                  "toDate" in clientProfile.notesTimestamp.timestamp &&
-                  typeof clientProfile.notesTimestamp.timestamp.toDate === "function"
-                    ? clientProfile.notesTimestamp.timestamp.toDate()
-                    : clientProfile.notesTimestamp.timestamp
-                ).toLocaleString()}
-            </p>
+          {clientProfile.notes?.trim() !== "" && notesLastEdited && (
+            <p id="timestamp">Last edited: {notesLastEdited}</p>
           )}
         </Box>
       </Box>

--- a/my-app/src/pages/Profile/components/FormField.tsx
+++ b/my-app/src/pages/Profile/components/FormField.tsx
@@ -819,16 +819,16 @@ const FormField = (props: FormFieldProps) => {
         fontWeight: 600,
         textAlign: "left",
         whiteSpace: "pre-wrap !important",
+        // Wrap at word boundaries; only break inside a word when it is too long to fit
+        // on a line of its own. break-all/lineBreak: anywhere split ordinary words mid-word.
         wordWrap: "break-word !important",
-        overflowWrap: "anywhere !important",
-        wordBreak: "break-all !important",
+        overflowWrap: "break-word !important",
+        wordBreak: "normal !important",
+        hyphens: "none",
         maxWidth: "100% !important",
         width: "100% !important",
         display: "block !important",
         overflow: "hidden !important",
-        // Additional CSS to ensure wrapping works
-        hyphens: "auto",
-        lineBreak: "anywhere",
       }}
     >
       {renderFieldValue(fieldPath, value)}

--- a/my-app/src/pages/Profile/components/MiscellaneousForm.tsx
+++ b/my-app/src/pages/Profile/components/MiscellaneousForm.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Box, Typography } from "@mui/material";
 import { ClientProfileKey, InputType } from "../types";
 import { deliveryDate } from "../../../utils/deliveryDate";
+import { formatLastEditedTimestamp } from "../../../utils/dates";
 
 interface ConfigField {
   id: string;
@@ -49,6 +50,13 @@ const MiscellaneousForm: React.FC<MiscellaneousFormProps> = ({
   const tefapCertDisplay = clientProfile.tefapCertDate
     ? deliveryDate.toDisplayString(clientProfile.tefapCertDate)
     : "N/A";
+
+  const lifeChallengesLastEdited = formatLastEditedTimestamp(
+    clientProfile.lifeChallengesTimestamp?.timestamp
+  );
+  const lifestyleGoalsLastEdited = formatLastEditedTimestamp(
+    clientProfile.lifestyleGoalsTimestamp?.timestamp
+  );
 
   return (
     <Box sx={{ width: "100%" }}>
@@ -144,21 +152,11 @@ const MiscellaneousForm: React.FC<MiscellaneousFormProps> = ({
               <Box sx={{ minHeight: 120, width: "100%" }}>
                 {renderField("lifeChallenges", "textarea")}
               </Box>
-              {clientProfile.lifeChallenges && clientProfile.lifeChallenges?.trim() !== "" && (
-                <span id="timestamp">
-                  Last edited:{" "}
-                  {clientProfile.lifeChallengesTimestamp &&
-                    clientProfile.lifeChallengesTimestamp.timestamp &&
-                    new Date(
-                      typeof clientProfile.lifeChallengesTimestamp.timestamp === "object" &&
-                      clientProfile.lifeChallengesTimestamp.timestamp !== null &&
-                      "toDate" in clientProfile.lifeChallengesTimestamp.timestamp &&
-                      typeof clientProfile.lifeChallengesTimestamp.timestamp.toDate === "function"
-                        ? clientProfile.lifeChallengesTimestamp.timestamp.toDate()
-                        : clientProfile.lifeChallengesTimestamp.timestamp
-                    ).toLocaleString()}
-                </span>
-              )}
+              {clientProfile.lifeChallenges &&
+                clientProfile.lifeChallenges?.trim() !== "" &&
+                lifeChallengesLastEdited && (
+                  <span id="timestamp">Last edited: {lifeChallengesLastEdited}</span>
+                )}
             </>
           ) : (
             <Typography data-testid="life-challenges-text" sx={narrativeTextSx}>
@@ -184,21 +182,11 @@ const MiscellaneousForm: React.FC<MiscellaneousFormProps> = ({
               <Box sx={{ minHeight: 120, width: "100%" }}>
                 {renderField("lifestyleGoals", "textarea")}
               </Box>
-              {clientProfile.lifestyleGoals && clientProfile.lifestyleGoals?.trim() !== "" && (
-                <span id="timestamp">
-                  Last edited:{" "}
-                  {clientProfile.lifestyleGoalsTimestamp &&
-                    clientProfile.lifestyleGoalsTimestamp.timestamp &&
-                    new Date(
-                      typeof clientProfile.lifestyleGoalsTimestamp.timestamp === "object" &&
-                      clientProfile.lifestyleGoalsTimestamp.timestamp !== null &&
-                      "toDate" in clientProfile.lifestyleGoalsTimestamp.timestamp &&
-                      typeof clientProfile.lifestyleGoalsTimestamp.timestamp.toDate === "function"
-                        ? clientProfile.lifestyleGoalsTimestamp.timestamp.toDate()
-                        : clientProfile.lifestyleGoalsTimestamp.timestamp
-                    ).toLocaleString()}
-                </span>
-              )}
+              {clientProfile.lifestyleGoals &&
+                clientProfile.lifestyleGoals?.trim() !== "" &&
+                lifestyleGoalsLastEdited && (
+                  <span id="timestamp">Last edited: {lifestyleGoalsLastEdited}</span>
+                )}
             </>
           ) : (
             <Typography data-testid="lifestyle-goals-text" sx={narrativeTextSx}>

--- a/my-app/src/services/client-service.ts
+++ b/my-app/src/services/client-service.ts
@@ -7,6 +7,7 @@ import { retry } from "../utils/retry";
 import { ServiceError, formatServiceError } from "../utils/serviceError";
 import { computeClientActiveStatus } from "../utils/clientStatus";
 import { deliveryDate } from "../utils/deliveryDate";
+import { toDateOrNull } from "../utils/dates";
 import {
   batchGetClientDeliverySummaries,
   type ClientDeliverySummary,
@@ -29,25 +30,8 @@ import {
 import { validateClientProfile } from "../utils/firestoreValidation";
 import dataSources from "../config/dataSources";
 
-const normalizeFirestoreDateValue = (value: unknown): unknown => {
-  if (value && typeof value === "object" && "toDate" in value) {
-    const maybeToDate = (value as { toDate?: unknown }).toDate;
-    if (typeof maybeToDate === "function") {
-      return (maybeToDate as () => Date)();
-    }
-  }
-
-  if (
-    value &&
-    typeof value === "object" &&
-    "seconds" in value &&
-    typeof (value as { seconds?: unknown }).seconds === "number"
-  ) {
-    return new Date((value as { seconds: number }).seconds * 1000);
-  }
-
-  return value;
-};
+const normalizeFirestoreDateValue = (value: unknown): unknown =>
+  value && typeof value === "object" ? toDateOrNull(value) : value;
 
 const normalizeDateStringField = (value: unknown): string => {
   const normalizedValue = normalizeFirestoreDateValue(value);

--- a/my-app/src/tests/utils/dates.test.ts
+++ b/my-app/src/tests/utils/dates.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest } from "@jest/globals";
-import { validateDateInput } from "../../utils/dates";
+import { formatLastEditedTimestamp, validateDateInput } from "../../utils/dates";
 
 describe("validateDateInput", () => {
   // App coverage:
@@ -60,5 +60,47 @@ describe("validateDateInput", () => {
     expect(result).toEqual({ isValid: false, errorMessage: "Year must be between 2000 and 2030" });
     expect(onValid).not.toHaveBeenCalled();
     expect(onError).toHaveBeenCalledWith("Year must be between 2000 and 2030");
+  });
+});
+
+describe("formatLastEditedTimestamp", () => {
+  // App coverage:
+  // - profile "Last edited" labels read timestamps that Firestore returns as Timestamp instances
+  // Behavior contract: a Firestore-style Timestamp is converted through toDate() and formatted.
+  it("formats a Firestore Timestamp via toDate()", () => {
+    const date = new Date("2026-03-15T12:00:00Z");
+    const timestamp = { seconds: Math.floor(date.getTime() / 1000), nanoseconds: 0, toDate: () => date };
+
+    expect(formatLastEditedTimestamp(timestamp)).toBe(date.toLocaleString());
+  });
+
+  // App coverage:
+  // - entering and cancelling profile edit mode deep-copies the profile, which can strip a
+  //   Timestamp's prototype and leave a bare { seconds, nanoseconds } map
+  // Behavior contract: a prototype-less timestamp map still formats instead of showing "Invalid date".
+  it("formats a prototype-less { seconds, nanoseconds } map", () => {
+    const date = new Date("2026-03-15T12:00:00Z");
+    const stripped = { seconds: Math.floor(date.getTime() / 1000), nanoseconds: 0 };
+
+    expect(formatLastEditedTimestamp(stripped)).toBe(date.toLocaleString());
+  });
+
+  // App coverage:
+  // - profiles saved in the current session hold plain JS Dates before any Firestore round-trip
+  // Behavior contract: a JS Date formats directly.
+  it("formats a plain JS Date", () => {
+    const date = new Date("2026-03-15T12:00:00Z");
+
+    expect(formatLastEditedTimestamp(date)).toBe(date.toLocaleString());
+  });
+
+  // App coverage:
+  // - clients that never had notes carry a null/absent timestamp
+  // Behavior contract: uninterpretable values yield an empty string so no label is rendered.
+  it("returns an empty string for missing or unusable values", () => {
+    expect(formatLastEditedTimestamp(null)).toBe("");
+    expect(formatLastEditedTimestamp(undefined)).toBe("");
+    expect(formatLastEditedTimestamp({})).toBe("");
+    expect(formatLastEditedTimestamp("not a date")).toBe("");
   });
 });

--- a/my-app/src/utils/dates.ts
+++ b/my-app/src/utils/dates.ts
@@ -36,6 +36,45 @@ export const formatDate = (date: Date | string): string => {
   }
 };
 
+const resolveDate = (value: unknown): unknown => {
+  if (value instanceof Date) return value;
+
+  if (value && typeof value === "object") {
+    const { toDate, seconds, nanoseconds } = value as {
+      toDate?: unknown;
+      seconds?: unknown;
+      nanoseconds?: unknown;
+    };
+    if (typeof toDate === "function") return (toDate as () => unknown).call(value);
+    if (typeof seconds !== "number") return null;
+    return new Date(seconds * 1000 + (typeof nanoseconds === "number" ? nanoseconds / 1e6 : 0));
+  }
+
+  return typeof value === "string" || typeof value === "number" ? new Date(value) : null;
+};
+
+/**
+ * Coerce any stored timestamp value into a JS Date.
+ * Handles Firestore Timestamps, the plain `{ seconds, nanoseconds }` maps left behind
+ * when a Timestamp is structurally copied, Dates, ISO strings and epoch millis.
+ * @param value The stored timestamp value
+ * @returns A valid Date, or null when the value cannot be interpreted as one
+ */
+export const toDateOrNull = (value: unknown): Date | null => {
+  const resolved = resolveDate(value);
+  return resolved instanceof Date && !Number.isNaN(resolved.getTime()) ? resolved : null;
+};
+
+/**
+ * Format a stored "last edited" timestamp for display.
+ * @param value The stored timestamp value
+ * @returns The localized date/time string, or an empty string when it cannot be interpreted
+ */
+export const formatLastEditedTimestamp = (value: unknown): string => {
+  const date = toDateOrNull(value);
+  return date ? date.toLocaleString() : "";
+};
+
 /**
  * Format a date to MM/DD/YYYY
  * @param date The date to format


### PR DESCRIPTION
2 issues fixed:
- Admin Notes broke mid-word: the fix for this was telling it not to break mid-word except for absurdly long words
- There were "invalid dates": deepcopy did not handle the Firestore timestamps correctly and stripped the toDate method. It now does not do that, and there is a new function to make sure they are handled correctly, and previously corrupted dates render correctly


- Added some tests to make sure this doesn't happen again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent localized “last edited” timestamps for delivery instructions, notes, life challenges, and lifestyle goals.
  * Timestamps now display reliably from dates, saved timestamp values, ISO strings, and epoch values.

* **Bug Fixes**
  * Improved handling of missing or invalid timestamps by preventing incorrect displays.
  * Preserved timestamp information during profile data processing.

* **Style**
  * Improved form text wrapping to keep words intact where possible and avoid unnecessary hyphenation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->