### PR TITLE
Feature: add new page - password reset

### DIFF
--- a/my-app/src/pages/Login/Login.module.css
+++ b/my-app/src/pages/Login/Login.module.css
@@ -373,3 +373,46 @@
 :global .MuiButton-outlined:hover {
   border-width: 1.5px;
 }
+
+/* Auth action (password reset) page */
+.statusBlock {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-lg) 0;
+}
+
+.statusBlock .subheading {
+  margin-bottom: 0;
+}
+
+.statusIconSuccess {
+  color: var(--color-primary) !important;
+  font-size: 3rem !important;
+  margin-bottom: var(--spacing-xs);
+  animation: fadeIn 0.3s ease;
+}
+
+.statusIconError {
+  color: var(--color-error-text) !important;
+  font-size: 3rem !important;
+  margin-bottom: var(--spacing-xs);
+  animation: fadeIn 0.3s ease;
+}
+
+/* Beats the global .MuiButton-root fill above so the secondary action reads as secondary */
+.secondaryButton.secondaryButton {
+  background-color: var(--color-transparent) !important;
+  color: var(--color-primary) !important;
+  border: 1.5px solid var(--color-primary);
+  box-shadow: none !important;
+  margin-top: var(--spacing-sm);
+}
+
+.secondaryButton.secondaryButton:hover {
+  background-color: rgba(37, 126, 104, 0.08) !important;
+  border-color: var(--color-primary-dark);
+  color: var(--color-primary-dark) !important;
+  box-shadow: none !important;
+}

--- a/my-app/src/pages/Login/auth-action.tsx
+++ b/my-app/src/pages/Login/auth-action.tsx
@@ -69,6 +69,18 @@ const AuthActionPage = () => {
   useEffect(() => {
     let cancelled = false;
 
+    // Opening a second action link in the same tab reuses this component, so clear
+    // anything left over from the previous code before validating the new one.
+    setStage("verifying");
+    setError("");
+    setAccountEmail("");
+    setSuccessMessage("");
+    setPassword("");
+    setConfirmPassword("");
+    setShowPassword(false);
+    setShowConfirmPassword(false);
+    setIsSubmitting(false);
+
     const verify = async () => {
       if (!oobCode) {
         if (!cancelled) {
@@ -97,6 +109,7 @@ const AuthActionPage = () => {
           setSuccessMessage("Your email address has been restored. You can sign in now.");
           setStage("success");
         } else {
+          if (cancelled) return;
           setError("This link isn't supported. Please request a new password reset email.");
           setStage("invalid");
         }

--- a/my-app/src/pages/Login/auth-action.tsx
+++ b/my-app/src/pages/Login/auth-action.tsx
@@ -1,0 +1,330 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { applyActionCode, confirmPasswordReset, verifyPasswordResetCode } from "firebase/auth";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import IconButton from "@mui/material/IconButton";
+import InputAdornment from "@mui/material/InputAdornment";
+import CircularProgress from "@mui/material/CircularProgress";
+import VisibilityIcon from "@mui/icons-material/Visibility";
+import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
+import { auth } from "../../auth/firebaseConfig";
+import styles from "./Login.module.css";
+import foodForAllDCLogin from "../../assets/food-for-all-dc-login.png";
+import foodForAllDCLogo from "../../assets/food-for-all-dc-logo.jpg";
+
+const MIN_PASSWORD_LENGTH = 8;
+
+type Stage = "verifying" | "form" | "success" | "invalid";
+
+// Maps Firebase action-code errors to messages that make sense to a user
+// who just clicked a link in their email.
+const mapActionCodeError = (error: any): string => {
+  switch (error?.code) {
+    case "auth/expired-action-code":
+      return "This password reset link has expired. Please request a new one.";
+    case "auth/invalid-action-code":
+      return "This password reset link is no longer valid. It may have already been used. Please request a new one.";
+    case "auth/user-disabled":
+      return "This account has been disabled. Please contact an administrator.";
+    case "auth/user-not-found":
+      return "No account was found for this reset link. Please contact an administrator.";
+    case "auth/weak-password":
+      return "That password is too weak. Please choose a stronger one.";
+    default:
+      return "Something went wrong. Please request a new password reset email and try again.";
+  }
+};
+
+const AuthActionPage = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  const mode = searchParams.get("mode");
+  const oobCode = searchParams.get("oobCode");
+
+  const [stage, setStage] = useState<Stage>("verifying");
+  const [accountEmail, setAccountEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [error, setError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [successHeading, setSuccessHeading] = useState("Password Updated");
+  const [successMessage, setSuccessMessage] = useState("");
+
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, []);
+
+  // Validate the emailed action code before showing any form, so an expired or
+  // already-used link fails up front instead of after the user types a password.
+  useEffect(() => {
+    let cancelled = false;
+
+    const verify = async () => {
+      if (!oobCode) {
+        if (!cancelled) {
+          setError("This link is missing information. Please request a new password reset email.");
+          setStage("invalid");
+        }
+        return;
+      }
+
+      try {
+        if (mode === "resetPassword") {
+          const email = await verifyPasswordResetCode(auth, oobCode);
+          if (cancelled) return;
+          setAccountEmail(email);
+          setStage("form");
+        } else if (mode === "verifyEmail") {
+          await applyActionCode(auth, oobCode);
+          if (cancelled) return;
+          setSuccessHeading("Email Verified");
+          setSuccessMessage("Your email address has been verified. You can sign in now.");
+          setStage("success");
+        } else if (mode === "recoverEmail") {
+          await applyActionCode(auth, oobCode);
+          if (cancelled) return;
+          setSuccessHeading("Email Restored");
+          setSuccessMessage("Your email address has been restored. You can sign in now.");
+          setStage("success");
+        } else {
+          setError("This link isn't supported. Please request a new password reset email.");
+          setStage("invalid");
+        }
+      } catch (verifyError: any) {
+        if (cancelled) return;
+        setError(mapActionCodeError(verifyError));
+        setStage("invalid");
+      }
+    };
+
+    verify();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [mode, oobCode]);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      setError("");
+
+      if (!password || !confirmPassword) {
+        setError("Please enter and confirm your new password.");
+        return;
+      }
+      if (password.length < MIN_PASSWORD_LENGTH) {
+        setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters long.`);
+        return;
+      }
+      if (password !== confirmPassword) {
+        setError("Passwords do not match.");
+        return;
+      }
+      if (!oobCode) {
+        setError("This link is missing information. Please request a new password reset email.");
+        setStage("invalid");
+        return;
+      }
+
+      setIsSubmitting(true);
+      try {
+        await confirmPasswordReset(auth, oobCode, password);
+        setSuccessHeading("Password Updated");
+        setSuccessMessage(
+          accountEmail
+            ? `Your password for ${accountEmail} has been changed. You can sign in with it now.`
+            : "Your password has been changed. You can sign in with it now."
+        );
+        setPassword("");
+        setConfirmPassword("");
+        setStage("success");
+      } catch (resetError: any) {
+        console.error("Password reset error:", resetError);
+        setError(mapActionCodeError(resetError));
+        if (
+          resetError?.code === "auth/expired-action-code" ||
+          resetError?.code === "auth/invalid-action-code"
+        ) {
+          setStage("invalid");
+        }
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [accountEmail, confirmPassword, oobCode, password]
+  );
+
+  const goToLogin = () => navigate("/");
+
+  const renderContent = () => {
+    if (stage === "verifying") {
+      return (
+        <div className={styles.statusBlock}>
+          <CircularProgress size={40} style={{ color: "var(--color-primary)" }} />
+          <p className={styles.subheading}>Checking your link...</p>
+        </div>
+      );
+    }
+
+    if (stage === "invalid") {
+      return (
+        <>
+          <ErrorOutlineIcon className={styles.statusIconError} />
+          <h1 className={styles.heading}>Link Not Valid</h1>
+          <p className={styles.subheading}>{error}</p>
+          <Button
+            variant="contained"
+            color="primary"
+            fullWidth
+            onClick={() => navigate("/forgot-password")}
+          >
+            Request New Link
+          </Button>
+          <Button
+            variant="outlined"
+            fullWidth
+            onClick={goToLogin}
+            className={styles.secondaryButton}
+          >
+            Back to Login
+          </Button>
+        </>
+      );
+    }
+
+    if (stage === "success") {
+      return (
+        <>
+          <CheckCircleOutlineIcon className={styles.statusIconSuccess} />
+          <h1 className={styles.heading}>{successHeading}</h1>
+          <p className={styles.subheading}>{successMessage}</p>
+          <Button variant="contained" color="primary" fullWidth onClick={goToLogin}>
+            Back to Login
+          </Button>
+        </>
+      );
+    }
+
+    return (
+      <>
+        <h1 className={styles.heading}>Reset Password</h1>
+        <p className={styles.subheading}>
+          {accountEmail
+            ? `Choose a new password for ${accountEmail}`
+            : "Choose a new password for your account"}
+        </p>
+        <form onSubmit={handleSubmit}>
+          <TextField
+            label="New Password"
+            variant="outlined"
+            type={showPassword ? "text" : "password"}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            fullWidth
+            required
+            autoFocus
+            disabled={isSubmitting}
+            autoComplete="new-password"
+            margin="normal"
+            className={styles.inputField}
+            helperText={`Must be at least ${MIN_PASSWORD_LENGTH} characters.`}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton
+                    aria-label="toggle password visibility"
+                    onClick={() => setShowPassword((prev) => !prev)}
+                    edge="end"
+                    disabled={isSubmitting}
+                  >
+                    {showPassword ? <VisibilityOffIcon /> : <VisibilityIcon />}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+          />
+          <TextField
+            label="Confirm New Password"
+            variant="outlined"
+            type={showConfirmPassword ? "text" : "password"}
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            fullWidth
+            required
+            disabled={isSubmitting}
+            autoComplete="new-password"
+            margin="normal"
+            className={styles.inputField}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton
+                    aria-label="toggle confirm password visibility"
+                    onClick={() => setShowConfirmPassword((prev) => !prev)}
+                    edge="end"
+                    disabled={isSubmitting}
+                  >
+                    {showConfirmPassword ? <VisibilityOffIcon /> : <VisibilityIcon />}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+          />
+
+          {error && (
+            <p className={styles.error} role="alert">
+              {error}
+            </p>
+          )}
+
+          <Button
+            type="submit"
+            variant="contained"
+            color="primary"
+            fullWidth
+            disabled={isSubmitting}
+            startIcon={isSubmitting ? <CircularProgress size={20} color="inherit" /> : null}
+          >
+            {isSubmitting ? "Saving..." : "Save New Password"}
+          </Button>
+          <Button
+            variant="outlined"
+            fullWidth
+            onClick={goToLogin}
+            disabled={isSubmitting}
+            className={styles.secondaryButton}
+          >
+            Back to Login
+          </Button>
+        </form>
+      </>
+    );
+  };
+
+  return (
+    <div className={styles.outerContainer}>
+      <div className={styles.imageContainer}>
+        <img src={foodForAllDCLogin} alt="Food for All DC" />
+      </div>
+      <div className={styles.container}>
+        <div>
+          <img className={styles.logoImage} src={foodForAllDCLogo} alt="Food for All DC" />
+        </div>
+        <div className={styles.formContainer}>{renderContent()}</div>
+      </div>
+    </div>
+  );
+};
+
+export default AuthActionPage;

--- a/my-app/src/routesConfig.tsx
+++ b/my-app/src/routesConfig.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import Login from "./pages/Login/Login";
 import ForgotPasswordPage from "./pages/Login/forgot-password";
+import AuthActionPage from "./pages/Login/auth-action";
 import CalendarPage from "./pages/Calendar/CalendarPage";
 import Spreadsheet from "./components/Spreadsheet/Spreadsheet";
 import UsersSpreadsheet from "./components/UsersSpreadsheet/UsersSpreadsheet";
@@ -41,6 +42,16 @@ export const routesConfig: AppRoute[] = [
     element: <ForgotPasswordPage />,
     public: true,
     meta: { title: "Forgot Password", description: "Password recovery page", icon: "lock" },
+  },
+  {
+    path: "/auth/action",
+    element: <AuthActionPage />,
+    public: true,
+    meta: {
+      title: "Reset Password",
+      description: "Handles password reset and email verification links",
+      icon: "lock_reset",
+    },
   },
   {
     path: "/*",


### PR DESCRIPTION
- Creates a new password reset page that looks like the app
- Links easily back to the main page (this is the feature request)

To test:
Send yourself a reset code with your local host, get the email, then put in your browser 'http://localhost:3000/auth/action?mode=resetPassword&oobCode=< code >' with < code > being the code from the end of the email link

To deploy to prod:
 - 1st deploy
    
 - Firebase Console -> Authentication -> Templates -> Password reset -> (edit icon) -> Customize action URL:
  https://food-for-all-dc-caf23.web.app/auth/action
  
  or [app.foodforalldc.org/auth/action](http://app.foodforalldc.org/auth/action)