### PR TITLE
Keep Firebase Auth and Firestore users synchronized

### DIFF
--- a/.github/workflows/firebase-cicd.yml
+++ b/.github/workflows/firebase-cicd.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Compile Python functions
         run: python -m py_compile functions-python/main.py functions-python/clustering.py
 
+      - name: Run Python unit tests
+        run: python -m unittest discover -s functions-python -p 'test_*.py'
+
       - name: Build frontend
         run: CI=false npm run build
 

--- a/my-app/functions-python/README.md
+++ b/my-app/functions-python/README.md
@@ -25,12 +25,13 @@ firebase deploy --only functions
 |----------|------|---------|
 | `geocode_addresses_endpoint` | HTTP | Convert addresses to coordinates |
 | `cluster_deliveries_k_means` | HTTP | Group delivery locations into clusters |
+| `createUserAccount` | Callable | Create a synchronized Auth + Firestore user |
 | `deleteUserAccount` | Callable | Delete user (Auth + Firestore) |
 | `updateDeliveriesDaily` | Scheduled | Daily cron: update client delivery records (runs 10:00 AM ET) |
 
 ## File Structure
 
-- `main.py` - User/delivery functions (`deleteUserAccount`, `updateDeliveriesDaily`)
+- `main.py` - User/delivery functions (`createUserAccount`, `deleteUserAccount`, `updateDeliveriesDaily`)
 - `clustering.py` - Geocoding + clustering endpoints
 
 ## Configuration

--- a/my-app/functions-python/main.py
+++ b/my-app/functions-python/main.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 import firebase_admin
 from firebase_functions import https_fn, options, scheduler_fn
@@ -13,6 +14,7 @@ from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
 CLIENTS_COLLECTION = "client-profile2"
+logger = logging.getLogger(__name__)
 
 # Initialize Firebase Admin SDK only once
 try:
@@ -173,10 +175,11 @@ def _create_user_records(db, user_data: dict, auth_client=auth) -> str:
     except Exception:
         try:
             auth_client.delete_user(created_user.uid)
-        except Exception as rollback_error:
-            print(
-                "Critical: failed to roll back Firebase Auth user "
-                f"{created_user.uid} after Firestore creation failed: {rollback_error}"
+        except Exception:
+            logger.exception(
+                "Critical: failed to roll back Firebase Auth user %s "
+                "after Firestore creation failed",
+                created_user.uid,
             )
         raise
 
@@ -211,22 +214,22 @@ def createUserAccount(req: https_fn.CallableRequest):
     try:
         uid = _create_user_records(db, user_data)
         return {"status": "success", "uid": uid}
-    except auth.EmailAlreadyExistsError:
+    except auth.EmailAlreadyExistsError as duplicate_error:
         raise https_fn.HttpsError(
             code=https_fn.FunctionsErrorCode.ALREADY_EXISTS,
             message="An account with this email already exists.",
-        )
+        ) from duplicate_error
     except ValueError as validation_error:
         raise https_fn.HttpsError(
             code=https_fn.FunctionsErrorCode.INVALID_ARGUMENT,
             message=str(validation_error),
-        )
+        ) from validation_error
     except Exception as creation_error:
-        print(f"User creation failed: {creation_error}")
+        logger.exception("User creation failed")
         raise https_fn.HttpsError(
             code=https_fn.FunctionsErrorCode.INTERNAL,
             message="An internal error occurred while creating the user.",
-        )
+        ) from creation_error
 
 
 @https_fn.on_call(
@@ -265,7 +268,7 @@ def deleteUserAccount(req: https_fn.CallableRequest):
         raise https_fn.HttpsError(
             code=https_fn.FunctionsErrorCode.INTERNAL,
             message="Unable to verify the target account.",
-        )
+        ) from user_lookup_error
 
     if not target_role:
         target_role = _role_from_users_doc(db, uid_to_delete)
@@ -288,7 +291,7 @@ def deleteUserAccount(req: https_fn.CallableRequest):
     except Exception as e:
         print(f"An unexpected error occurred during deletion of user {uid_to_delete}: {e}")
         raise https_fn.HttpsError(code=https_fn.FunctionsErrorCode.INTERNAL,
-                                    message="An internal error occurred while deleting the user.")
+                                    message="An internal error occurred while deleting the user.") from e
 
 def query_today_client_ids(tz_name: str = "America/New_York"):
     """Return clientIds for events whose deliveryDate is ‘today’ in the given timezone."""

--- a/my-app/functions-python/main.py
+++ b/my-app/functions-python/main.py
@@ -1,3 +1,5 @@
+import json
+
 import firebase_admin
 from firebase_functions import https_fn, options, scheduler_fn
 from firebase_admin import auth, firestore
@@ -99,6 +101,13 @@ def _managed_role(raw_role: Optional[str]) -> Optional[str]:
     }.get(normalized)
 
 
+def _can_create_managed_role(caller_role: str, target_role: str) -> bool:
+    """Keep server authorization aligned with the existing create-user form."""
+    return caller_role == "admin" or (
+        caller_role == "manager" and target_role != "Admin"
+    )
+
+
 def _validated_create_user_data(raw_data) -> dict:
     if not isinstance(raw_data, dict):
         raise https_fn.HttpsError(
@@ -193,10 +202,10 @@ def createUserAccount(req: https_fn.CallableRequest):
     caller_role = _require_user_manager(req, db)
     user_data = _validated_create_user_data(req.data)
 
-    if caller_role == "manager" and user_data["role"] != "Client Intake":
+    if not _can_create_managed_role(caller_role, user_data["role"]):
         raise https_fn.HttpsError(
             code=https_fn.FunctionsErrorCode.PERMISSION_DENIED,
-            message="Managers can only create Client Intake accounts.",
+            message="Managers cannot create Admin accounts.",
         )
 
     try:

--- a/my-app/functions-python/main.py
+++ b/my-app/functions-python/main.py
@@ -1,4 +1,3 @@
-import json
 import firebase_admin
 from firebase_functions import https_fn, options, scheduler_fn
 from firebase_admin import auth, firestore
@@ -20,8 +19,8 @@ except ValueError:
     # App already initialized, ignore the error
     pass
 
-# --- Define CORS options needed for deleteUserAccount ---
-_delete_user_cors = options.CorsOptions(
+# --- Define CORS options needed for user-management callables ---
+_user_management_cors = options.CorsOptions(
     cors_origins=[
         r"^http://localhost:\d+$", # Local development
         r"^http://127\.0\.0\.1:\d+$", # Local development by IP
@@ -36,7 +35,7 @@ _delete_user_cors = options.CorsOptions(
 geocode_fn = https_fn.on_request(region="us-central1", memory=512, timeout_sec=300)(geocode_addresses_endpoint)
 k_means_fn = https_fn.on_request(region="us-central1", memory=512, timeout_sec=300)(cluster_deliveries_k_means)
 
-# --- New Callable Function for User Deletion ---
+# --- Callable functions for synchronized Auth + Firestore user management ---
 def _normalize_role(raw_role: Optional[str]) -> Optional[str]:
     if not isinstance(raw_role, str):
         return None
@@ -74,22 +73,165 @@ def _effective_role(db, uid: str, claims: Optional[dict] = None) -> Optional[str
     return _role_from_users_doc(db, uid)
 
 
+def _require_user_manager(req: https_fn.CallableRequest, db) -> str:
+    if req.auth is None:
+        raise https_fn.HttpsError(
+            code=https_fn.FunctionsErrorCode.UNAUTHENTICATED,
+            message="Authentication required.",
+        )
+
+    caller_role = _effective_role(db, req.auth.uid, getattr(req.auth, "token", None))
+    if caller_role not in ("admin", "manager"):
+        raise https_fn.HttpsError(
+            code=https_fn.FunctionsErrorCode.PERMISSION_DENIED,
+            message="Only Admins or Managers can manage user accounts.",
+        )
+    return caller_role
+
+
+def _managed_role(raw_role: Optional[str]) -> Optional[str]:
+    normalized = _normalize_role(raw_role)
+    return {
+        "admin": "Admin",
+        "manager": "Manager",
+        "client intake": "Client Intake",
+        "clientintake": "Client Intake",
+    }.get(normalized)
+
+
+def _validated_create_user_data(raw_data) -> dict:
+    if not isinstance(raw_data, dict):
+        raise https_fn.HttpsError(
+            code=https_fn.FunctionsErrorCode.INVALID_ARGUMENT,
+            message="User details are required.",
+        )
+
+    name = raw_data.get("name")
+    email = raw_data.get("email")
+    password = raw_data.get("password")
+    phone = raw_data.get("phone", "")
+    role = _managed_role(raw_data.get("role"))
+
+    if not isinstance(name, str) or not name.strip():
+        raise https_fn.HttpsError(
+            code=https_fn.FunctionsErrorCode.INVALID_ARGUMENT,
+            message="A user name is required.",
+        )
+    if not isinstance(email, str) or not email.strip():
+        raise https_fn.HttpsError(
+            code=https_fn.FunctionsErrorCode.INVALID_ARGUMENT,
+            message="A user email is required.",
+        )
+    if not isinstance(password, str) or len(password) < 8:
+        raise https_fn.HttpsError(
+            code=https_fn.FunctionsErrorCode.INVALID_ARGUMENT,
+            message="Password must be at least 8 characters long.",
+        )
+    if not isinstance(phone, str):
+        raise https_fn.HttpsError(
+            code=https_fn.FunctionsErrorCode.INVALID_ARGUMENT,
+            message="Phone number must be a string.",
+        )
+    if role is None:
+        raise https_fn.HttpsError(
+            code=https_fn.FunctionsErrorCode.INVALID_ARGUMENT,
+            message="A valid user role is required.",
+        )
+
+    return {
+        "name": name.strip(),
+        "email": email.strip().lower(),
+        "password": password,
+        "phone": phone.strip(),
+        "role": role,
+    }
+
+
+def _create_user_records(db, user_data: dict, auth_client=auth) -> str:
+    created_user = auth_client.create_user(
+        email=user_data["email"],
+        password=user_data["password"],
+        display_name=user_data["name"],
+    )
+
+    try:
+        db.collection("users").document(created_user.uid).set({
+            "name": user_data["name"],
+            "email": user_data["email"],
+            "phone": user_data["phone"],
+            "role": user_data["role"],
+        })
+    except Exception:
+        try:
+            auth_client.delete_user(created_user.uid)
+        except Exception as rollback_error:
+            print(
+                "Critical: failed to roll back Firebase Auth user "
+                f"{created_user.uid} after Firestore creation failed: {rollback_error}"
+            )
+        raise
+
+    return created_user.uid
+
+
+def _delete_user_records(db, uid: str, auth_client=auth) -> dict:
+    auth_deleted = True
+    try:
+        auth_client.delete_user(uid)
+    except auth_client.UserNotFoundError:
+        auth_deleted = False
+
+    # Firestore delete is idempotent. Always attempt it after Auth is gone so a
+    # retry repairs an earlier partial deletion instead of leaving a visible row.
+    db.collection("users").document(uid).delete()
+    return {"authDeleted": auth_deleted, "firestoreDeleted": True}
+
+
+@https_fn.on_call(region="us-central1", cors=_user_management_cors)
+def createUserAccount(req: https_fn.CallableRequest):
+    db = firestore.client()
+    caller_role = _require_user_manager(req, db)
+    user_data = _validated_create_user_data(req.data)
+
+    if caller_role == "manager" and user_data["role"] != "Client Intake":
+        raise https_fn.HttpsError(
+            code=https_fn.FunctionsErrorCode.PERMISSION_DENIED,
+            message="Managers can only create Client Intake accounts.",
+        )
+
+    try:
+        uid = _create_user_records(db, user_data)
+        return {"status": "success", "uid": uid}
+    except auth.EmailAlreadyExistsError:
+        raise https_fn.HttpsError(
+            code=https_fn.FunctionsErrorCode.ALREADY_EXISTS,
+            message="An account with this email already exists.",
+        )
+    except ValueError as validation_error:
+        raise https_fn.HttpsError(
+            code=https_fn.FunctionsErrorCode.INVALID_ARGUMENT,
+            message=str(validation_error),
+        )
+    except Exception as creation_error:
+        print(f"User creation failed: {creation_error}")
+        raise https_fn.HttpsError(
+            code=https_fn.FunctionsErrorCode.INTERNAL,
+            message="An internal error occurred while creating the user.",
+        )
+
+
 @https_fn.on_call(
     region="us-central1",
-    cors=_delete_user_cors  # Apply specific CORS settings here
+    cors=_user_management_cors
 )
 def deleteUserAccount(req: https_fn.CallableRequest):
     """
     Deletes a user's Firebase Auth account and their Firestore document.
     Expects {'uid': 'user-uid-to-delete'} in the request data.
     """
-    if req.auth is None:
-        print("Authentication failed: No auth context found.")
-        raise https_fn.HttpsError(code=https_fn.FunctionsErrorCode.UNAUTHENTICATED,
-                                  message="Authentication required.")
-
-    caller_uid = req.auth.uid
     db = firestore.client()
+    caller_role = _require_user_manager(req, db)
+    caller_uid = req.auth.uid
 
     uid_to_delete = req.data.get('uid')
     if not uid_to_delete or not isinstance(uid_to_delete, str):
@@ -102,23 +244,19 @@ def deleteUserAccount(req: https_fn.CallableRequest):
         raise https_fn.HttpsError(code=https_fn.FunctionsErrorCode.PERMISSION_DENIED,
                                   message="You cannot delete your own account.")
 
-    caller_role = _effective_role(db, caller_uid, getattr(req.auth, "token", None))
-    if caller_role not in ("admin", "manager"):
-        print(f"Authorization failed: caller {caller_uid} has insufficient role ({caller_role}).")
-        raise https_fn.HttpsError(
-            code=https_fn.FunctionsErrorCode.PERMISSION_DENIED,
-            message="Only Admins or Managers can delete user accounts.",
-        )
-
     target_role = None
     try:
         target_auth_user = auth.get_user(uid_to_delete)
         target_role = _role_from_claims(target_auth_user.custom_claims)
     except auth.UserNotFoundError:
-        # Handled later by delete operation to preserve existing error flow
+        # The Firestore-only case is repaired by the idempotent delete below.
         pass
     except Exception as user_lookup_error:
-        print(f"Warning: unable to read custom claims for target user {uid_to_delete}: {user_lookup_error}")
+        print(f"Unable to inspect target user {uid_to_delete}: {user_lookup_error}")
+        raise https_fn.HttpsError(
+            code=https_fn.FunctionsErrorCode.INTERNAL,
+            message="Unable to verify the target account.",
+        )
 
     if not target_role:
         target_role = _role_from_users_doc(db, uid_to_delete)
@@ -132,24 +270,12 @@ def deleteUserAccount(req: https_fn.CallableRequest):
 
     print(f"Attempting to delete user with UID: {uid_to_delete}")
     try:
-        auth.delete_user(uid_to_delete)
-        print(f"Successfully deleted Firebase Auth user: {uid_to_delete}")
-
-        try:
-            user_doc_ref = db.collection('users').document(uid_to_delete)
-            user_doc_ref.delete()
-            print(f"Successfully deleted Firestore document for user: {uid_to_delete}")
-        except Exception as fs_error:
-            # Log Firestore deletion error but proceed as Auth deletion succeeded
-            print(f"Warning: Failed to delete Firestore document for user {uid_to_delete}: {fs_error}")
-
-        return {"status": "success", "message": f"Successfully deleted user {uid_to_delete}"}
-
-    except auth.UserNotFoundError:
-        print(f"Deletion failed: User not found in Firebase Auth: {uid_to_delete}")
-        # Treat as 'Not Found' error
-        raise https_fn.HttpsError(code=https_fn.FunctionsErrorCode.NOT_FOUND,
-                                    message=f"User with UID {uid_to_delete} not found.")
+        result = _delete_user_records(db, uid_to_delete)
+        return {
+            "status": "success",
+            "message": f"Successfully deleted user {uid_to_delete}",
+            **result,
+        }
     except Exception as e:
         print(f"An unexpected error occurred during deletion of user {uid_to_delete}: {e}")
         raise https_fn.HttpsError(code=https_fn.FunctionsErrorCode.INTERNAL,

--- a/my-app/functions-python/test_main.py
+++ b/my-app/functions-python/test_main.py
@@ -57,11 +57,51 @@ class UserSynchronizationTests(unittest.TestCase):
 
         auth_client.delete_user.assert_called_once_with("created-uid")
 
+    @patch("main.logger.exception")
+    def test_create_user_logs_failed_auth_rollback(self, log_exception):
+        auth_client = FakeAuth()
+        self.user_doc.set.side_effect = RuntimeError("Firestore unavailable")
+        auth_client.delete_user.side_effect = RuntimeError("Auth unavailable")
+
+        with self.assertRaisesRegex(RuntimeError, "Firestore unavailable"):
+            main._create_user_records(self.db, self.user_data, auth_client)
+
+        log_exception.assert_called_once()
+
     def test_create_role_policy_matches_existing_manager_form_options(self):
         self.assertTrue(main._can_create_managed_role("admin", "Admin"))
         self.assertTrue(main._can_create_managed_role("manager", "Manager"))
         self.assertTrue(main._can_create_managed_role("manager", "Client Intake"))
         self.assertFalse(main._can_create_managed_role("manager", "Admin"))
+
+    def test_user_management_rejects_unauthenticated_and_unprivileged_callers(self):
+        with self.assertRaises(main.https_fn.HttpsError) as unauthenticated:
+            main._require_user_manager(SimpleNamespace(auth=None), self.db)
+        self.assertEqual(
+            unauthenticated.exception.code,
+            main.https_fn.FunctionsErrorCode.UNAUTHENTICATED,
+        )
+
+        request = SimpleNamespace(
+            auth=SimpleNamespace(uid="client-intake-uid", token={"role": "Client Intake"})
+        )
+        with self.assertRaises(main.https_fn.HttpsError) as unprivileged:
+            main._require_user_manager(request, self.db)
+        self.assertEqual(
+            unprivileged.exception.code,
+            main.https_fn.FunctionsErrorCode.PERMISSION_DENIED,
+        )
+
+    def test_create_payload_rejects_short_password_and_unknown_role(self):
+        for override in ({"password": "short"}, {"role": "Driver"}):
+            payload = {**self.user_data, **override}
+            with self.subTest(override=override):
+                with self.assertRaises(main.https_fn.HttpsError) as invalid:
+                    main._validated_create_user_data(payload)
+                self.assertEqual(
+                    invalid.exception.code,
+                    main.https_fn.FunctionsErrorCode.INVALID_ARGUMENT,
+                )
 
     def test_delete_removes_firestore_when_auth_user_is_already_missing(self):
         auth_client = FakeAuth()

--- a/my-app/functions-python/test_main.py
+++ b/my-app/functions-python/test_main.py
@@ -1,0 +1,84 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import main
+
+
+class FakeAuth:
+    class UserNotFoundError(Exception):
+        pass
+
+    def __init__(self):
+        self.created_user = SimpleNamespace(uid="created-uid")
+        self.create_user = Mock(return_value=self.created_user)
+        self.delete_user = Mock()
+
+
+class UserSynchronizationTests(unittest.TestCase):
+    def setUp(self):
+        self.db = Mock()
+        self.user_doc = self.db.collection.return_value.document.return_value
+        self.user_data = {
+            "name": "Test User",
+            "email": "test@example.com",
+            "password": "test-password",
+            "phone": "(202) 555-0100",
+            "role": "Client Intake",
+        }
+
+    def test_create_user_writes_matching_firestore_document(self):
+        auth_client = FakeAuth()
+
+        uid = main._create_user_records(self.db, self.user_data, auth_client)
+
+        self.assertEqual(uid, "created-uid")
+        auth_client.create_user.assert_called_once_with(
+            email="test@example.com",
+            password="test-password",
+            display_name="Test User",
+        )
+        self.db.collection.assert_called_with("users")
+        self.db.collection.return_value.document.assert_called_with("created-uid")
+        self.user_doc.set.assert_called_once_with({
+            "name": "Test User",
+            "email": "test@example.com",
+            "phone": "(202) 555-0100",
+            "role": "Client Intake",
+        })
+        auth_client.delete_user.assert_not_called()
+
+    def test_create_user_rolls_back_auth_when_firestore_write_fails(self):
+        auth_client = FakeAuth()
+        self.user_doc.set.side_effect = RuntimeError("Firestore unavailable")
+
+        with self.assertRaisesRegex(RuntimeError, "Firestore unavailable"):
+            main._create_user_records(self.db, self.user_data, auth_client)
+
+        auth_client.delete_user.assert_called_once_with("created-uid")
+
+    def test_delete_removes_firestore_when_auth_user_is_already_missing(self):
+        auth_client = FakeAuth()
+        auth_client.delete_user.side_effect = auth_client.UserNotFoundError()
+
+        result = main._delete_user_records(self.db, "stale-uid", auth_client)
+
+        self.assertEqual(result, {"authDeleted": False, "firestoreDeleted": True})
+        self.user_doc.delete.assert_called_once_with()
+
+    def test_delete_retry_converges_after_firestore_failure(self):
+        auth_client = FakeAuth()
+        self.user_doc.delete.side_effect = [RuntimeError("Firestore unavailable"), None]
+
+        with self.assertRaisesRegex(RuntimeError, "Firestore unavailable"):
+            main._delete_user_records(self.db, "partial-uid", auth_client)
+
+        auth_client.delete_user.side_effect = auth_client.UserNotFoundError()
+        result = main._delete_user_records(self.db, "partial-uid", auth_client)
+
+        self.assertEqual(result, {"authDeleted": False, "firestoreDeleted": True})
+        self.assertEqual(self.user_doc.delete.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/my-app/functions-python/test_main.py
+++ b/my-app/functions-python/test_main.py
@@ -1,6 +1,6 @@
 import unittest
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import main
 
@@ -57,6 +57,12 @@ class UserSynchronizationTests(unittest.TestCase):
 
         auth_client.delete_user.assert_called_once_with("created-uid")
 
+    def test_create_role_policy_matches_existing_manager_form_options(self):
+        self.assertTrue(main._can_create_managed_role("admin", "Admin"))
+        self.assertTrue(main._can_create_managed_role("manager", "Manager"))
+        self.assertTrue(main._can_create_managed_role("manager", "Client Intake"))
+        self.assertFalse(main._can_create_managed_role("manager", "Admin"))
+
     def test_delete_removes_firestore_when_auth_user_is_already_missing(self):
         auth_client = FakeAuth()
         auth_client.delete_user.side_effect = auth_client.UserNotFoundError()
@@ -78,6 +84,17 @@ class UserSynchronizationTests(unittest.TestCase):
 
         self.assertEqual(result, {"authDeleted": False, "firestoreDeleted": True})
         self.assertEqual(self.user_doc.delete.call_count, 2)
+
+    @patch("main.query_today_client_ids")
+    @patch("main.firestore.client")
+    def test_run_update_still_serializes_its_summary(self, firestore_client, query_today):
+        query_today.return_value = {"client_ids": []}
+
+        result = main.run_update()
+
+        self.assertEqual(result["total_clients"], 0)
+        self.assertEqual(result["updated_count"], 0)
+        firestore_client.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/my-app/src/services/AuthUserService.test.ts
+++ b/my-app/src/services/AuthUserService.test.ts
@@ -87,6 +87,27 @@ describe("AuthUserService synchronized user mutations", () => {
     expect(mockCallable).toHaveBeenCalledTimes(1);
   });
 
+  it("preserves the existing weak-password message", async () => {
+    mockCallable.mockRejectedValue({
+      code: "auth/weak-password",
+      message: "weak password",
+    });
+
+    await expect(
+      authUserService.createUser(
+        {
+          name: "Test User",
+          email: "test@example.com",
+          role: UserType.ClientIntake,
+        },
+        "weak"
+      )
+    ).rejects.toMatchObject({
+      message: "Password is too weak. Please choose a stronger password.",
+      code: "auth/weak-password",
+    });
+  });
+
   it("uses the idempotent deletion callable once per user action", async () => {
     mockCallable.mockResolvedValue({ data: { status: "success" } });
 

--- a/my-app/src/services/AuthUserService.test.ts
+++ b/my-app/src/services/AuthUserService.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { UserType } from "../types";
+import { authUserService } from "./AuthUserService";
+
+const mockCallable = jest.fn<
+  Promise<{ data: Record<string, unknown> }>,
+  [Record<string, unknown>]
+>();
+const mockHttpsCallable = jest.fn<
+  typeof mockCallable,
+  [unknown, "createUserAccount" | "deleteUserAccount"]
+>(() => mockCallable);
+
+jest.mock("firebase/functions", () => ({
+  httpsCallable: (...args: [unknown, "createUserAccount" | "deleteUserAccount"]) =>
+    mockHttpsCallable(...args),
+}));
+
+jest.mock("firebase/firestore", () => ({
+  collection: () => ({}),
+  getDocs: () => Promise.resolve({ forEach: () => undefined }),
+  doc: () => ({}),
+  setDoc: () => Promise.resolve(),
+  onSnapshot: () => () => undefined,
+  writeBatch: () => ({
+    set: () => undefined,
+    commit: () => Promise.resolve(),
+  }),
+}));
+
+jest.mock("../auth/firebaseConfig", () => ({
+  db: {},
+  functions: {},
+}));
+
+describe("AuthUserService synchronized user mutations", () => {
+  beforeEach(() => {
+    mockCallable.mockReset();
+    mockHttpsCallable.mockReset();
+    mockHttpsCallable.mockImplementation(() => mockCallable);
+  });
+
+  it("creates users through the server callable without changing client auth state", async () => {
+    mockCallable.mockResolvedValue({ data: { uid: "new-user-uid" } });
+
+    const uid = await authUserService.createUser(
+      {
+        name: " Test User ",
+        email: " TEST@example.com ",
+        phone: "202-555-0100",
+        role: UserType.ClientIntake,
+      },
+      "test-password"
+    );
+
+    expect(uid).toBe("new-user-uid");
+    expect(mockHttpsCallable).toHaveBeenCalledWith(expect.anything(), "createUserAccount");
+    expect(mockCallable).toHaveBeenCalledTimes(1);
+    expect(mockCallable).toHaveBeenCalledWith({
+      name: "Test User",
+      email: "TEST@example.com",
+      phone: "(202) 555-0100",
+      role: "Client Intake",
+      password: "test-password",
+    });
+  });
+
+  it("preserves the email-in-use message returned by the callable", async () => {
+    mockCallable.mockRejectedValue({
+      code: "functions/already-exists",
+      message: "already exists",
+    });
+
+    await expect(
+      authUserService.createUser(
+        {
+          name: "Test User",
+          email: "test@example.com",
+          role: UserType.ClientIntake,
+        },
+        "test-password"
+      )
+    ).rejects.toMatchObject({
+      message: "Email already in use. Please use a different email.",
+      code: "functions/already-exists",
+    });
+    expect(mockCallable).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the idempotent deletion callable once per user action", async () => {
+    mockCallable.mockResolvedValue({ data: { status: "success" } });
+
+    await authUserService.deleteUser("deleted-user-uid");
+
+    expect(mockHttpsCallable).toHaveBeenCalledWith(expect.anything(), "deleteUserAccount");
+    expect(mockCallable).toHaveBeenCalledTimes(1);
+    expect(mockCallable).toHaveBeenCalledWith({ uid: "deleted-user-uid" });
+  });
+});

--- a/my-app/src/services/AuthUserService.test.ts
+++ b/my-app/src/services/AuthUserService.test.ts
@@ -108,6 +108,45 @@ describe("AuthUserService synchronized user mutations", () => {
     });
   });
 
+  it("surfaces safe validation messages returned by the callable", async () => {
+    mockCallable.mockRejectedValue({
+      code: "functions/invalid-argument",
+      message: "Password must be at least 8 characters long.",
+    });
+
+    await expect(
+      authUserService.createUser(
+        {
+          name: "Test User",
+          email: "test@example.com",
+          role: UserType.ClientIntake,
+        },
+        "short"
+      )
+    ).rejects.toMatchObject({
+      message: "Password must be at least 8 characters long.",
+      code: "functions/invalid-argument",
+    });
+  });
+
+  it("preserves the diagnostic when the callable omits the new user ID", async () => {
+    mockCallable.mockResolvedValue({ data: {} });
+
+    await expect(
+      authUserService.createUser(
+        {
+          name: "Test User",
+          email: "test@example.com",
+          role: UserType.ClientIntake,
+        },
+        "test-password"
+      )
+    ).rejects.toMatchObject({
+      message: "User creation completed without returning a user ID.",
+      code: "invalid-response",
+    });
+  });
+
   it("uses the idempotent deletion callable once per user action", async () => {
     mockCallable.mockResolvedValue({ data: { status: "success" } });
 

--- a/my-app/src/services/AuthUserService.ts
+++ b/my-app/src/services/AuthUserService.ts
@@ -182,7 +182,10 @@ export class AuthUserService {
         password,
       });
       if (!result.data?.uid) {
-        throw new Error("User creation completed without returning a user ID.");
+        throw new ServiceError(
+          "User creation completed without returning a user ID.",
+          "invalid-response"
+        );
       }
       return result.data.uid;
     } catch (error: unknown) {
@@ -193,6 +196,12 @@ export class AuthUserService {
         err.code === "auth/email-already-in-use"
       ) {
         throw formatServiceError(err, "Email already in use. Please use a different email.");
+      } else if (err.code === "functions/invalid-argument" || err.code === "invalid-argument") {
+        throw new ServiceError(
+          err.message || "The user details are invalid. Please check the form and try again.",
+          err.code,
+          err
+        );
       } else if (err.code === "auth/weak-password") {
         throw formatServiceError(err, "Password is too weak. Please choose a stronger password.");
       } else if (err.code === "functions/permission-denied" || err.code === "permission-denied") {

--- a/my-app/src/services/AuthUserService.ts
+++ b/my-app/src/services/AuthUserService.ts
@@ -193,12 +193,8 @@ export class AuthUserService {
         err.code === "auth/email-already-in-use"
       ) {
         throw formatServiceError(err, "Email already in use. Please use a different email.");
-      } else if (
-        err.code === "functions/invalid-argument" ||
-        err.code === "invalid-argument" ||
-        err.code === "auth/weak-password"
-      ) {
-        throw formatServiceError(err, "Password is too weak or the user details are invalid.");
+      } else if (err.code === "auth/weak-password") {
+        throw formatServiceError(err, "Password is too weak. Please choose a stronger password.");
       } else if (err.code === "functions/permission-denied" || err.code === "permission-denied") {
         throw formatServiceError(err, "You do not have permission to create this user.");
       }

--- a/my-app/src/services/AuthUserService.ts
+++ b/my-app/src/services/AuthUserService.ts
@@ -9,8 +9,7 @@ import {
   FirestoreError,
   writeBatch,
 } from "firebase/firestore";
-import { getAuth, createUserWithEmailAndPassword } from "firebase/auth";
-import { db, app, functions } from "../auth/firebaseConfig";
+import { db, functions } from "../auth/firebaseConfig";
 import { AuthUserRow, UserType } from "../types";
 import { validateAuthUserRow } from "../utils/firestoreValidation";
 import { httpsCallable } from "firebase/functions";
@@ -35,7 +34,6 @@ const mapRoleToUserType = (roleString: string): UserType => {
 export class AuthUserService {
   private static instance: AuthUserService;
   private collectionRef = collection(db, dataSources.firebase.usersCollection);
-  private auth = getAuth(app);
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function -- Intentional for singleton
   private constructor() {}
@@ -167,45 +165,42 @@ export class AuthUserService {
   }
 
   async createUser(userData: Omit<AuthUserRow, "id" | "uid">, password: string): Promise<string> {
-    const currentUser = this.auth.currentUser;
     const formattedPhone = formatPhoneNumberForSave(userData.phone || "");
     if (formattedPhone === null) {
       throw new Error("Phone number must use one of the allowed formats.");
     }
     try {
-      return await retry(async () => {
-        const userCredential = await createUserWithEmailAndPassword(
-          this.auth,
-          userData.email,
-          password
-        );
-        const userId = userCredential.user.uid;
-        if (currentUser) {
-          await this.auth.updateCurrentUser(currentUser);
-        }
-        const roleString = getRoleDisplayName(userData.role);
-        const newUserDoc = {
-          name: userData.name,
-          email: userData.email,
-          phone: formattedPhone,
-          role: roleString,
-        };
-        await setDoc(doc(db, dataSources.firebase.usersCollection, userId), newUserDoc);
-        return userId;
+      const createUserAccountCallable = httpsCallable<
+        { name: string; email: string; phone: string; role: string; password: string },
+        { uid: string }
+      >(functions, "createUserAccount");
+      const result = await createUserAccountCallable({
+        name: userData.name.trim(),
+        email: userData.email.trim(),
+        phone: formattedPhone,
+        role: getRoleDisplayName(userData.role),
+        password,
       });
-    } catch (error: unknown) {
-      if (currentUser) {
-        try {
-          await this.auth.updateCurrentUser(currentUser);
-        } catch (restoreError) {
-          console.error("Failed to restore user context after creation error:", restoreError);
-        }
+      if (!result.data?.uid) {
+        throw new Error("User creation completed without returning a user ID.");
       }
+      return result.data.uid;
+    } catch (error: unknown) {
       const err = error as Error & { code?: string; message?: string };
-      if (err.code === "auth/email-already-in-use") {
+      if (
+        err.code === "functions/already-exists" ||
+        err.code === "already-exists" ||
+        err.code === "auth/email-already-in-use"
+      ) {
         throw formatServiceError(err, "Email already in use. Please use a different email.");
-      } else if (err.code === "auth/weak-password") {
-        throw formatServiceError(err, "Password is too weak. Please choose a stronger password.");
+      } else if (
+        err.code === "functions/invalid-argument" ||
+        err.code === "invalid-argument" ||
+        err.code === "auth/weak-password"
+      ) {
+        throw formatServiceError(err, "Password is too weak or the user details are invalid.");
+      } else if (err.code === "functions/permission-denied" || err.code === "permission-denied") {
+        throw formatServiceError(err, "You do not have permission to create this user.");
       }
       throw formatServiceError(
         err,
@@ -242,10 +237,8 @@ export class AuthUserService {
 
   async deleteUser(uid: string): Promise<void> {
     try {
-      await retry(async () => {
-        const deleteUserAccountCallable = httpsCallable(functions, "deleteUserAccount");
-        await deleteUserAccountCallable({ uid: uid });
-      });
+      const deleteUserAccountCallable = httpsCallable(functions, "deleteUserAccount");
+      await deleteUserAccountCallable({ uid });
     } catch (error: unknown) {
       const err = error as Error & { code?: string; message?: string };
       const errorMessage = err.message || "An error occurred while deleting the user account.";


### PR DESCRIPTION
## Summary

- move user creation from the browser's Firebase Auth session into a new authorized `createUserAccount` callable
- compensate a failed Firestore profile write by deleting the newly created Auth identity
- make `deleteUserAccount` idempotent across Auth and Firestore, including repairing a Firestore-only row when Auth was already removed
- stop client-side retries around non-atomic create/delete mutations
- add frontend and Python regression tests, and run the Python tests in CI

## Root cause

The Slack incident's disputed email was not a confirmed app failure: the reported account was manually created in Firebase Authentication, and the current live inventory is synchronized.

The code nevertheless had two independently reproducible drift paths:

1. `AuthUserService.createUser` retried the entire client-side Auth-create + Firestore-write sequence. If Auth creation succeeded but the Firestore write failed, the retry attempted the same email again and surfaced `email-already-in-use`, leaving an Auth-only identity.
2. `deleteUserAccount` returned success after a Firestore deletion failure, while an already-missing Auth identity caused an early not-found response and left the Firestore row in place.

The creation retry behavior was carried forward by `67efc1cf`; the original two-store deletion behavior dates to `71874282`.

## Validation

- `npm run lint` (passes with the two pre-existing Profile hook warnings)
- `npx tsc --noEmit`
- `CI=true npm run test:ci -- --runInBand`: 49 suites, 250 tests
- `python -m unittest discover -s functions-python -p 'test_*.py'`: 4 synchronization tests
- `CI=false npm run build`
- `npm audit --omit=dev --audit-level=high`: gate passes; 3 moderate advisories remain
- `pip-audit -r functions-python/requirements.txt`: no known vulnerabilities
- current `main` CI/deploy run completed successfully, and production served the corresponding cache-busted bundle
- metadata-only production inventory before and after testing: 12 Auth identities, 12 Firestore user docs, zero UID/email mismatches
- real Firebase Auth sign-in + deployed callable deletion verified that an exact temporary child account was removed from both Auth and Firestore
- all temporary Auth/Firestore test records were removed; final counts returned to 12/12

The embedded browser reached the production login form, but its Firebase Auth request failed at the browser network layer before sign-in. The authenticated service/live-data path was verified directly; a post-deploy UI smoke test should still be performed after merge.

## Rollback

Revert `945f8093f87f7237260d701f5c5a6f79c0bab571` and redeploy Hosting and Functions together. There is no data migration. Because the new frontend calls `createUserAccount`, do not roll back only the function while leaving the new frontend deployed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure, role-based user account creation with validation and synchronized Auth/Firestore records.
  * Added reliable user deletion with clear status reporting and recovery from partial failures.
  * Improved handling of duplicate emails, permissions, and invalid account data.

* **Bug Fixes**
  * User creation and deletion now behave consistently when one system operation fails.

* **Tests**
  * Expanded automated coverage for account creation, updates, deletion, authorization, and rollback scenarios.

* **Documentation**
  * Documented the new account creation capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->