### PR TITLE
Adding scroll functionality

### DIFF
--- a/my-app/src/pages/Profile/components/FormField.tsx
+++ b/my-app/src/pages/Profile/components/FormField.tsx
@@ -53,6 +53,8 @@ const fieldStyles = {
   marginTop: "0px",
 };
 
+const TEXTAREA_DISPLAY_MAX_HEIGHT = "120px";
+
 const CustomTextField = styled(TextField)({
   "& .MuiOutlinedInput-root": {
     "& fieldset": {
@@ -812,6 +814,8 @@ const FormField = (props: FormFieldProps) => {
     }
   }
 
+  const isMultilineDisplay = type === "textarea";
+
   return (
     <Typography
       variant="body1"
@@ -829,6 +833,12 @@ const FormField = (props: FormFieldProps) => {
         width: "100% !important",
         display: "block !important",
         overflow: "hidden !important",
+        ...(isMultilineDisplay && {
+          maxHeight: TEXTAREA_DISPLAY_MAX_HEIGHT,
+          overflowY: "auto !important",
+          // Keep text clear of the scrollbar once the content overflows.
+          paddingRight: "8px",
+        }),
       }}
     >
       {renderFieldValue(fieldPath, value)}

--- a/my-app/src/pages/Profile/components/FormField.tsx
+++ b/my-app/src/pages/Profile/components/FormField.tsx
@@ -55,6 +55,16 @@ const fieldStyles = {
 
 const TEXTAREA_DISPLAY_MAX_HEIGHT = "120px";
 
+const getDisplayFieldLabel = (fieldPath: ClientProfileKey): string => {
+  if (fieldPath === "notes") return "Admin Notes";
+
+  const fieldName = String(fieldPath).split(".").pop() || String(fieldPath);
+  return fieldName
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/([A-Za-z])(\d+)/g, "$1 $2")
+    .replace(/^./, (character) => character.toUpperCase());
+};
+
 const CustomTextField = styled(TextField)({
   "& .MuiOutlinedInput-root": {
     "& fieldset": {
@@ -819,6 +829,9 @@ const FormField = (props: FormFieldProps) => {
   return (
     <Typography
       variant="body1"
+      tabIndex={isMultilineDisplay ? 0 : undefined}
+      role={isMultilineDisplay ? "region" : undefined}
+      aria-label={isMultilineDisplay ? getDisplayFieldLabel(fieldPath) : undefined}
       sx={{
         fontWeight: 600,
         textAlign: "left",
@@ -838,6 +851,11 @@ const FormField = (props: FormFieldProps) => {
           overflowY: "auto !important",
           // Keep text clear of the scrollbar once the content overflows.
           paddingRight: "8px",
+          "&:focus-visible": {
+            outline: "2px solid var(--color-primary)",
+            outlineOffset: "2px",
+            borderRadius: "2px",
+          },
         }),
       }}
     >

--- a/my-app/src/tests/pages/Profile/FormField.test.tsx
+++ b/my-app/src/tests/pages/Profile/FormField.test.tsx
@@ -60,4 +60,39 @@ describe("FormField view mode value rendering", () => {
 
     expect(container.textContent).toBe("202-555-0100");
   });
+
+  it.each([
+    ["notes", "Admin Notes"],
+    ["deliveryDetails.deliveryInstructions", "Delivery Instructions"],
+    ["address2", "Address 2"],
+    ["ward", "Ward"],
+  ])("makes the read-only %s field keyboard-accessible", (fieldPath, accessibleName) => {
+    renderViewMode(fieldPath, "Long field value ".repeat(50), "textarea");
+
+    const multilineRegion = screen.getByRole("region", { name: accessibleName });
+    expect(multilineRegion.getAttribute("tabindex")).toBe("0");
+
+    multilineRegion.focus();
+    expect(document.activeElement).toBe(multilineRegion);
+  });
+
+  it("preserves the PR's multiline height and scrolling behavior", () => {
+    renderViewMode("notes", "Long admin notes ".repeat(50), "textarea");
+
+    const notesRegion = screen.getByRole("region", { name: "Admin Notes" });
+    const styles = getComputedStyle(notesRegion);
+
+    expect(styles.maxHeight).toBe("120px");
+    expect(styles.overflowY).toBe("auto");
+    expect(styles.paddingRight).toBe("8px");
+  });
+
+  it("does not add a keyboard stop to a regular read-only field", () => {
+    const { container } = renderViewMode("phone", "202-555-0100", "text");
+    const phoneDisplay = container.firstElementChild;
+
+    expect(phoneDisplay?.getAttribute("tabindex")).toBeNull();
+    expect(phoneDisplay?.getAttribute("role")).toBeNull();
+    expect(phoneDisplay?.getAttribute("aria-label")).toBeNull();
+  });
 });


### PR DESCRIPTION
When admin notes are long enough, turns the text into a scrolling text display

Long enough
<img width="1210" height="432" alt="image" src="https://github.com/user-attachments/assets/f9b479ef-1cf5-4148-a83b-f660e661a0b8" />

Not long enough
<img width="1259" height="382" alt="image" src="https://github.com/user-attachments/assets/36f33676-5745-4669-9468-6e6315f97abc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved read-only text areas by limiting their height to 120px and enabling vertical scrolling for long content.
  * Added spacing to prevent text from being obscured by the scrollbar.
  * Preserved existing display behavior for other field types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->