### PR TITLE
Fix: Evaluate report clients at selected end date

### DIFF
--- a/my-app/src/pages/Reports/SummaryReport.test.tsx
+++ b/my-app/src/pages/Reports/SummaryReport.test.tsx
@@ -55,14 +55,14 @@ describe("SummaryReport", () => {
         uid: "active-without-delivery",
         firstName: "Test",
         lastName: "Client",
-        startDate: DateTime.now().minus({ days: 30 }),
-        endDate: DateTime.now().plus({ days: 30 }),
+        startDate: DateTime.fromISO("2026-06-01"),
+        endDate: DateTime.fromISO("2026-08-12"),
         tags: ["HFA"],
       },
     ]);
   });
 
-  it("loads all clients so an active client without a date-scoped delivery contributes tags", async () => {
+  it("counts an unserved client who was active at the selected report end date", async () => {
     render(<SummaryReport />);
 
     fireEvent.click(screen.getByRole("button", { name: "Generate" }));

--- a/my-app/src/pages/Reports/reportDataLoader.test.ts
+++ b/my-app/src/pages/Reports/reportDataLoader.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import type { QueryDocumentSnapshot } from "firebase/firestore";
+import { getDocs } from "firebase/firestore";
+import type { MockedFunction } from "jest-mock";
+import { loadAllReportClients } from "./reportDataLoader";
+
+jest.mock("../../auth/firebaseConfig", () => ({ db: {} }));
+jest.mock("../../config/dataSources", () => ({
+  __esModule: true,
+  default: { firebase: { clientsCollection: "client-profile2" } },
+}));
+jest.mock("firebase/firestore", () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const mockJest = require("@jest/globals").jest;
+
+  return {
+    collection: mockJest.fn(),
+    documentId: mockJest.fn(() => "__name__"),
+    getDocs: mockJest.fn(),
+    limit: mockJest.fn(),
+    orderBy: mockJest.fn(),
+    query: mockJest.fn((...parts: unknown[]) => parts),
+    startAfter: mockJest.fn(),
+    Timestamp: class Timestamp {},
+    where: mockJest.fn(),
+  };
+});
+
+const mockedGetDocs = getDocs as MockedFunction<typeof getDocs>;
+
+describe("reportDataLoader", () => {
+  it("maps three-strikes history needed by historical summary reports", async () => {
+    const docSnapshot = {
+      id: "client-1",
+      data: () => ({
+        firstName: "Test",
+        lastName: "Client",
+        startDate: "2026-06-01",
+        endDate: "2026-08-20",
+        autoInactiveReason: "three-strikes",
+        autoInactivePreviousEndDate: "2026-12-31",
+        autoInactiveStrikeDate: "2026-08-20",
+        tags: ["HFA"],
+      }),
+    } as unknown as QueryDocumentSnapshot;
+    mockedGetDocs.mockResolvedValueOnce({
+      docs: [docSnapshot],
+      empty: false,
+      size: 1,
+    } as Awaited<ReturnType<typeof getDocs>>);
+
+    await expect(loadAllReportClients()).resolves.toEqual([
+      expect.objectContaining({
+        uid: "client-1",
+        autoInactiveReason: "three-strikes",
+        autoInactivePreviousEndDate: "2026-12-31",
+        autoInactiveStrikeDate: "2026-08-20",
+      }),
+    ]);
+  });
+});

--- a/my-app/src/pages/Reports/reportDataLoader.ts
+++ b/my-app/src/pages/Reports/reportDataLoader.ts
@@ -72,6 +72,22 @@ const mapReportClient = (docSnapshot: QueryDocumentSnapshot): ReportClientRecord
     endDate: (raw.endDate as string | Date | Timestamp | DateTime | null | undefined) ?? null,
     autoInactiveReason:
       typeof raw.autoInactiveReason === "string" ? raw.autoInactiveReason : null,
+    autoInactivePreviousEndDate:
+      (raw.autoInactivePreviousEndDate as
+        | string
+        | Date
+        | Timestamp
+        | DateTime
+        | null
+        | undefined) ?? null,
+    autoInactiveStrikeDate:
+      (raw.autoInactiveStrikeDate as
+        | string
+        | Date
+        | Timestamp
+        | DateTime
+        | null
+        | undefined) ?? null,
     referralEntity: referralEntity
       ? {
           id:

--- a/my-app/src/pages/Reports/reportUtils.test.ts
+++ b/my-app/src/pages/Reports/reportUtils.test.ts
@@ -1,6 +1,5 @@
 import { DateTime } from "luxon";
 import { describe, expect, it } from "@jest/globals";
-import { deliveryDate } from "../../utils/deliveryDate";
 import {
   buildSummaryReportData,
   ReportClientRecord,
@@ -11,14 +10,12 @@ const createClient = (
   uid: string,
   overrides: Partial<ReportClientRecord> = {}
 ): ReportClientRecord => {
-  const today = deliveryDate.today();
-
   return {
     uid,
     firstName: "Test",
     lastName: uid,
-    startDate: today.minus({ days: 30 }),
-    endDate: today.plus({ days: 30 }),
+    startDate: "2026-06-01",
+    endDate: "2026-12-31",
     adults: 2,
     children: 1,
     seniors: 0,
@@ -42,9 +39,10 @@ const createDelivery = (id: string, clientId: string): ReportDeliveryRecord => (
 });
 
 describe("buildSummaryReportData", () => {
-  it("counts attributes once for every eligible active client, including clients without an in-range delivery", () => {
+  it("counts attributes for clients active at the selected report end date", () => {
     const activeWithoutDelivery = createClient("active-without-delivery", {
-      tags: ["HFA", "HFA", "FAM"],
+      endDate: "2026-08-12",
+      tags: ["HFA", "HFA", "FAM", "Historical"],
       deliveryDetails: { dietaryRestrictions: { halal: true } },
       physicalAilments: { diabetes: true },
       physicalDisability: { other: true },
@@ -52,18 +50,41 @@ describe("buildSummaryReportData", () => {
     });
     const servedActiveClient = createClient("served-active", { tags: ["HFA", "FAM"] });
     const expiredClient = createClient("expired", {
-      endDate: deliveryDate.today().minus({ days: 1 }),
+      endDate: "2026-08-11",
       tags: ["HFA"],
       deliveryDetails: { dietaryRestrictions: { vegan: true } },
       physicalAilments: { hypertension: true },
     });
     const futureClient = createClient("future", {
-      startDate: deliveryDate.today().plus({ days: 1 }),
-      tags: ["HFA"],
+      startDate: "2026-08-13",
+      tags: ["Future"],
     });
     const threeStrikesClient = {
-      ...createClient("three-strikes", { tags: ["HFA"] }),
+      ...createClient("three-strikes", {
+        endDate: "2026-08-01",
+        tags: ["HFA"],
+      }),
       autoInactiveReason: "three-strikes",
+      autoInactivePreviousEndDate: "2026-12-31",
+      autoInactiveStrikeDate: "2026-08-01",
+    } as ReportClientRecord;
+    const struckAfterReportEnd = {
+      ...createClient("future-three-strikes", {
+        endDate: "2026-08-20",
+        tags: ["HFA", "PreStrike"],
+      }),
+      autoInactiveReason: "three-strikes",
+      autoInactivePreviousEndDate: "2026-12-31",
+      autoInactiveStrikeDate: "2026-08-20",
+    } as ReportClientRecord;
+    const endedBeforeFutureStrike = {
+      ...createClient("ended-before-future-strike", {
+        endDate: "2026-08-20",
+        tags: ["EndedBeforeStrike"],
+      }),
+      autoInactiveReason: "three-strikes",
+      autoInactivePreviousEndDate: "2026-08-10",
+      autoInactiveStrikeDate: "2026-08-20",
     } as ReportClientRecord;
     const servedEvents = [
       createDelivery("delivery-1", servedActiveClient.uid),
@@ -78,6 +99,8 @@ describe("buildSummaryReportData", () => {
         expiredClient,
         futureClient,
         threeStrikesClient,
+        struckAfterReportEnd,
+        endedBeforeFutureStrike,
       ],
       servedEvents,
       firstDeliveriesByClientId: new Map(),
@@ -85,8 +108,12 @@ describe("buildSummaryReportData", () => {
       end: DateTime.fromISO("2026-08-12").endOf("day"),
     });
 
-    expect(result.data.Tags.HFA.value).toBe(2);
+    expect(result.data.Tags.HFA.value).toBe(3);
     expect(result.data.Tags.FAM.value).toBe(2);
+    expect(result.data.Tags.Historical.value).toBe(1);
+    expect(result.data.Tags.PreStrike.value).toBe(1);
+    expect(result.data.Tags.Future).toBeUndefined();
+    expect(result.data.Tags.EndedBeforeStrike).toBeUndefined();
     expect(
       result.data["FAM (Food as Medicine)"]["Clients Receiving Medically Tailored Food"].value
     ).toBe(1);

--- a/my-app/src/pages/Reports/reportUtils.ts
+++ b/my-app/src/pages/Reports/reportUtils.ts
@@ -40,6 +40,8 @@ export interface ReportClientRecord {
   startDate?: SupportedDateInput;
   endDate?: SupportedDateInput;
   autoInactiveReason?: string | null;
+  autoInactivePreviousEndDate?: SupportedDateInput;
+  autoInactiveStrikeDate?: SupportedDateInput;
   adults?: number;
   seniors?: number;
   children?: number;
@@ -453,7 +455,11 @@ export const buildSummaryReportData = ({
   const clientsById = getClientMap(clients);
   const servedEventsByClientId = groupEventsByClientId(servedEvents);
   const activeClients = Array.from(clientsById.values()).filter((client) =>
-    computeClientActiveStatus(client.startDate, client.endDate, client.autoInactiveReason)
+    computeClientActiveStatus(client.startDate, client.endDate, client.autoInactiveReason, {
+      referenceDate: end,
+      autoInactiveStrikeDate: client.autoInactiveStrikeDate,
+      autoInactivePreviousEndDate: client.autoInactivePreviousEndDate,
+    })
   );
 
   let usedLegacySnapshotFallback = false;

--- a/my-app/src/tests/utils/clientStatus.test.ts
+++ b/my-app/src/tests/utils/clientStatus.test.ts
@@ -22,6 +22,60 @@ describe("clientStatus utilities", () => {
   });
 
   // App coverage:
+  // - historical reports need stable status results when rerun after a client's end date
+  // - other app surfaces should continue to evaluate status against today by default
+  // Behavior contract: an explicit reference date replaces today without changing inclusive boundaries.
+  it("evaluates active status against an explicit reference date", () => {
+    const fixedToday = DateTime.fromISO("2026-08-23T12:00:00", { zone: deliveryDate.zone });
+    jest.spyOn(deliveryDate, "today").mockReturnValue(fixedToday);
+
+    expect(computeClientActiveStatus("2026-06-01", "2026-08-12")).toBe(false);
+    expect(
+      computeClientActiveStatus("2026-06-01", "2026-08-12", null, {
+        referenceDate: "2026-08-12",
+      })
+    ).toBe(true);
+    expect(
+      computeClientActiveStatus("2026-08-13", "2026-12-31", null, {
+        referenceDate: "2026-08-12",
+      })
+    ).toBe(false);
+  });
+
+  // App coverage:
+  // - three-strikes automation replaces endDate but preserves the strike date and prior end date
+  // - historical reports before the strike need the client's pre-strike status
+  // Behavior contract: strike status starts on the strike date; earlier dates use the prior end date.
+  it("reconstructs three-strikes status for a historical reference date", () => {
+    expect(
+      computeClientActiveStatus("2026-06-01", "2026-08-20", "three-strikes", {
+        referenceDate: "2026-08-12",
+        autoInactiveStrikeDate: "2026-08-20",
+        autoInactivePreviousEndDate: "2026-12-31",
+      })
+    ).toBe(true);
+    expect(
+      computeClientActiveStatus("2026-06-01", "2026-08-20", "three-strikes", {
+        referenceDate: "2026-08-12",
+        autoInactiveStrikeDate: "2026-08-20",
+        autoInactivePreviousEndDate: "2026-08-10",
+      })
+    ).toBe(false);
+    expect(
+      computeClientActiveStatus("2026-06-01", "2026-08-20", "three-strikes", {
+        referenceDate: "2026-08-20",
+        autoInactiveStrikeDate: "2026-08-20",
+        autoInactivePreviousEndDate: "2026-12-31",
+      })
+    ).toBe(false);
+    expect(
+      computeClientActiveStatus("2026-06-01", "2026-08-20", "three-strikes", {
+        referenceDate: "2026-08-12",
+      })
+    ).toBe(false);
+  });
+
+  // App coverage:
   // - three-strikes automation should force inactive presentation regardless of date range validity
   // - this override prevents re-activation by date edits alone when strike policy applies
   // Behavior contract: autoInactiveReason=three-strikes always returns inactive.

--- a/my-app/src/utils/clientStatus.ts
+++ b/my-app/src/utils/clientStatus.ts
@@ -1,6 +1,4 @@
-import type { Timestamp } from "firebase/firestore";
-import type { DateTime } from "luxon";
-import { deliveryDate } from "./deliveryDate";
+import { deliveryDate, type DeliveryDateInput } from "./deliveryDate";
 
 const ACTIVE_ICON_PATH =
   "M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z";
@@ -15,29 +13,59 @@ export interface ClientStatusPresentation {
   tooltip: string;
 }
 
+export interface ClientActiveStatusOptions {
+  referenceDate?: DeliveryDateInput;
+  autoInactiveStrikeDate?: DeliveryDateInput;
+  autoInactivePreviousEndDate?: DeliveryDateInput;
+}
+
 export const computeClientActiveStatus = (
-  startDate: string | Date | DateTime | Timestamp | null | undefined,
-  endDate: string | Date | DateTime | Timestamp | null | undefined,
-  autoInactiveReason?: string | null
+  startDate: DeliveryDateInput,
+  endDate: DeliveryDateInput,
+  autoInactiveReason?: string | null,
+  options: ClientActiveStatusOptions = {}
 ): boolean => {
-  if (autoInactiveReason === "three-strikes") {
+  const hasReferenceDate = options.referenceDate !== null && options.referenceDate !== undefined;
+  const statusDate = hasReferenceDate
+    ? deliveryDate.tryToDateTime(options.referenceDate)?.startOf("day")
+    : deliveryDate.today().startOf("day");
+  if (!statusDate?.isValid) {
     return false;
   }
 
-  const today = deliveryDate.today().startOf("day");
+  let effectiveEndDate = endDate;
+  if (autoInactiveReason === "three-strikes") {
+    if (!hasReferenceDate) {
+      return false;
+    }
+
+    const strikeDate = options.autoInactiveStrikeDate
+      ? deliveryDate.tryToDateTime(options.autoInactiveStrikeDate)?.startOf("day")
+      : null;
+    if (!strikeDate?.isValid || statusDate.toMillis() >= strikeDate.toMillis()) {
+      return false;
+    }
+
+    effectiveEndDate = options.autoInactivePreviousEndDate;
+  }
+
   const startDateTime = startDate ? deliveryDate.tryToDateTime(startDate)?.startOf("day") : null;
   if (!startDateTime?.isValid) {
     return false;
   }
 
-  const endDateTime = endDate ? deliveryDate.tryToDateTime(endDate)?.startOf("day") : null;
-  const todayMillis = today.toMillis();
+  const endDateTime = effectiveEndDate
+    ? deliveryDate.tryToDateTime(effectiveEndDate)?.startOf("day")
+    : null;
+  const statusDateMillis = statusDate.toMillis();
 
   if (endDateTime?.isValid) {
-    return todayMillis >= startDateTime.toMillis() && todayMillis <= endDateTime.toMillis();
+    return (
+      statusDateMillis >= startDateTime.toMillis() && statusDateMillis <= endDateTime.toMillis()
+    );
   }
 
-  return todayMillis >= startDateTime.toMillis();
+  return statusDateMillis >= startDateTime.toMillis();
 };
 
 export const getClientStatusPresentation = (


### PR DESCRIPTION
## What

- Evaluate Summary Report client status as of the selected report end date instead of the day the report is generated.
- Keep the existing active-status behavior unchanged everywhere else; those screens still evaluate against today.
- Reconstruct the pre-strike status of clients who were automatically marked inactive after three missed deliveries, using the stored strike date and prior end date.
- Preserve all delivery-scoped metrics from #326.
- Add regression coverage for historical, future, inclusive end-date, unserved, and three-strikes cases.

## Why

This follows up on #326 and [Jamie's question](https://github.com/Hack4Impact-UMD/food-for-all-dc/pull/326#issuecomment-5335712996). Peter confirmed that the selected report dates should determine which clients count as active.

The same historical report now returns stable tag, dietary, and health totals when rerun later.

## Deep-review finding fixed

The first version passed the selected end date, but it still treated every three-strikes client as inactive for all history. Because the three-strikes automation overwrites the current end date, that could make someone disappear from a report dated before their third missed delivery. The final version loads the stored strike history and reconstructs the correct status for the report date. Legacy records without that history remain safely excluded.

## Validation

From `my-app/`:

- Focused report/status regression tests — 4 suites / 9 tests passed.
- Full frontend suite with CI environment — 57 suites / 336 tests passed.
- `npx tsc --noEmit` — passed.
- `npm run lint` — passed with the existing `Profile.tsx` hook warning.
- `CI=false npm run build` — completed with the existing dependency-expression, hook, and bundle-size warnings.
- `npm audit --omit=dev --audit-level=high` — passed; only 3 moderate production advisories remain.
- `git diff --check` — passed.
- GitHub Firebase CI/CD run [#313](https://github.com/Hack4Impact-UMD/food-for-all-dc/actions/runs/32674812409) — CI Checks passed; PR production deploy correctly skipped.
- GitHub's exact synthetic merge commit was inspected and is mergeable with current `main` (1 ahead, 0 behind).

## Authenticated UI E2E

Using the external browser extension, the final branch was run locally against the real authenticated service without changing any data:

- Summary Report for **2026-07-01 through 2026-07-01** showed no HFA clients.
- Summary Report for **2026-07-16 through 2026-08-12** showed **HFA = 13** and a success message.
- The separate read-only query tool returned exactly **13 HFA clients**. Every HFA enrollment began after July 1 and on or before August 12, independently matching both report results.
- The clean final report run had no browser console errors.

No visual UI change.