### PR TITLE
address picker on client page

### DIFF
--- a/my-app/src/pages/Profile/Profile.addressAutocomplete.test.tsx
+++ b/my-app/src/pages/Profile/Profile.addressAutocomplete.test.tsx
@@ -58,11 +58,13 @@ const savedProfile = {
 
 class MockAutocomplete {
   input: HTMLInputElement;
+  options?: google.maps.places.AutocompleteOptions;
   place: google.maps.places.PlaceResult = {};
   placeChanged: (() => Promise<void>) | null = null;
 
-  constructor(input: HTMLInputElement) {
+  constructor(input: HTMLInputElement, options?: google.maps.places.AutocompleteOptions) {
     this.input = input;
+    this.options = options;
     autocompleteInstances.push(this);
   }
 
@@ -278,6 +280,14 @@ describe("Profile address autocomplete lifecycle", () => {
     const firstInput = await screen.findByRole("textbox", { name: "address" });
     await waitFor(() => expect(autocompleteInstances).toHaveLength(1));
     expect(autocompleteInstances[0].input).toBe(firstInput);
+    expect(autocompleteInstances[0].options).toEqual(
+      expect.objectContaining({
+        types: ["address"],
+        componentRestrictions: { country: "us" },
+        bounds: { north: 39.35, south: 38.3, east: -76.7, west: -77.8 },
+        strictBounds: true,
+      })
+    );
 
     fireEvent.click(screen.getAllByRole("button", { name: "save" })[0]);
     await waitFor(() => expect(mockSetDoc).toHaveBeenCalled());

--- a/my-app/src/pages/Profile/Profile.tsx
+++ b/my-app/src/pages/Profile/Profile.tsx
@@ -96,6 +96,13 @@ const ADDRESS_DIRECTION_ABBREVIATIONS: Record<string, string> = {
   southwest: "SW",
 };
 
+const DMV_AUTOCOMPLETE_BOUNDS: google.maps.LatLngBoundsLiteral = {
+  north: 39.35,
+  south: 38.3,
+  east: -76.7,
+  west: -77.8,
+};
+
 const standardizeAddressDirections = (value: string): string =>
   value.replace(/\b(northwest|northeast|southwest|southeast)\b/gi, (match) =>
     ADDRESS_DIRECTION_ABBREVIATIONS[match.toLowerCase()] ?? match
@@ -2752,6 +2759,8 @@ const Profile = () => {
         {
           types: ["address"],
           componentRestrictions: { country: "us" },
+          bounds: DMV_AUTOCOMPLETE_BOUNDS,
+          strictBounds: true,
         }
       );
       autocompleteRef.current = autocomplete;


### PR DESCRIPTION
the address picker in the client page that uses the google tool now restricts addresses to the DMV only