### PR TITLE
added date picker to the adhoc query for dates

### DIFF
--- a/my-app/src/pages/ClientQueryTool/FilterValueInput.test.tsx
+++ b/my-app/src/pages/ClientQueryTool/FilterValueInput.test.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { describe, expect, it, jest } from "@jest/globals";
 import { fireEvent, render, screen } from "@testing-library/react";
+import { LocalizationProvider } from "@mui/x-date-pickers";
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import FilterValueInput from "./FilterValueInput";
 import type { QueryFieldDef } from "../../types/query-tool-types";
 
@@ -46,5 +48,27 @@ describe("FilterValueInput phone smart values", () => {
     expect(await screen.findByRole("option", { name: "(202) 489-8676" })).toBeTruthy();
     expect(screen.getByRole("option", { name: "(571) 330-1121" })).toBeTruthy();
     expect(screen.queryByRole("option", { name: "(123) 45" })).toBeNull();
+  });
+});
+
+describe("FilterValueInput date values", () => {
+  it("shows a calendar picker for route delivery dates", () => {
+    render(
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <FilterValueInput
+          id="delivery-date-filter"
+          fieldDef={{ field: "deliveryDate", label: "Delivery Date", type: "timestamp", format: "date" }}
+          operator="=="
+          value=""
+          onChange={jest.fn()}
+          tagOptions={[]}
+          referralOrgOptions={[]}
+          driverOptions={[]}
+          fieldOptions={[]}
+        />
+      </LocalizationProvider>
+    );
+
+    expect(screen.getByRole("button", { name: /choose date/i })).toBeTruthy();
   });
 });

--- a/my-app/src/pages/ClientQueryTool/FilterValueInput.tsx
+++ b/my-app/src/pages/ClientQueryTool/FilterValueInput.tsx
@@ -4,8 +4,9 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import { Autocomplete, Checkbox, MenuItem, TextField } from "@mui/material";
+import { DatePicker } from "@mui/x-date-pickers/DatePicker";
 import { QueryFieldDef, QueryOperator } from "../../types/query-tool-types";
-import { formatAssignedTime, formatDateMask, formatPhoneNumber } from "../../utils/queryToolFormatting";
+import { formatAssignedTime, formatPhoneNumber } from "../../utils/queryToolFormatting";
 
 interface FilterValueInputProps {
   fieldDef: QueryFieldDef;
@@ -43,6 +44,29 @@ const isOrganizationField = (field: QueryFieldDef): boolean =>
 const isWardField = (field: QueryFieldDef): boolean => field.field === "ward";
 const isClusterField = (field: QueryFieldDef): boolean => field.field === "cluster";
 const ALL_VALUES_OPTION = "__all_values__";
+
+const parseDateValue = (value: unknown): Date | null => {
+  if (typeof value !== "string") return null;
+
+  const match = value.trim().match(/^(\d{2})[/-](\d{2})[/-](\d{4})$|^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return null;
+
+  const year = Number(match[3] ?? match[4]);
+  const month = Number(match[1] ?? match[5]);
+  const day = Number(match[2] ?? match[6]);
+  const date = new Date(year, month - 1, day);
+
+  return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day
+    ? date
+    : null;
+};
+
+const formatPickedDate = (date: Date, fieldDef: QueryFieldDef): string => {
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const year = date.getFullYear();
+  return fieldDef.type === "timestamp" ? `${year}-${month}-${day}` : `${month}/${day}/${year}`;
+};
 
 const formatPhoneOption = (value: string): string => {
   const digits = value.replace(/\D/g, "");
@@ -366,13 +390,19 @@ const FilterValueInput: React.FC<FilterValueInputProps> = ({
 
   if (fieldDef.format === "date") {
     return (
-      <TextField
-        {...commonProps}
+      <DatePicker
         label="Value"
-        value={formatDateMask(value)}
-        onChange={(event) => onChange(formatDateMask(event.target.value))}
-        placeholder="MM/DD/YYYY"
-        inputProps={{ inputMode: "numeric", maxLength: 10 }}
+        format="MM/dd/yyyy"
+        value={parseDateValue(value)}
+        onChange={(date) =>
+          onChange(date && !Number.isNaN(date.getTime()) ? formatPickedDate(date, fieldDef) : "")
+        }
+        slotProps={{
+          textField: {
+            ...commonProps,
+            placeholder: "MM/DD/YYYY",
+          },
+        }}
       />
     );
   }


### PR DESCRIPTION
Each date in the ad hoc query tool allows you to have a date picker now so dates dont have to be (but still can be) typed in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a calendar-based date picker for date filter fields.
  * Supports dates entered in `MM/DD/YYYY`, `MM-DD-YYYY`, and `YYYY-MM-DD` formats.
  * Validates and formats selected dates according to the field type.

* **Bug Fixes**
  * Improved handling and display of date values in query filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->