### PR TITLE
tags bug

### DIFF
--- a/my-app/src/pages/Profile/Tags/TagManager.test.tsx
+++ b/my-app/src/pages/Profile/Tags/TagManager.test.tsx
@@ -6,7 +6,7 @@ const mockSetDoc = jest.fn();
 const mockBatchSet = jest.fn();
 const mockBatchUpdate = jest.fn();
 const mockBatchCommit = jest.fn();
-const mockTagColors = { Delivery: "#257e68" };
+let mockTagColors = { Delivery: "#257e68" };
 const mockTagColorPalette = [
   "#257e68",
   "#1976d2",
@@ -54,6 +54,7 @@ jest.mock("../../../context/ClientDataContext", () => ({
 
 describe("TagManager", () => {
   beforeEach(() => {
+    mockTagColors = { Delivery: "#257e68" };
     mockSetDoc.mockReset();
     mockSetDoc.mockResolvedValue(undefined as never);
     mockBatchSet.mockReset();
@@ -98,8 +99,6 @@ describe("TagManager", () => {
     expect(mockBatchSet).toHaveBeenLastCalledWith(
       { id: "tags-document" },
       {
-        tags: ["Delivery"],
-        tagColors: { Delivery: "#257e68" },
         tagColorPalette: [
           "#257e68",
           "#222222",
@@ -114,6 +113,104 @@ describe("TagManager", () => {
       { merge: true }
     );
     expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+  });
+
+  it("requires a palette slot before customizing an existing tag outside the palette", async () => {
+    mockTagColors = { Delivery: "#abcdef" };
+    const handleTag = jest.fn((_tag: string, _options?: { persist?: boolean }) => undefined);
+
+    render(
+      <TagManager
+        allTags={["Delivery"]}
+        values={[]}
+        handleTag={handleTag}
+        setInnerPopup={jest.fn()}
+        deleteMode={false}
+        setTagToDelete={jest.fn()}
+        clientUid="client-1"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit tags" }));
+    fireEvent.change(screen.getByLabelText("Select tag or type new tag"), {
+      target: { value: "Delivery" },
+    });
+    fireEvent.keyDown(screen.getByLabelText("Select tag or type new tag"), { key: "Enter" });
+
+    const customColorInput = screen.getByLabelText("Custom tag color") as HTMLInputElement;
+    expect(customColorInput.disabled).toBe(true);
+    expect(
+      screen.getByText("Select a predefined color before choosing a custom palette color.")
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Select palette color 2" }));
+    expect(customColorInput.disabled).toBe(false);
+    fireEvent.change(customColorInput, { target: { value: "#333333" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add Tag" }));
+
+    await waitFor(() => expect(handleTag).toHaveBeenCalledWith("Delivery", { persist: false }));
+    expect(mockBatchSet).toHaveBeenLastCalledWith(
+      { id: "tags-document" },
+      {
+        tagColorPalette: [
+          "#257e68",
+          "#333333",
+          "#7b1fa2",
+          "#c2185b",
+          "#d84315",
+          "#f9a825",
+          "#546e7a",
+          "#5d4037",
+        ],
+      },
+      { merge: true }
+    );
+  });
+
+  it("persists only palette changes for an existing tag without a client", async () => {
+    const handleTag = jest.fn((_tag: string, _options?: { persist?: boolean }) => undefined);
+
+    render(
+      <TagManager
+        allTags={["Delivery"]}
+        values={[]}
+        handleTag={handleTag}
+        setInnerPopup={jest.fn()}
+        deleteMode={false}
+        setTagToDelete={jest.fn()}
+        clientUid=""
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit tags" }));
+    fireEvent.change(screen.getByLabelText("Select tag or type new tag"), {
+      target: { value: "Delivery" },
+    });
+    fireEvent.keyDown(screen.getByLabelText("Select tag or type new tag"), { key: "Enter" });
+    fireEvent.click(screen.getByRole("button", { name: "Select palette color 2" }));
+    fireEvent.change(screen.getByLabelText("Custom tag color"), {
+      target: { value: "#444444" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add Tag" }));
+
+    await waitFor(() => expect(handleTag).toHaveBeenCalledWith("Delivery"));
+    expect(mockSetDoc).toHaveBeenCalledWith(
+      { id: "tags-document" },
+      {
+        tagColorPalette: [
+          "#257e68",
+          "#444444",
+          "#7b1fa2",
+          "#c2185b",
+          "#d84315",
+          "#f9a825",
+          "#546e7a",
+          "#5d4037",
+        ],
+      },
+      { merge: true }
+    );
+    expect(mockBatchCommit).not.toHaveBeenCalled();
   });
 
   it("saves every predefined color change when adding a new tag", async () => {

--- a/my-app/src/pages/Profile/Tags/TagManager.test.tsx
+++ b/my-app/src/pages/Profile/Tags/TagManager.test.tsx
@@ -62,7 +62,7 @@ describe("TagManager", () => {
     mockBatchCommit.mockResolvedValue(undefined as never);
   });
 
-  it("uses the saved spelling and skips metadata writes for an existing tag", async () => {
+  it("uses the saved spelling and persists palette edits for an existing tag", async () => {
     const handleTag = jest.fn((_tag: string, _options?: { persist?: boolean }) => undefined);
 
     render(
@@ -82,11 +82,38 @@ describe("TagManager", () => {
       target: { value: "delivery" },
     });
     fireEvent.keyDown(screen.getByLabelText("Select tag or type new tag"), { key: "Enter" });
+    fireEvent.click(screen.getByRole("button", { name: "Select palette color 2" }));
+    fireEvent.change(screen.getByLabelText("Custom tag color"), {
+      target: { value: "#222222" },
+    });
+    expect(screen.getByText("delivery").getAttribute("class")).toContain("MuiChip-label");
+    expect(
+      getComputedStyle(screen.getByText("delivery").closest(".MuiChip-root") as HTMLElement)
+        .backgroundColor
+    ).toBe("rgb(34, 34, 34)");
     fireEvent.click(screen.getByRole("button", { name: "Add Tag" }));
 
-    await waitFor(() => expect(handleTag).toHaveBeenCalledWith("Delivery"));
+    await waitFor(() => expect(handleTag).toHaveBeenCalledWith("Delivery", { persist: false }));
     expect(mockSetDoc).not.toHaveBeenCalled();
-    expect(mockBatchCommit).not.toHaveBeenCalled();
+    expect(mockBatchSet).toHaveBeenLastCalledWith(
+      { id: "tags-document" },
+      {
+        tags: ["Delivery"],
+        tagColors: { Delivery: "#257e68" },
+        tagColorPalette: [
+          "#257e68",
+          "#222222",
+          "#7b1fa2",
+          "#c2185b",
+          "#d84315",
+          "#f9a825",
+          "#546e7a",
+          "#5d4037",
+        ],
+      },
+      { merge: true }
+    );
+    expect(mockBatchCommit).toHaveBeenCalledTimes(1);
   });
 
   it("saves every predefined color change when adding a new tag", async () => {

--- a/my-app/src/pages/Profile/Tags/TagManager.tsx
+++ b/my-app/src/pages/Profile/Tags/TagManager.tsx
@@ -357,7 +357,7 @@ export default function TagManager({
 
       let didUpdateClient: boolean | void;
       try {
-        if (clientUid && !existingTag) {
+        if (clientUid) {
           await assignTagToClient({
             db,
             clientUid,
@@ -368,19 +368,15 @@ export default function TagManager({
             auditMetadata: getAuditMetadata(),
           });
           didUpdateClient = await handleTag(newTagId, { persist: false });
-        } else if (clientUid) {
-          didUpdateClient = await handleTag(newTagId);
         } else {
-          if (!existingTag) {
-            await setDoc(
-              doc(db, dataSources.firebase.tagsCollection, dataSources.firebase.tagsDocId),
-              {
-                ...updatedMetadata,
-                tagColorPalette: colorPalette,
-              },
-              { merge: true }
-            );
-          }
+          await setDoc(
+            doc(db, dataSources.firebase.tagsCollection, dataSources.firebase.tagsDocId),
+            {
+              ...updatedMetadata,
+              tagColorPalette: colorPalette,
+            },
+            { merge: true }
+          );
           didUpdateClient = await handleTag(newTagId);
         }
         setMasterTags(updatedMetadata.tags);
@@ -709,7 +705,6 @@ export default function TagManager({
                       key={index}
                       aria-label={`Select palette color ${index + 1}`}
                       aria-pressed={selectedPaletteIndex === index}
-                      disabled={Boolean(selectedExistingTag)}
                       onClick={() => {
                         setSelectedPaletteIndex(index);
                         setSelectedColor(color);
@@ -734,7 +729,6 @@ export default function TagManager({
                     type="color"
                     aria-label="Custom tag color"
                     value={selectedColor}
-                    disabled={Boolean(selectedExistingTag)}
                     onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                       const color = event.target.value;
                       setSelectedColor(color);

--- a/my-app/src/pages/Profile/Tags/TagManager.tsx
+++ b/my-app/src/pages/Profile/Tags/TagManager.tsx
@@ -353,6 +353,7 @@ export default function TagManager({
       const updatedMetadata = existingTag
         ? { tags: masterTags, tagColors }
         : addTagMetadata(masterTags, tagColors, newTagId, selectedColor);
+      const metadataToPersist = existingTag ? undefined : updatedMetadata;
       setAddError("");
 
       let didUpdateClient: boolean | void;
@@ -363,7 +364,7 @@ export default function TagManager({
             clientUid,
             clientTags: values,
             tag: newTagId,
-            metadata: updatedMetadata,
+            metadata: metadataToPersist,
             tagColorPalette: colorPalette,
             auditMetadata: getAuditMetadata(),
           });
@@ -371,10 +372,9 @@ export default function TagManager({
         } else {
           await setDoc(
             doc(db, dataSources.firebase.tagsCollection, dataSources.firebase.tagsDocId),
-            {
-              ...updatedMetadata,
-              tagColorPalette: colorPalette,
-            },
+            metadataToPersist
+              ? { ...metadataToPersist, tagColorPalette: colorPalette }
+              : { tagColorPalette: colorPalette },
             { merge: true }
           );
           didUpdateClient = await handleTag(newTagId);
@@ -729,6 +729,7 @@ export default function TagManager({
                     type="color"
                     aria-label="Custom tag color"
                     value={selectedColor}
+                    disabled={selectedPaletteIndex === null}
                     onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                       const color = event.target.value;
                       setSelectedColor(color);
@@ -747,6 +748,11 @@ export default function TagManager({
                       cursor: "pointer",
                     }}
                   />
+                  {selectedPaletteIndex === null && (
+                    <Typography variant="caption" sx={{ width: "100%" }}>
+                      Select a predefined color before choosing a custom palette color.
+                    </Typography>
+                  )}
                 </Box>
               </Box>
               {selectedTag?.trim() && (

--- a/my-app/src/pages/Profile/Tags/tagPersistence.test.ts
+++ b/my-app/src/pages/Profile/Tags/tagPersistence.test.ts
@@ -179,6 +179,25 @@ describe("tag assignment and deletion", () => {
     expect(mockBatchCommit).toHaveBeenCalledTimes(1);
   });
 
+  it("updates only the palette when assigning an existing tag", async () => {
+    await assignTagToClient({
+      db: {} as never,
+      clientUid: "client-1",
+      clientTags: [],
+      tag: "Delivery",
+      tagColorPalette: ["#111111", "#222222"],
+      auditMetadata: buildOptions().auditMetadata,
+    });
+
+    expect(mockBatchSet).toHaveBeenNthCalledWith(
+      2,
+      { collectionName: "tags", id: "oGuiR2dQQeOBXHCkhDeX" },
+      { tagColorPalette: ["#111111", "#222222"] },
+      { merge: true }
+    );
+    expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+  });
+
   it("deletes a tag from clients and master metadata in one batch", async () => {
     const clientRef = { id: "client-1" };
     mockGetDocs.mockResolvedValue({

--- a/my-app/src/pages/Profile/Tags/tagPersistence.ts
+++ b/my-app/src/pages/Profile/Tags/tagPersistence.ts
@@ -42,7 +42,7 @@ interface AssignTagToClientOptions {
   clientUid: string;
   clientTags: string[];
   tag: string;
-  metadata: TagMetadata;
+  metadata?: TagMetadata;
   tagColorPalette: string[];
   auditMetadata: ClientAuditWriteMetadata;
 }
@@ -67,7 +67,7 @@ export const assignTagToClient = async ({
   );
   batch.set(
     doc(db, dataSources.firebase.tagsCollection, dataSources.firebase.tagsDocId),
-    { ...metadata, tagColorPalette },
+    metadata ? { ...metadata, tagColorPalette } : { tagColorPalette },
     { merge: true }
   );
   await batch.commit();


### PR DESCRIPTION
- Enabled predefined palette controls when selecting an existing tag from the dropdown.
- Enabled the custom color picker for existing dropdown tags.
- Updated the tag preview immediately when a predefined or custom color changes.
- Saved all edited predefined palette colors when adding an existing tag.
- Preserved the existing tag’s globally assigned color unless it is changed through Edit Tag.
- Added regression tests for palette editing, preview updates, and color persistence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Existing tags can now be customized with palette and color controls when adding or editing tags.
  * Tag color changes are saved and remain visible on the tag chip.
  * Tags associated with a client are handled consistently during tag assignment.

* **Bug Fixes**
  * Fixed tag updates so customized colors and saved tag names are preserved reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->