### PR TITLE
Client Profile + Unknown

### DIFF
--- a/my-app/src/pages/Profile/Profile.tsx
+++ b/my-app/src/pages/Profile/Profile.tsx
@@ -74,6 +74,7 @@ import HealthCheckbox from "./components/HealthCheckbox";
 import { buildHouseholdSnapshot } from "../../utils/householdSnapshot";
 import { deliveryDate } from "../../utils/deliveryDate";
 import { computeClientActiveStatus } from "../../utils/clientStatus";
+import { GENDER_OPTIONS, normalizeGender } from "../../utils/gender";
 import { toJSDate } from "../../utils/timestamp";
 import {
   buildGeocodingAddress,
@@ -459,6 +460,7 @@ const Profile = () => {
 
       const normalizedData = {
         ...data,
+        gender: normalizeGender(data.gender),
         tefapCert: normalizeBooleanField(data.tefapCert),
         tefapCertDate: deliveryDate.tryToISODateString(data.tefapCertDate) ?? "",
         activeStatus: computeClientActiveStatus(
@@ -2227,7 +2229,7 @@ const Profile = () => {
         return <Box>{clientProfile.gender}</Box>;
       }
 
-      const preDefinedOptions = ["Male", "Female", "Unknown", "Other"];
+      const preDefinedOptions = GENDER_OPTIONS;
 
       const isPredefined = preDefinedOptions.includes(clientProfile.gender);
       const selectValue = isPredefined ? clientProfile.gender : "Unknown";

--- a/my-app/src/pages/Profile/Profile.tsx
+++ b/my-app/src/pages/Profile/Profile.tsx
@@ -268,7 +268,7 @@ const Profile = () => {
     total: 0,
     seniors: 0,
     headOfHousehold: "Adult",
-    gender: "Male",
+    gender: "Unknown",
     ethnicity: "",
     deliveryDetails: {
       deliveryInstructions: "",
@@ -2043,7 +2043,7 @@ const Profile = () => {
         return <Box>{clientProfile.language}</Box>;
       }
 
-      const preDefinedOptions = ["English", "Spanish"];
+      const preDefinedOptions = ["English", "Spanish", "Unknown"];
       // If the stored language is not one of the predefined ones, we default to "Other"
       const isPredefined = preDefinedOptions.includes(clientProfile.language);
       const selectValue = isPredefined ? clientProfile.language : "Other";
@@ -2144,6 +2144,7 @@ const Profile = () => {
         "Middle Eastern or North African",
         "Native Hawaiian or Pacific Islander",
         "Prefer Not to Say",
+        "Unknown",
       ];
 
       const isPredefined = preDefinedOptions.includes(clientProfile.ethnicity);
@@ -2226,10 +2227,10 @@ const Profile = () => {
         return <Box>{clientProfile.gender}</Box>;
       }
 
-      const preDefinedOptions = ["Male", "Female", "Other"];
+      const preDefinedOptions = ["Male", "Female", "Unknown", "Other"];
 
       const isPredefined = preDefinedOptions.includes(clientProfile.gender);
-      const selectValue = isPredefined ? clientProfile.gender : "Other";
+      const selectValue = isPredefined ? clientProfile.gender : "Unknown";
 
       const handleGenderSelectChange = (e: any) => {
         const newVal = e.target.value;

--- a/my-app/src/pages/Profile/components/FormField.tsx
+++ b/my-app/src/pages/Profile/components/FormField.tsx
@@ -581,6 +581,7 @@ const FormField = (props: FormFieldProps) => {
                 </MenuItem>
                 <MenuItem value="Male">Male</MenuItem>
                 <MenuItem value="Female">Female</MenuItem>
+                <MenuItem value="Unknown">Unknown</MenuItem>
                 <MenuItem value="Other">Other</MenuItem>
               </CustomSelect>
             </Box>

--- a/my-app/src/services/client-service.ts
+++ b/my-app/src/services/client-service.ts
@@ -29,6 +29,7 @@ import {
 import { validateClientProfile } from "../utils/firestoreValidation";
 import dataSources from "../config/dataSources";
 import { buildClientAuditWriteMetadata } from "../utils/clientAudit";
+import { normalizeGender } from "../utils/gender";
 
 const getCurrentUserClientAuditMetadata = () => {
   const user = auth.currentUser;
@@ -197,6 +198,7 @@ class ClientService {
 
         return {
           ...data,
+          gender: normalizeGender(data.gender),
           tefapCert: normalizeBooleanField(data.tefapCert),
           tefapCertDate: normalizeDateStringField((data as any).tefapCertDate),
           activeStatus: deriveClientActiveStatus(data),
@@ -249,7 +251,7 @@ class ClientService {
             adults: raw.adults || 0,
             children: raw.children || 0,
             total: raw.total || 0,
-            gender: raw.gender || "Unknown",
+            gender: normalizeGender(raw.gender),
             ethnicity: raw.ethnicity || "",
             deliveryDetails: {
               deliveryInstructions: deliveryDetails.deliveryInstructions || "",

--- a/my-app/src/services/client-service.ts
+++ b/my-app/src/services/client-service.ts
@@ -249,7 +249,7 @@ class ClientService {
             adults: raw.adults || 0,
             children: raw.children || 0,
             total: raw.total || 0,
-            gender: raw.gender || "Other",
+            gender: raw.gender || "Unknown",
             ethnicity: raw.ethnicity || "",
             deliveryDetails: {
               deliveryInstructions: deliveryDetails.deliveryInstructions || "",

--- a/my-app/src/types/client-types.ts
+++ b/my-app/src/types/client-types.ts
@@ -48,7 +48,7 @@ export interface ClientProfile {
   adults: number;
   children: number;
   total: number;
-  gender: "Male" | "Female" | "Other";
+  gender: "Male" | "Female" | "Other" | "Unknown";
   ethnicity: string;
   deliveryDetails: {
     deliveryInstructions: string;

--- a/my-app/src/utils/gender.test.ts
+++ b/my-app/src/utils/gender.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "@jest/globals";
+import { GENDER_OPTIONS, normalizeGender } from "./gender";
+
+describe("normalizeGender", () => {
+  it("keeps every canonical option unchanged", () => {
+    for (const option of GENDER_OPTIONS) {
+      expect(normalizeGender(option)).toBe(option);
+    }
+  });
+
+  it("matches stored values case-insensitively and ignores surrounding whitespace", () => {
+    expect(normalizeGender("male")).toBe("Male");
+    expect(normalizeGender("  FEMALE ")).toBe("Female");
+  });
+
+  it("falls back to Unknown for missing values", () => {
+    expect(normalizeGender(undefined)).toBe("Unknown");
+    expect(normalizeGender(null)).toBe("Unknown");
+    expect(normalizeGender("")).toBe("Unknown");
+  });
+
+  it("falls back to Unknown for values the dropdown cannot represent", () => {
+    expect(normalizeGender("M")).toBe("Unknown");
+    expect(normalizeGender("Nonbinary")).toBe("Unknown");
+    expect(normalizeGender(42)).toBe("Unknown");
+  });
+});

--- a/my-app/src/utils/gender.ts
+++ b/my-app/src/utils/gender.ts
@@ -1,0 +1,25 @@
+import type { ClientProfile } from "../types/client-types";
+
+export type Gender = ClientProfile["gender"];
+
+/** Canonical gender values, in the order the profile dropdown shows them. */
+export const GENDER_OPTIONS = [
+  "Male",
+  "Female",
+  "Unknown",
+  "Other",
+] as const satisfies readonly Gender[];
+
+/**
+ * Coerce a stored gender value to one of the canonical options.
+ * Records written before the option list was fixed can hold anything, so
+ * unrecognized values become "Unknown" rather than reaching the UI as a value
+ * the dropdown cannot represent (which would show one value and save another).
+ */
+export const normalizeGender = (value: unknown): Gender => {
+  if (typeof value !== "string") {
+    return "Unknown";
+  }
+  const normalized = value.trim().toLowerCase();
+  return GENDER_OPTIONS.find((option) => option.toLowerCase() === normalized) ?? "Unknown";
+};


### PR DESCRIPTION
What changed

[client-types.ts:51](vscode-webview://1fvb9kig92ghssktmdu5ivlqkn6m7ten1buh3oqjl6ump3guv75u/my-app/src/types/client-types.ts#L51) — widened the gender union to include "Unknown". Without this the rest doesn't compile.
[Profile.tsx:2229](vscode-webview://1fvb9kig92ghssktmdu5ivlqkn6m7ten1buh3oqjl6ump3guv75u/my-app/src/pages/Profile/Profile.tsx#L2229) — Gender options now ["Male", "Female", "Unknown", "Other"], with "Unknown" before "Other" so the catch-all stays last.
[Profile.tsx:2232](vscode-webview://1fvb9kig92ghssktmdu5ivlqkn6m7ten1buh3oqjl6ump3guv75u/my-app/src/pages/Profile/Profile.tsx#L2232) — the empty-value fallback now resolves to "Unknown" instead of displaying "Other" against a stored "", which is what made the field look filled in while failing validation.
[Profile.tsx:2046](vscode-webview://1fvb9kig92ghssktmdu5ivlqkn6m7ten1buh3oqjl6ump3guv75u/my-app/src/pages/Profile/Profile.tsx#L2046) — Language gains "Unknown"; the separate "Other" MenuItem and its free-text box are untouched.
[Profile.tsx:2147](vscode-webview://1fvb9kig92ghssktmdu5ivlqkn6m7ten1buh3oqjl6ump3guv75u/my-app/src/pages/Profile/Profile.tsx#L2147) — "Unknown" appended to the ethnicity array, so it renders above "Other".
[Profile.tsx:271](vscode-webview://1fvb9kig92ghssktmdu5ivlqkn6m7ten1buh3oqjl6ump3guv75u/my-app/src/pages/Profile/Profile.tsx#L271) — new profiles default to gender: "Unknown" rather than "Male".
[client-service.ts:252](vscode-webview://1fvb9kig92ghssktmdu5ivlqkn6m7ten1buh3oqjl6ump3guv75u/my-app/src/services/client-service.ts#L252) — imported records with no gender fall back to "Unknown", not "Other".
[FormField.tsx:584](vscode-webview://1fvb9kig92ghssktmdu5ivlqkn6m7ten1buh3oqjl6ump3guv75u/my-app/src/pages/Profile/components/FormField.tsx#L584) — added the option to the second, currently-unreachable gender dropdown so it doesn't drift. I kept the branch rather than deleting it; removing dead code is a separate call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added “Unknown” as an available option for gender, language, and ethnicity.
  * Profiles with missing or unrecognized gender information now display “Unknown” instead of “Other”.
  * Standardized gender values for consistent display across profiles and client records.
  * Updated profile information handling to support the new gender option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->