### PR TITLE
Revert quadrant dropdown (PR #332)

### DIFF
--- a/my-app/src/pages/Profile/Profile.addressAutocomplete.test.tsx
+++ b/my-app/src/pages/Profile/Profile.addressAutocomplete.test.tsx
@@ -170,7 +170,6 @@ jest.mock("./components/BasicInfoForm", () => ({
   default: ({ clientProfile, renderField, addressInputRef }: any) => (
     <div>
       {renderField("address", "text", addressInputRef)}
-      {renderField("quadrant", "select")}
       {renderField("phone", "text")}
       {renderField("alternativePhone", "text")}
       <output data-testid="address-fields">
@@ -328,44 +327,6 @@ describe("Profile address autocomplete lifecycle", () => {
     expect(screen.getByTestId("address-fields").textContent).toBe(
       "1600 Pennsylvania Avenue NW|Washington|DC|20006|NW|2"
     );
-  });
-
-  it("keeps the street, quadrant, coordinates, and ward in sync after a quadrant change", async () => {
-    render(
-      <MemoryRouter
-        initialEntries={["/profile/client-1"]}
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
-      >
-        <Routes>
-          <Route path="/profile/:clientId" element={<Profile />} />
-        </Routes>
-      </MemoryRouter>
-    );
-
-    await screen.findByText("100 Main Street NW");
-    fireEvent.click(screen.getAllByTestId("EditIcon")[0].closest("button")!);
-    fireEvent.change(await screen.findByRole("textbox", { name: "quadrant" }), {
-      target: { name: "quadrant", value: "NE" },
-    });
-
-    expect(screen.getByTestId("address-fields").textContent).toBe(
-      "100 Main Street NE|Washington|DC|20001|NE|Ward 1"
-    );
-
-    fireEvent.click(screen.getAllByRole("button", { name: "save" })[0]);
-
-    await waitFor(() => {
-      expect(mockSetDoc).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({
-          address: "100 Main Street NE",
-          quadrant: "NE",
-          coordinates: [38.91, -77.02],
-          ward: "2",
-        }),
-        { merge: true }
-      );
-    });
   });
 
   it("formats profile phone numbers when saving while accepting allowed input formats", async () => {

--- a/my-app/src/pages/Profile/Profile.addressAutocomplete.test.tsx
+++ b/my-app/src/pages/Profile/Profile.addressAutocomplete.test.tsx
@@ -170,6 +170,7 @@ jest.mock("./components/BasicInfoForm", () => ({
   default: ({ clientProfile, renderField, addressInputRef }: any) => (
     <div>
       {renderField("address", "text", addressInputRef)}
+      {renderField("quadrant", "text")}
       {renderField("phone", "text")}
       {renderField("alternativePhone", "text")}
       <output data-testid="address-fields">
@@ -327,6 +328,58 @@ describe("Profile address autocomplete lifecycle", () => {
     expect(screen.getByTestId("address-fields").textContent).toBe(
       "1600 Pennsylvania Avenue NW|Washington|DC|20006|NW|2"
     );
+  });
+
+  it("shows the quadrant derived from the address while it is being edited", async () => {
+    render(
+      <MemoryRouter
+        initialEntries={["/profile/client-1"]}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <Routes>
+          <Route path="/profile/:clientId" element={<Profile />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByText("100 Main Street NW");
+    fireEvent.click(screen.getAllByTestId("EditIcon")[0].closest("button")!);
+
+    expect(
+      ((await screen.findByRole("textbox", { name: "quadrant" })) as HTMLInputElement).value
+    ).toBe("NW");
+
+    fireEvent.change(screen.getByRole("textbox", { name: "address" }), {
+      target: { name: "address", value: "250 Elm Street SE" },
+    });
+
+    expect(
+      (screen.getByRole("textbox", { name: "quadrant" }) as HTMLInputElement).value
+    ).toBe("SE");
+  });
+
+  it("keeps the stored quadrant when the edited address has no quadrant token", async () => {
+    render(
+      <MemoryRouter
+        initialEntries={["/profile/client-1"]}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <Routes>
+          <Route path="/profile/:clientId" element={<Profile />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByText("100 Main Street NW");
+    fireEvent.click(screen.getAllByTestId("EditIcon")[0].closest("button")!);
+
+    fireEvent.change(await screen.findByRole("textbox", { name: "address" }), {
+      target: { name: "address", value: "250 Elm Street" },
+    });
+
+    expect(
+      (screen.getByRole("textbox", { name: "quadrant" }) as HTMLInputElement).value
+    ).toBe("NW");
   });
 
   it("formats profile phone numbers when saving while accepting allowed input formats", async () => {

--- a/my-app/src/pages/Profile/Profile.tsx
+++ b/my-app/src/pages/Profile/Profile.tsx
@@ -77,8 +77,6 @@ import { computeClientActiveStatus } from "../../utils/clientStatus";
 import { toJSDate } from "../../utils/timestamp";
 import {
   buildGeocodingAddress,
-  normalizeQuadrantToken,
-  replaceAddressQuadrant,
   resolveAddressQuadrant,
   shouldGeocodeClientLocation,
 } from "../../utils/addressFormat";
@@ -927,13 +925,6 @@ const Profile = () => {
         else delete newErrors[name];
         return newErrors;
       });
-    } else if (name === "quadrant") {
-      const normalizedQuadrant = normalizeQuadrantToken(value);
-      setClientProfile((prevState) => ({
-        ...prevState,
-        address: replaceAddressQuadrant(prevState.address, normalizedQuadrant),
-        quadrant: normalizedQuadrant,
-      }));
     } else {
       setClientProfile((prevState) => {
         let updatedProfile = {
@@ -2379,7 +2370,9 @@ const Profile = () => {
       : clientProfile[fieldPath as keyof ClientProfile];
 
     // Determine if the field should be disabled
-    const isDisabledField = ["city", "state", "zipCode", "ward", "total"].includes(fieldPath);
+    const isDisabledField = ["city", "state", "zipCode", "quadrant", "ward", "total"].includes(
+      fieldPath
+    );
 
     return (
       <Box

--- a/my-app/src/pages/Profile/Profile.tsx
+++ b/my-app/src/pages/Profile/Profile.tsx
@@ -2369,6 +2369,14 @@ const Profile = () => {
       ? getNestedValue(clientProfile, fieldPath)
       : clientProfile[fieldPath as keyof ClientProfile];
 
+    // Quadrant is read-only and derived from the street address, which handleSave treats as
+    // authoritative. Derive it here too so the displayed value cannot go stale while the
+    // address is being edited.
+    const displayValue =
+      fieldPath === "quadrant"
+        ? resolveAddressQuadrant(clientProfile.address, clientProfile.quadrant)
+        : value;
+
     // Determine if the field should be disabled
     const isDisabledField = ["city", "state", "zipCode", "quadrant", "ward", "total"].includes(
       fieldPath
@@ -2385,7 +2393,7 @@ const Profile = () => {
       >
         <FormField
           fieldPath={fieldPath}
-          value={value}
+          value={displayValue}
           type={type}
           isEditing={isEditing}
           handleChange={handleChange}

--- a/my-app/src/pages/Profile/components/BasicInfoForm.tsx
+++ b/my-app/src/pages/Profile/components/BasicInfoForm.tsx
@@ -127,18 +127,7 @@ const BasicInfoForm: React.FC<BasicInfoFormProps> = ({
         <Typography className="field-descriptor" sx={fieldLabelStyles}>
           QUADRANT
         </Typography>
-        {isEditing ? (
-          <Tooltip
-            title="Pre-filled from the selected address. Change it if the address falls in a different quadrant."
-            placement="top"
-          >
-            <span style={{ display: "block", width: "100%" }}>
-              {renderField("quadrant", "select")}
-            </span>
-          </Tooltip>
-        ) : (
-          renderField("quadrant", "select")
-        )}
+        {renderField("quadrant", "text")}
       </Box>
       {/* Ward */}
       <Box>

--- a/my-app/src/pages/Profile/components/FormField.tsx
+++ b/my-app/src/pages/Profile/components/FormField.tsx
@@ -20,7 +20,7 @@ import TagManager from "../Tags/TagManager";
 import "../../../styles/checkbox-override.css";
 import { deliveryDate } from "../../../utils/deliveryDate";
 
-export interface FormFieldProps {
+interface FormFieldProps {
   fieldPath: ClientProfileKey;
   value: any;
   type?: string;
@@ -582,30 +582,6 @@ const FormField = (props: FormFieldProps) => {
                 <MenuItem value="Male">Male</MenuItem>
                 <MenuItem value="Female">Female</MenuItem>
                 <MenuItem value="Other">Other</MenuItem>
-              </CustomSelect>
-            </Box>
-          );
-        } else if (fieldPath === "quadrant") {
-          return (
-            <Box sx={{ position: "relative", width: "100%" }}>
-              <CustomSelect
-                name={fieldPath}
-                value={(value as string) || ""}
-                onChange={(e) => handleChange(e as SelectChangeEvent<string>)}
-                displayEmpty
-                inputProps={selectInputProps}
-                sx={{ width: "100%" }}
-                MenuProps={{
-                  sx: { marginTop: "2px" },
-                }}
-              >
-                <MenuItem value="" disabled>
-                  Select
-                </MenuItem>
-                <MenuItem value="NW">NW</MenuItem>
-                <MenuItem value="NE">NE</MenuItem>
-                <MenuItem value="SW">SW</MenuItem>
-                <MenuItem value="SE">SE</MenuItem>
               </CustomSelect>
             </Box>
           );

--- a/my-app/src/utils/addressFormat.test.ts
+++ b/my-app/src/utils/addressFormat.test.ts
@@ -5,7 +5,6 @@ import {
   formatAddressWithQuadrantAndUnit,
   isStreetStyleAddress,
   normalizeQuadrantToken,
-  replaceAddressQuadrant,
   resolveAddressQuadrant,
   shouldGeocodeClientLocation,
 } from "./addressFormat";
@@ -98,19 +97,6 @@ describe("addressFormat", () => {
   it("treats the street quadrant as authoritative when fields disagree", () => {
     expect(resolveAddressQuadrant("201 I Street SW", "NW")).toBe("SW");
     expect(formatAddressWithQuadrant("201 I Street SW", "NW")).toBe("201 I Street SW");
-  });
-
-  it("replaces the street token when a user explicitly changes the quadrant", () => {
-    expect(replaceAddressQuadrant("100 Main Street NW", "NE")).toBe("100 Main Street NE");
-    expect(replaceAddressQuadrant("100 Main Street Northwest", "SE")).toBe(
-      "100 Main Street SE"
-    );
-  });
-
-  it("appends the selected quadrant when the street does not contain one", () => {
-    expect(replaceAddressQuadrant("100 Main Street", "Southwest")).toBe(
-      "100 Main Street SW"
-    );
   });
 
   it("standardizes full-word directions already in address", () => {

--- a/my-app/src/utils/addressFormat.ts
+++ b/my-app/src/utils/addressFormat.ts
@@ -47,21 +47,6 @@ export const formatAddressWithQuadrant = (address: unknown, quadrant: unknown): 
   return `${baseAddress} ${normalizedQuadrant}`.trim();
 };
 
-export const replaceAddressQuadrant = (address: unknown, quadrant: unknown): string => {
-  const baseAddress = typeof address === "string" ? standardizeAddressDirections(address).trim() : "";
-  const normalizedQuadrant = normalizeQuadrantToken(quadrant);
-
-  if (!baseAddress || !normalizedQuadrant) {
-    return baseAddress;
-  }
-
-  if (QUADRANT_TOKEN_REGEX.test(baseAddress)) {
-    return baseAddress.replace(QUADRANT_TOKEN_REGEX, normalizedQuadrant);
-  }
-
-  return `${baseAddress} ${normalizedQuadrant}`.trim();
-};
-
 export const formatAddressWithQuadrantAndUnit = (
   address: unknown,
   quadrant: unknown,


### PR DESCRIPTION
Reverts "Merge pull request #332 from Chase-Fournier/Chase-Fournier/Quadrant-Form-Field".

Quadrant returns to a read-only text field derived from the address. Keeps resolveAddressQuadrant, which was added after PR #332.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated profile forms so the Quadrant field is displayed and edited as standard text.
  * Removed the dedicated quadrant selector and related address modification behavior.
  * Quadrant updates no longer automatically replace or append quadrant information in the address.
* **Tests**
  * Removed tests for quadrant-based address updates and synchronization.
  * Retained existing address-formatting coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->